### PR TITLE
Adding dataProvidersMetadata for onboarding flow as well

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -110,10 +110,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                     invocationResponse.UpdateDetectorStatusFromInsights();
 
                     List<DataProviderMetadata> dataProvidersMetadata = null;
-                    if (cxt.IsInternalCall)
-                    {
-                        dataProvidersMetadata = GetDataProvidersMetadata(dataProviders);
-                    }
+                    dataProvidersMetadata = GetDataProvidersMetadata(dataProviders);                    
                     queryRes.InvocationOutput = DiagnosticApiResponse.FromCsxResponse(invocationResponse, dataProvidersMetadata);
                 }
             }

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -110,7 +110,11 @@ namespace Diagnostics.RuntimeHost.Controllers
                     invocationResponse.UpdateDetectorStatusFromInsights();
 
                     List<DataProviderMetadata> dataProvidersMetadata = null;
-                    dataProvidersMetadata = GetDataProvidersMetadata(dataProviders);                    
+                    if  (cxt.IsInternalCall)
+                    {
+                        dataProvidersMetadata = GetDataProvidersMetadata(dataProviders);
+                    }
+                                        
                     queryRes.InvocationOutput = DiagnosticApiResponse.FromCsxResponse(invocationResponse, dataProvidersMetadata);
                 }
             }

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -108,7 +108,13 @@ namespace Diagnostics.RuntimeHost.Controllers
                     var responseInput = new Response() { Metadata = RemovePIIFromDefinition(invoker.EntryPointDefinitionAttribute, cxt.IsInternalCall) };
                     var invocationResponse = (Response)await invoker.Invoke(new object[] { dataProviders, cxt, responseInput });
                     invocationResponse.UpdateDetectorStatusFromInsights();
-                    queryRes.InvocationOutput = DiagnosticApiResponse.FromCsxResponse(invocationResponse);
+
+                    List<DataProviderMetadata> dataProvidersMetadata = null;
+                    if (cxt.IsInternalCall)
+                    {
+                        dataProvidersMetadata = GetDataProvidersMetadata(dataProviders);
+                    }
+                    queryRes.InvocationOutput = DiagnosticApiResponse.FromCsxResponse(invocationResponse, dataProvidersMetadata);
                 }
             }
 


### PR DESCRIPTION
This will allow applens to show KUSTO Query information even in the on-boarding flow