### PR TITLE
Locking on a null value results in ArgumentNullException

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -17,6 +17,7 @@ namespace Diagnostics.DataProviders
         private static AuthenticationContext _authContext;
         private static ClientCredential _aadCredentials;
         private readonly HttpClient _httpClient;
+        private object _lockObject = new object();
 
         public SupportObserverDataProvider(OperationDataCache cache, SupportObserverDataProviderConfiguration configuration) : base(cache)
         {
@@ -141,7 +142,7 @@ namespace Diagnostics.DataProviders
         {
             if (_authContext == null)
             {
-                lock (_authContext)
+                lock (_lockObject)
                 {
                     if (_authContext == null)
                     {


### PR DESCRIPTION
Currently in prod, when runtimehost tries to get access token from AAD, it throws ArgumentNullException. 

System.AggregateException: One or more errors occurred. (Value cannot be null.) ---> System.ArgumentNullException: Value cannot be null.
   at System.Threading.Monitor.Enter(Object obj)
   at Diagnostics.DataProviders.SupportObserverDataProvider.<GetAccessToken>d__24.MoveNext() in E:\git\Azure-AppServices-Diagnostics\src\Diagnostics.DataProviders\DataProviders\SupportObserverDataProvider.cs:line 144

Fix: Create a separate object to use for synchronization between threads.
