### PR TITLE
Adding support to call the site root path in GeoMasterDataProvider

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -284,7 +284,10 @@ namespace Diagnostics.DataProviders
         /// </example>
         public async Task<T> MakeHttpGetRequest<T>(string subscriptionId, string resourceGroupName, string name, string path = "")
         {
-            path = path.StartsWith("/") ? path.Substring(1) : path;
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                path = path.StartsWith("/") ? path.Substring(1) : path;
+            }
             if (string.IsNullOrWhiteSpace(path))
             {
                 path = $"{SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name)}";

--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -263,20 +263,38 @@ namespace Diagnostics.DataProviders
         ///                   name, 
         ///                   "usages");
         ///     
-        ///     foreach(var val in respVal.value)
+        ///     foreach(var val in respVal.Value)
         ///     {
         ///         var unit = val.unit;
         ///         var name = val.name.value;
         ///         var localizedValue = val.name.localizedValue;
         ///         var currentValue = val.currentValue;
         ///     }
+        ///     
+        ///     // To get properties on the site root path, just pass an empty string like this
+        ///     var siteProperties = await dp.GeoMaster.MakeHttpGetRequest<![CDATA[<GeoMasterResponse>]]>(subId, 
+        ///                rg, 
+        ///                name, 
+        ///                "");
+        ///     foreach(var item in siteProperties.Properties)
+        ///     {
+        ///         string str = item.Key + " " + item.Value;
+        ///     }
         /// }
         /// </code>
         /// </example>
         public async Task<T> MakeHttpGetRequest<T>(string subscriptionId, string resourceGroupName, string name, string path)
         {
-            path = path.StartsWith("/") ? path.Substring(1): path;
-            path = $"{SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name)}/{path}";
+            path = path.StartsWith("/") ? path.Substring(1) : path;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                path = $"{SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name)}";
+            }
+            else
+            {
+                path = $"{SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name)}/{path}";
+            }
+
             var geoMasterResponse = await HttpGet<T>(path);
             return geoMasterResponse;
         }

--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -271,11 +271,10 @@ namespace Diagnostics.DataProviders
         ///         var currentValue = val.currentValue;
         ///     }
         ///     
-        ///     // To get properties on the site root path, just pass an empty string like this
+        ///     // To get properties on the site root path, just call the method like this
         ///     var siteProperties = await dp.GeoMaster.MakeHttpGetRequest<![CDATA[<GeoMasterResponse>]]>(subId, 
         ///                rg, 
-        ///                name, 
-        ///                "");
+        ///                name);
         ///     foreach(var item in siteProperties.Properties)
         ///     {
         ///         string str = item.Key + " " + item.Value;
@@ -283,7 +282,7 @@ namespace Diagnostics.DataProviders
         /// }
         /// </code>
         /// </example>
-        public async Task<T> MakeHttpGetRequest<T>(string subscriptionId, string resourceGroupName, string name, string path)
+        public async Task<T> MakeHttpGetRequest<T>(string subscriptionId, string resourceGroupName, string name, string path = "")
         {
             path = path.StartsWith("/") ? path.Substring(1) : path;
             if (string.IsNullOrWhiteSpace(path))


### PR DESCRIPTION
This will allow detectors to get properties that are defined at the site root level and not in observer and looks like there are a lot of them which will benefit from this change.