### PR TITLE
Add Category to definition

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Attributes/Definition.cs
+++ b/src/Diagnostics.ModelsAndUtils/Attributes/Definition.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Diagnostics.ModelsAndUtils.Models;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
@@ -33,6 +34,17 @@ namespace Diagnostics.ModelsAndUtils.Attributes
         /// </summary>
         [DataMember]
         public string Author { get; set; }
+
+        public Category Category { get; set; }
+
+        [DataMember]
+        public string ProblemCategory
+        {
+            get
+            {
+                return Category != null ? Category.Value : null;
+            }
+        }
 
         /// <summary>
         /// List of Support Topics for which this detector is enabled.

--- a/src/Diagnostics.ModelsAndUtils/Models/Category.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Category.cs
@@ -18,7 +18,41 @@ namespace Diagnostics.ModelsAndUtils.Models
             return new Category(name);
         }
 
+        // The predefined categories below are broken out by resource type, 
+        // but it does not mean they can only by used by that resource type.
+
+        // General
         public static readonly Category AvailabilityAndPerformance = new Category("Availability and Performance");
         public static readonly Category ConfigurationAndManagement = new Category("Configuration and Management");
+        public static readonly Category Deployment = new Category("Deployment");
+        public static readonly Category OpenSourceTechnologies = new Category("Open Source Technologies");
+        public static readonly Category SSL = new Category("SSL");
+
+        // Site Specific
+        public static readonly Category ProblemsWithAse = new Category("Problems with ASE"); // For site on ASE
+        public static readonly Category ProblemsWithWebjobs = new Category("Problems with Webjobs");
+
+        // Linux Specific
+        public static readonly Category DockerContainers = new Category("DockerContainers");
+
+        // ASE Specific
+        public static readonly Category Networking = new Category("Problems with Webjobs");
+
+        // Function Specific
+        public static readonly Category DeployingFunctionApps = new Category("Deploying Function Apps");
+        public static readonly Category AddingFunctions = new Category("Adding Functions");
+        public static readonly Category AuthenticationAndAuthorization = new Category("Authentication and Authorization");
+        public static readonly Category ConfiguringAndManagingFunctionApps = new Category("Configuring and Managing Function Apps");
+        public static readonly Category DurableFunctions = new Category("Durable Functions");
+        public static readonly Category FunctionPortalIssues = new Category("Function Portal Issues");
+        public static readonly Category FunctionsPerformance = new Category("Functions Performance");
+        public static readonly Category MonitoringFunctions = new Category("Monitoring Functions");
+
+        // Certificates Specific
+        public static readonly Category Importing = new Category("Importing");
+        public static readonly Category Renewals = new Category("Renewals");
+
+        // Domains Specific
+        public static readonly Category Domains = new Category("App Service Domains");
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Category.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Category.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Diagnostics.ModelsAndUtils.Models
+{
+    public class Category 
+    {
+        private Category(string categoryName)
+        {
+            Value = categoryName;
+        }
+
+        public string Value { get; private set; }
+
+        public static Category Custom(string name)
+        {
+            return new Category(name);
+        }
+
+        public static readonly Category AvailabilityAndPerformance = new Category("Availability and Performance");
+        public static readonly Category ConfigurationAndManagement = new Category("Configuration and Management");
+    }
+}

--- a/src/Diagnostics.ModelsAndUtils/Models/Category.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Category.cs
@@ -33,10 +33,13 @@ namespace Diagnostics.ModelsAndUtils.Models
         public static readonly Category ProblemsWithWebjobs = new Category("Problems with Webjobs");
 
         // Linux Specific
-        public static readonly Category DockerContainers = new Category("DockerContainers");
+        public static readonly Category DockerContainers = new Category("Docker Containers");
 
         // ASE Specific
-        public static readonly Category Networking = new Category("Problems with Webjobs");
+        public static readonly Category NetworkConfiguration = new Category("Network Configuration");
+        public static readonly Category ASEDeployment = new Category("ASE Deployment");
+        public static readonly Category Scaling = new Category("Scaling");
+        public static readonly Category Management = new Category("Management");
 
         // Function Specific
         public static readonly Category DeployingFunctionApps = new Category("Deploying Function Apps");

--- a/src/Diagnostics.ModelsAndUtils/Models/ResponseExtensions/Insight.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/ResponseExtensions/Insight.cs
@@ -42,6 +42,7 @@ namespace Diagnostics.ModelsAndUtils.Models.ResponseExtensions
             this.Status = status;
             this.Message = message ?? string.Empty;
             this.Body = new Dictionary<string, string>();
+            this.IsExpanded = false;
         }
 
         /// <summary>
@@ -55,6 +56,7 @@ namespace Diagnostics.ModelsAndUtils.Models.ResponseExtensions
             this.Status = status;
             this.Message = message ?? string.Empty;
             this.Body = body;
+            this.IsExpanded = false;
         }
 
         /// <summary>
@@ -112,7 +114,8 @@ namespace Diagnostics.ModelsAndUtils.Models.ResponseExtensions
                 new DataColumn("Status", typeof(string)),
                 new DataColumn("Message", typeof(string)),
                 new DataColumn("Data.Name", typeof(string)),
-                new DataColumn("Data.Value", typeof(string))
+                new DataColumn("Data.Value", typeof(string)),
+                new DataColumn("Expanded", typeof(string))
             });
 
             insights.ForEach(insight =>
@@ -124,7 +127,8 @@ namespace Diagnostics.ModelsAndUtils.Models.ResponseExtensions
                         insight.Status.ToString(),
                         insight.Message,
                         string.Empty,
-                        string.Empty
+                        string.Empty,
+                        insight.IsExpanded.ToString()
                     });
                 }
                 else
@@ -136,7 +140,8 @@ namespace Diagnostics.ModelsAndUtils.Models.ResponseExtensions
                             insight.Status.ToString(),
                             insight.Message,
                             entry.Key,
-                            entry.Value
+                            entry.Value,
+                            insight.IsExpanded.ToString()
                         });
 
                     }

--- a/tests/ModelTests/ResponseExtensionTests.cs
+++ b/tests/ModelTests/ResponseExtensionTests.cs
@@ -30,7 +30,7 @@ namespace Diagnostics.Tests.ModelTests
 
             foreach (DataRow row in insightFromDataSet.Table.Rows)
             {
-                Assert.Equal(4, row.ItemArray.Count());
+                Assert.Equal(5, row.ItemArray.Count());
             }
         }
 


### PR DESCRIPTION
This is just a proof of concept, I will add more predefined categories before I would check in.

Here are the reasons I am doing it this way:

- Enums don't have a way for assigning a string value (with spaces)
- This would give hard coded defaults for people to use so that we are in control of the categories
- If someone wants a category that we have not added, they can use the Custom(name) method, which is really meant to be a stopgap way of not having to wait for a deployment. We would need to push people to add hard coded values later and then updating the detectors. I have some worry about that happening successfully. 
- The UI will just group detectors by category and render them in those groups, no hard coding needed in the UI (applens and support center)
  - The exception to this is old detectors and Puneet's tools etc., those will continue to be hard coded for now.
- They are not defined per resource, we expect our filtering logic to only return detectors of categories that make sense. 

The downside is that with the custom method, people could theoretically add whatever they want and make it public, but we are already at risk for people adding whatever detector they want publicly. I am basically choosing not having to do a georegion deployment to update the categories to the possibility of someone adding one that doesn't make sense. 