### PR TITLE
Fix GetTenantCall in StampService

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
@@ -94,7 +94,8 @@ namespace Diagnostics.RuntimeHost.Services
 
             return
                 $@"{tableName}
-                | where TIMESTAMP >= datetime({startTimeStr}) and TIMESTAMP <= datetime({endTimeStr}) and PublicHost startswith ""{stamp}""
+                | where TIMESTAMP >= datetime({startTimeStr}) and TIMESTAMP <= datetime({endTimeStr}) 
+                | where PublicHost =~ ""{stamp}.cloudapp.net"" or PublicHost matches regex ""{stamp}([a-z{{1}}]).cloudapp.net""
                 | summarize by Tenant, PublicHost";
         }
     }


### PR DESCRIPTION
Assumption : All the Secondary stamps have just **One letter(a-z)** after the main stamp name.  so it was also remove dr stamps from the list.

Did some research on the existing data  in RoleInstance heartbeat table and so far the assumption looks correct.