### PR TITLE
Add observer passthrough pt2

### DIFF
--- a/data/samples/Diagnostics.Samples/BackupCheckDetector.csx
+++ b/data/samples/Diagnostics.Samples/BackupCheckDetector.csx
@@ -1,0 +1,32 @@
+﻿private static string _latestKuduDeployQuery = @"
+Kudu
+| where PreciseTimeStamp >= ago(30d) and Tenant =~ ""{tenantId}""
+| where TaskName =~ ""ProjectDeployed"" and (siteName =~ ""{siteName}"" or siteName startswith ""{siteName}__"")
+| summarize max(PreciseTimeStamp), TotalDeployments30d = count()
+";
+
+private static string _latestMsDeployQuery = @"
+MSDeploy
+| where PreciseTimeStamp >= ago(30d) and Tenant =~ ""{tenantId}""
+| where (SiteName =~ ""~1{siteName}"" or SiteName startswith ""~1{siteName}__"")
+| where (Message contains ""PassId: 1"" or Message contains ""Package deployed successfully"" )
+| summarize max(PreciseTimeStamp), TotalDeployments30d = count()
+";
+
+[Definition(Id = "backupcheckerdetector", Name = "Check Backup", Description = "Check for optimal use of backup/restore feature")]
+public async static Task<Response> Run(DataProviders dp, OperationContext cxt, Response res)
+{
+    var siteDataTask = dp.Observer.GetSite(cxt.Resource.Stamp, cxt.Resource.SiteName);
+    var latestKuduDeploymentTask = dp.Kusto.ExecuteQuery(_latestKuduDeployQuery.Replace("{siteName}", cxt.Resource.SiteName).Replace("{tenantId}", (cxt.Resource.TenantIdList as List<string>)[0]), cxt.Resource.Stamp);
+    var latestMsDeploymentTask = dp.Kusto.ExecuteQuery(_latestMsDeployQuery.Replace("{siteName}", cxt.Resource.SiteName).Replace("{tenantId}", (cxt.Resource.TenantIdList as List<string>)[0]), cxt.Resource.Stamp);
+
+    await Task.WhenAll(new Task[] { siteDataTask, latestKuduDeploymentTask, latestMsDeploymentTask });
+
+    var siteData = await siteDataTask;
+
+    if (siteData[0].sku == "Premium" || siteData[0].sku == "Standard")
+    {
+        Console.WriteLine("hello it works");
+    }
+    return res;
+}

--- a/data/samples/Diagnostics.Samples/BackupCheckDetector.csx
+++ b/data/samples/Diagnostics.Samples/BackupCheckDetector.csx
@@ -20,72 +20,79 @@ public async static Task<Response> Run(DataProviders dp, OperationContext cxt, R
     string resolution = null;
 
     var siteDataTask = dp.Observer.GetSite(cxt.Resource.Stamp, cxt.Resource.SiteName);
-    var latestKuduDeploymentTask = dp.Kusto.ExecuteQuery(_latestKuduDeployQuery.Replace("{siteName}", cxt.Resource.SiteName).Replace("{tenantId}", (cxt.Resource.TenantIdList as List<string>)[0]), cxt.Resource.Stamp);
-    var latestMsDeploymentTask = dp.Kusto.ExecuteQuery(_latestMsDeployQuery.Replace("{siteName}", cxt.Resource.SiteName).Replace("{tenantId}", (cxt.Resource.TenantIdList as List<string>)[0]), cxt.Resource.Stamp);
+    var latestKuduDeploymentTask = dp.Kusto.ExecuteQuery(_latestKuduDeployQuery.Replace("{siteName}", cxt.Resource.SiteName).Replace("{tenantId}", (cxt.Resource.TenantIdList as List<string>)[0]), cxt.Resource.Stamp, operationName: "GetLatestDeployment");
+    var latestMsDeploymentTask = dp.Kusto.ExecuteQuery(_latestMsDeployQuery.Replace("{siteName}", cxt.Resource.SiteName).Replace("{tenantId}", (cxt.Resource.TenantIdList as List<string>)[0]), cxt.Resource.Stamp, operationName: "GetLatestDeployment");
 
     await Task.WhenAll(new Task[] { siteDataTask, latestKuduDeploymentTask, latestMsDeploymentTask });
 
     var siteData = await siteDataTask;
 
-    if (siteData[0].sku == "Premium" || siteData[0].sku == "Standard")
+    try
     {
-        if (siteData[0].backups.Count == 0)
+        if (siteData[0].sku == "Premium" || siteData[0].sku == "Standard")
         {
-            Console.WriteLine(siteData[0].backups.Count);
-            observationStatement = "Your website does not have any backups. It may not have backup/restore feature enabled.";
-            resolution = $"Enable backup/restore feature for your website. It comes free with {siteData[0].sku} sku websites";
-        }
-        else
-        {
-            var latestBackupTimeStamp = siteData[0].backups[siteData[0].backups.Count - 1].Value<DateTime>("finished_time_stamp");
-            var latestKuduDeploymentTimeStamp = (await latestKuduDeploymentTask).Rows[0][0];
-            var latestMsDeploymentTimeStamp = (await latestMsDeploymentTask).Rows[0][0];
-
-            DateTime latestDeploymentTimeStamp = default(DateTime);
-            int outstandingDays = 0;
-
-            if (!string.IsNullOrWhiteSpace(latestKuduDeploymentTimeStamp))
+            if (siteData[0].backups.Count == 0)
             {
-                latestDeploymentTimeStamp = DateTime.Parse(latestKuduDeploymentTimeStamp);
-            }
-
-            if (!string.IsNullOrWhiteSpace(latestMsDeploymentTimeStamp))
-            {
-                var tmpTimeStamp = DateTime.Parse(latestMsDeploymentTimeStamp);
-                latestDeploymentTimeStamp = new DateTime(Math.Max(latestDeploymentTimeStamp.Ticks, tmpTimeStamp.Ticks));
-            }
-
-            if (latestDeploymentTimeStamp != default(DateTime))
-            {
-                outstandingDays = (int)Math.Abs((latestDeploymentTimeStamp - latestBackupTimeStamp).TotalDays);
-            }
-
-            if (outstandingDays >= 1)
-            {
-                observationStatement = $"Your last backup is {outstandingDays} days old.";
-                resolution = "Create a new backup or enable the automatic backup feature";
+                Console.WriteLine(siteData[0].backups.Count);
+                observationStatement = "Your website does not have any backups. It may not have backup/restore feature enabled.";
+                resolution = $"Enable backup/restore feature for your website. It comes free with {siteData[0].sku} sku websites";
             }
             else
             {
-                observationStatement = $"Your backups are only less than a day old. This is good but take a backup at your earliest convenience to protect your site.";
+                var latestBackupTimeStamp = siteData[0].backups[siteData[0].backups.Count - 1].Value<DateTime>("finished_time_stamp");
+                var latestKuduDeploymentTimeStamp = (await latestKuduDeploymentTask).Rows[0][0];
+                var latestMsDeploymentTimeStamp = (await latestMsDeploymentTask).Rows[0][0];
+
+                DateTime latestDeploymentTimeStamp = default(DateTime);
+                int outstandingDays = 0;
+
+                if (!string.IsNullOrWhiteSpace(latestKuduDeploymentTimeStamp))
+                {
+                    latestDeploymentTimeStamp = DateTime.Parse(latestKuduDeploymentTimeStamp);
+                }
+
+                if (!string.IsNullOrWhiteSpace(latestMsDeploymentTimeStamp))
+                {
+                    var tmpTimeStamp = DateTime.Parse(latestMsDeploymentTimeStamp);
+                    latestDeploymentTimeStamp = new DateTime(Math.Max(latestDeploymentTimeStamp.Ticks, tmpTimeStamp.Ticks));
+                }
+
+                if (latestDeploymentTimeStamp != default(DateTime))
+                {
+                    outstandingDays = (int)Math.Abs((latestDeploymentTimeStamp - latestBackupTimeStamp).TotalDays);
+                }
+
+                if (outstandingDays >= 1)
+                {
+                    observationStatement = $"Your last backup is {outstandingDays} days old.";
+                    resolution = "Create a new backup or enable the automatic backup feature";
+                }
+                else
+                {
+                    observationStatement = $"Your backups are only less than a day old. This is good but take a backup at your earliest convenience to protect your site.";
+                }
             }
         }
-    }
-    else
-    {
-        observationStatement = "Your website does not have backup/restore feature enabled. This is only offered or standard and premium sku websites. To learn more about this feature click here https://docs.microsoft.com/en-us/azure/app-service/web-sites-backup";
-    }
+        else
+        {
+            observationStatement = "Your website does not have backup/restore feature enabled. This is only offered or standard and premium sku websites. To learn more about this feature click here https://docs.microsoft.com/en-us/azure/app-service/web-sites-backup";
+        }
 
-    var dataSummaries = new List<DataSummary>(){
+        var dataSummaries = new List<DataSummary>(){
         new DataSummary("Observation", observationStatement)
     };
 
-    if (!string.IsNullOrWhiteSpace(resolution))
-    {
-        dataSummaries.Add(new DataSummary("Solution", resolution));
-    }
+        if (!string.IsNullOrWhiteSpace(resolution))
+        {
+            dataSummaries.Add(new DataSummary("Solution", resolution));
+        }
 
-    res.AddDataSummary(dataSummaries);
+        res.AddDataSummary(dataSummaries);
+    }catch(Exception ex)
+    {
+        Console.WriteLine(ex);
+        throw;
+    }
 
     return res;
 }

--- a/data/samples/Diagnostics.Samples/Diagnostics.Samples.projitems
+++ b/data/samples/Diagnostics.Samples/Diagnostics.Samples.projitems
@@ -9,6 +9,9 @@
     <Import_RootNamespace>Diagnostics.Samples</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)BackupCheckDetector.csx">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="$(MSBuildThisFileDirectory)GetRuntimeSiteSlotMapData.csx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
@@ -33,9 +33,14 @@ namespace Diagnostics.DataProviders
         public bool IsMockConfigured { get; set; }
 
         /// <summary>
-        /// Uri for SupportObserverResourceAAD app
+        /// ResourceId for WAWSObserver AAD app
         /// </summary>
-        public string ResourceUri { get { return "https://microsoft.onmicrosoft.com/SupportObserverResourceApp"; } }
+        public string ResourceId { get { return "d1abfd91-e19c-426e-802f-a6c55421a5ef"; } }
+        /// <summary>
+        /// Uri for SupportObserverResourceAAD app. 
+        /// We are only hitting this API to access runtime site slot map data
+        /// </summary>
+        public string RuntimeSiteSlotMapResourceUri { get { return "https://microsoft.onmicrosoft.com/SupportObserverResourceApp"; } }
 
         public void PostInitialize()
         {

--- a/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
@@ -88,7 +88,7 @@ namespace Diagnostics.DataProviders
 
         public async Task<dynamic> GetSite(string siteName)
         {
-            return await GetSiteInternal();
+            throw new NotImplementedException();
         }
 
         public async Task<dynamic> GetSite(string stampName, string siteName)

--- a/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Diagnostics.ModelsAndUtils.Models;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Diagnostics.DataProviders
@@ -63,10 +64,10 @@ namespace Diagnostics.DataProviders
 
             switch (siteName.ToLower())
             {
-                case "thor-api":
-                    mock.Add("production", new List<RuntimeSitenameTimeRange> { new RuntimeSitenameTimeRange { RuntimeSitename = "thor-api", StartTime = DateTime.UtcNow.AddDays(-5), EndTime = DateTime.UtcNow } });
-                    mock.Add("staging", new List<RuntimeSitenameTimeRange> { new RuntimeSitenameTimeRange { RuntimeSitename = "thor-api__a88nf", StartTime = DateTime.UtcNow.AddDays(-5), EndTime = DateTime.UtcNow } });
-                    mock.Add("testing", new List<RuntimeSitenameTimeRange> { new RuntimeSitenameTimeRange { RuntimeSitename = "thor-api__v85ae", StartTime = DateTime.UtcNow.AddDays(-5), EndTime = DateTime.UtcNow } });
+                case "my-api":
+                    mock.Add("production", new List<RuntimeSitenameTimeRange> { new RuntimeSitenameTimeRange { RuntimeSitename = "my-api;", StartTime = DateTime.UtcNow.AddDays(-5), EndTime = DateTime.UtcNow } });
+                    mock.Add("staging", new List<RuntimeSitenameTimeRange> { new RuntimeSitenameTimeRange { RuntimeSitename = "my-api__a88nf", StartTime = DateTime.UtcNow.AddDays(-5), EndTime = DateTime.UtcNow } });
+                    mock.Add("testing", new List<RuntimeSitenameTimeRange> { new RuntimeSitenameTimeRange { RuntimeSitename = "my-api__v85ae", StartTime = DateTime.UtcNow.AddDays(-5), EndTime = DateTime.UtcNow } });
                     break;
                 default:
                     break;
@@ -85,14 +86,38 @@ namespace Diagnostics.DataProviders
             throw new NotImplementedException();
         }
 
-        public Task<dynamic> GetSite(string siteName)
+        public async Task<dynamic> GetSite(string siteName)
         {
-            throw new NotImplementedException();
+            return await GetSiteInternal();
         }
 
-        public Task<dynamic> GetSite(string stampName, string siteName)
+        public async Task<dynamic> GetSite(string stampName, string siteName)
         {
-            throw new NotImplementedException();
+            return await GetSiteInternal();
+        }
+
+        private Task<dynamic> GetSiteInternal()
+        {
+            var siteData = @"
+[
+  {
+    ""sku"": ""Premium"",
+    ""backups"": [
+      {
+        ""id"": 1,
+        ""name"": ""my-api;_201611282122147173"",
+        ""blob_name"": ""my-api;_201611282122147173.zip"",
+        ""status"": 1,
+        ""created_time"": ""2016-11-28T21: 22: 16.2544605"",
+        ""started_time_stamp"": ""2016-11-28T21: 22: 19.2148232"",
+        ""finished_time_stamp"": ""2016-11-28T21: 33: 40.5215806"",
+        ""log"": ""Thewebsite+databasesizeexceedsthe10GBlimitforbackups.Yourcontentsizeis10GB."",
+        ""correlation_id"": ""f786719b-6d62-4993-b94e-d862dc9c2070""
+      }
+    ]
+  }
+]";
+            return Task.FromResult(JsonConvert.DeserializeObject(siteData));
         }
 
         public Task<string> GetSiteResourceGroupName(string siteName)

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -22,7 +22,7 @@ namespace Diagnostics.DataProviders
         {
             _configuration = configuration;
             _httpClient = new HttpClient();
-            _httpClient.BaseAddress = new Uri("https://support-bay-api.azurewebsites.net/observer/");
+            _httpClient.BaseAddress = new Uri("https://wawsobserver-prod.azurewebsites.net/api/");
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
@@ -53,16 +53,22 @@ namespace Diagnostics.DataProviders
 
         public async Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string siteName)
         {
-            var response = await GetObserverResource($"sites/{siteName}/runtimesiteslotmap");
-            var slotTimeRangeCaseSensitiveDictionary = JsonConvert.DeserializeObject<Dictionary<string, List<RuntimeSitenameTimeRange>>>(response);
-            var slotTimeRange = new Dictionary<string, List<RuntimeSitenameTimeRange>>(slotTimeRangeCaseSensitiveDictionary, StringComparer.CurrentCultureIgnoreCase);
-            return slotTimeRange;
+            return await GetRuntimeSiteSlotMap(null, siteName);
         }
 
         public async Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string stampName, string siteName)
         {
-            var response = await GetObserverResource($"stamp/{stampName}/sites/{siteName}/runtimesiteslotmap");
-            var slotTimeRangeCaseSensitiveDictionary = JsonConvert.DeserializeObject<Dictionary<string, List<RuntimeSitenameTimeRange>>>(response);
+            return await GetRuntimeSiteSlotMapInternal(stampName, siteName);
+        }
+
+        private async Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMapInternal(string stampName, string siteName)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, string.IsNullOrEmpty(stampName) ? $"/sites/{siteName}/runtimesiteslotmap" : $"stamp/{stampName}/sites/{siteName}/runtimesiteslotmap");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await GetAccessToken(_configuration.RuntimeSiteSlotMapResourceUri));
+            var response = await _httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            var result = await response.Content.ReadAsStringAsync();
+            var slotTimeRangeCaseSensitiveDictionary = JsonConvert.DeserializeObject<Dictionary<string, List<RuntimeSitenameTimeRange>>>(result);
             var slotTimeRange = new Dictionary<string, List<RuntimeSitenameTimeRange>>(slotTimeRangeCaseSensitiveDictionary, StringComparer.CurrentCultureIgnoreCase);
             return slotTimeRange;
         }
@@ -116,20 +122,22 @@ namespace Diagnostics.DataProviders
 
         public async Task<dynamic> GetSite(string stampName, string siteName)
         {
-            return await GetSite(siteName);
+            var response = await GetObserverResource($"stamps/{stampName}/sites/{siteName}");
+            var siteObject = JsonConvert.DeserializeObject(response);
+            return siteObject;
         }
 
-        private async Task<string> GetObserverResource(string url)
+        private async Task<string> GetObserverResource(string url, string resourceId = null)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await GetAccessToken());
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await GetAccessToken(resourceId));
             var response = await _httpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
             var result = await response.Content.ReadAsStringAsync();
             return result;
         }
 
-        private async Task<string> GetAccessToken()
+        private async Task<string> GetAccessToken(string resourceId = null)
         {
             if (_authContext == null)
             {
@@ -137,7 +145,7 @@ namespace Diagnostics.DataProviders
                 _authContext = new AuthenticationContext("https://login.microsoftonline.com/microsoft.onmicrosoft.com", TokenCache.DefaultShared);
             }
 
-            var authResult = await _authContext.AcquireTokenAsync(_configuration.ResourceUri, _aadCredentials);
+            var authResult = await _authContext.AcquireTokenAsync(resourceId ?? _configuration.ResourceId, _aadCredentials);
             return authResult.AccessToken;
         }
     }

--- a/src/Diagnostics.DataProviders/MockKustoClient.cs
+++ b/src/Diagnostics.DataProviders/MockKustoClient.cs
@@ -17,7 +17,8 @@ namespace Diagnostics.DataProviders
                 {
                     case "gettenantidforstamp":
                         return await GetFakeTenantIdResults();
-
+                    case "getlatestdeployment":
+                        return await GetLatestDeployment();
                     default:
                         return await GetTestA();
                 }
@@ -66,6 +67,20 @@ namespace Diagnostics.DataProviders
             res.Columns = new List<DataTableResponseColumn>(new[] { testColumn });
             
             return Task.FromResult(res);
+        }
+
+        private Task<DataTableResponseObject> GetLatestDeployment()
+        {
+            var resp = new DataTableResponseObject();
+            resp.Columns = new List<DataTableResponseColumn>()
+            {
+                new DataTableResponseColumn(){ ColumnName = "LatestDeployment", ColumnType = "datetime", DataType = "datetime" }
+            };
+
+            resp.Rows = new string[1][];
+            resp.Rows[0] = new String[1] { DateTime.UtcNow.ToString("o")  };
+
+            return Task.FromResult(resp);
         }
     }
 }

--- a/tests/DataProviderTests/SupportObserverTests.cs
+++ b/tests/DataProviderTests/SupportObserverTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Diagnostics.Tests.DataProviderTests
@@ -49,7 +50,7 @@ namespace Diagnostics.Tests.DataProviderTests
         }
 
         [Fact]
-        public async System.Threading.Tasks.Task E2E_Test_WAWSObserverAsync()
+        public async Task E2E_Test_WAWSObserverAsync()
         {
             var configFactory = new MockDataProviderConfigurationFactory();
             var config = configFactory.LoadConfigurations();

--- a/tests/DataProviderTests/SupportObserverTests.cs
+++ b/tests/DataProviderTests/SupportObserverTests.cs
@@ -47,5 +47,35 @@ namespace Diagnostics.Tests.DataProviderTests
                 Assert.Equal("thor-api__a88nf", result.Dataset.First().Table.Rows[1][1]);
             }
         }
+
+        [Fact]
+        public async System.Threading.Tasks.Task E2E_Test_WAWSObserverAsync()
+        {
+            var configFactory = new MockDataProviderConfigurationFactory();
+            var config = configFactory.LoadConfigurations();
+
+            EntityMetadata metadata = ScriptTestDataHelper.GetRandomMetadata();
+            //read a sample csx file from local directory
+            metadata.ScriptText = await File.ReadAllTextAsync("BackupCheckDetector.csx");
+
+            var dataProviders = new DataProviders.DataProviders(config);
+
+            using (EntityInvoker invoker = new EntityInvoker(metadata, ScriptHelper.GetFrameworkReferences(), ScriptHelper.GetFrameworkImports()))
+            {
+                await invoker.InitializeEntryPointAsync();
+
+                var siteResource = new SiteResource
+                {
+                    SiteName = "thor-api",
+                    Stamp = "waws-prod-bn1-71717c45"
+                };
+
+                var operationContext = new OperationContext(siteResource, null, null);
+
+                var response = new Response();
+
+                Response result = (Response)await invoker.Invoke(new object[] { dataProviders, operationContext, response });
+            }
+        }
     }
 }

--- a/tests/DataProviderTests/SupportObserverTests.cs
+++ b/tests/DataProviderTests/SupportObserverTests.cs
@@ -36,7 +36,7 @@ namespace Diagnostics.Tests.DataProviderTests
 
                 var siteResource = new SiteResource
                 {
-                    SiteName = "thor-api",
+                    SiteName = "my-api",
                     Stamp = "waws-prod-bn1-71717c45"
                 };
                 var operationContext = new OperationContext(siteResource, null, null);
@@ -44,7 +44,7 @@ namespace Diagnostics.Tests.DataProviderTests
 
                 Response result = (Response)await invoker.Invoke(new object[] { dataProviders, operationContext, response });
 
-                Assert.Equal("thor-api__a88nf", result.Dataset.First().Table.Rows[1][1]);
+                Assert.Equal("my-api__a88nf", result.Dataset.First().Table.Rows[1][1]);
             }
         }
 
@@ -66,8 +66,12 @@ namespace Diagnostics.Tests.DataProviderTests
 
                 var siteResource = new SiteResource
                 {
-                    SiteName = "thor-api",
-                    Stamp = "waws-prod-bn1-71717c45"
+                    SiteName = "my-api",
+                    Stamp = "waws-prod-bn1-71717c45",
+                    TenantIdList = new List<string>()
+                    {
+                        Guid.NewGuid().ToString()
+                    }
                 };
 
                 var operationContext = new OperationContext(siteResource, null, null);


### PR DESCRIPTION
-Reference WAWS Observer API endpoint to get database data.
-Create sample detector. Example, BackupCheckDetector
-Still reference support bay api for RuntimeSiteSlotMap data
