### PR TITLE
Use URI object to remove query path which has token

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/GithubClient/GithubClient.cs
+++ b/src/Diagnostics.RuntimeHost/Services/GithubClient/GithubClient.cs
@@ -90,7 +90,8 @@ namespace Diagnostics.RuntimeHost.Services
             {
                 if (!httpResponse.IsSuccessStatusCode)
                 {
-                    throw new HttpRequestException($"Failed while getting resource : {fileUrl} . Http Status Code : {httpResponse.StatusCode}");
+                    var uri = new Uri(fileUrl);
+                    throw new HttpRequestException($"Failed while getting resource : {uri.Scheme}:/{uri.AbsolutePath} . Http Status Code : {httpResponse.StatusCode}");
                 }
 
                 using (Stream srcStream = await httpResponse.Content.ReadAsStreamAsync(),


### PR DESCRIPTION
Looking over source watcher failures, I noticed that we're logging the github access token. This PR addresses that problem by using the URI object to only log the host and path and not the query strings.