### PR TITLE
Fix site level for ase

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/HostingEnvironment.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/HostingEnvironment.cs
@@ -28,6 +28,11 @@ namespace Diagnostics.ModelsAndUtils.Models
         public string InternalName { get; set; }
 
         /// <summary>
+        /// If the hosting environment is an ASE then this would be the ASE name
+        /// </summary>
+        public string FriendlyName { get; set; }
+
+        /// <summary>
         /// Service Address
         /// </summary>
         public string ServiceAddress { get; set; }
@@ -96,7 +101,7 @@ namespace Diagnostics.ModelsAndUtils.Models
         {
             this.SubscriptionId = subscriptionId;
             this.ResourceGroup = resourceGroup;
-            this.Name = name;
+            this.FriendlyName = name;
             this.TenantIdList = new List<string>();
         }
 

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -280,6 +280,7 @@ namespace Diagnostics.RuntimeHost.Controllers
 
             HostingEnvironment hostingEnv = new HostingEnvironment(subscriptionId, resourceGroup, name)
             {
+                Name = stampPostBody.InternalName,
                 InternalName = stampPostBody.InternalName,
                 ServiceAddress = stampPostBody.ServiceAddress,
                 State = stampPostBody.State,

--- a/tests/DataProviderTests/SupportObserverTests.cs
+++ b/tests/DataProviderTests/SupportObserverTests.cs
@@ -41,6 +41,9 @@ namespace Diagnostics.Tests.DataProviderTests
                 var appResource = new App(string.Empty, string.Empty, "my-api")
                 {
                     Stamp = new HostingEnvironment(string.Empty, string.Empty, "waws-prod-bn1-71717c45")
+                    {
+                        Name = "waws-prod-bn1-71717c45"
+                    }
                 };
 
                 var operationContext = new OperationContext<App>(appResource, string.Empty, string.Empty, true, string.Empty);


### PR DESCRIPTION
Set the resource name for hosting environment to the stamp name
This may break some ASE detectors but there are few so its easy to edit them.
