### PR TITLE
 LSI Fix : Handle Exceptions in Kusto Token Service

### DIFF
--- a/src/Diagnostics.DataProviders/KustoTokenService.cs
+++ b/src/Diagnostics.DataProviders/KustoTokenService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.IdentityModel.Clients.ActiveDirectory;
+﻿using Diagnostics.Logger;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -21,7 +22,7 @@ namespace Diagnostics.DataProviders
         public string AuthorizationToken => _authorizationToken;
 
         private KustoTokenService() : base()
-        {   
+        {
         }
 
         public void Initialize(KustoDataProviderConfiguration configuration)
@@ -37,10 +38,39 @@ namespace Diagnostics.DataProviders
         {
             while (true)
             {
-                _acquireTokenTask = _authContext.AcquireTokenAsync(DataProviderConstants.DefaultKustoEndpoint, _clientCredential);
-                AuthenticationResult authResult = await _acquireTokenTask;
-                _authorizationToken = GetAuthTokenFromAuthenticationResult(authResult);
-                _tokenAcquiredAtleastOnce = true;
+                DateTime invocationStartTime = DateTime.UtcNow;
+                string exceptionType = string.Empty;
+                string exceptionDetails = string.Empty;
+                string message = string.Empty;
+
+                try
+                {
+                    _acquireTokenTask = _authContext.AcquireTokenAsync(DataProviderConstants.DefaultKustoEndpoint, _clientCredential);
+                    AuthenticationResult authResult = await _acquireTokenTask;
+                    _authorizationToken = GetAuthTokenFromAuthenticationResult(authResult);
+                    _tokenAcquiredAtleastOnce = true;
+                    message = "Token Acquisition Status : Success";
+                }
+                catch (Exception ex)
+                {
+                    exceptionType = ex.GetType().ToString();
+                    exceptionDetails = ex.ToString();
+                    message = "Token Acquisition Status : Failed";
+                }
+                finally
+                {
+                    DateTime invocationEndTime = DateTime.UtcNow;
+                    long latencyInMs = Convert.ToInt64((invocationEndTime - invocationStartTime).TotalMilliseconds);
+                    DiagnosticsETWProvider.Instance.LogKustoTokenRefreshSummary(
+                        "KustoTokenRefreshService",
+                        message,
+                        latencyInMs,
+                        invocationStartTime.ToString("HH:mm:ss.fff"),
+                        invocationEndTime.ToString("HH:mm:ss.fff"),
+                        exceptionType,
+                        exceptionDetails
+                        );
+                }
 
                 await Task.Delay(DataProviderConstants.TokenRefreshIntervalInMs);
             }

--- a/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
+++ b/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
@@ -221,12 +221,11 @@ namespace Diagnostics.Logger
         }
 
         [Event(3003, Level = EventLevel.Warning, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogKustoTokenRefreshSummary)]
-        public void LogKustoTokenRefreshSummary(string RequestId, string Source, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime, string ExceptionType, string ExceptionDetails)
+        public void LogKustoTokenRefreshSummary(string Source, string Message, long LatencyInMilliseconds, string StartTime, string EndTime, string ExceptionType, string ExceptionDetails)
         {
             WriteDiagnosticsEvent(3003,
-                RequestId,
                 Source,
-                StatusCode,
+                Message,
                 LatencyInMilliseconds,
                 StartTime,
                 EndTime,

--- a/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
+++ b/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
@@ -220,7 +220,7 @@ namespace Diagnostics.Logger
                 LatencyInMilliseconds);
         }
 
-        [Event(3003, Level = EventLevel.Warning, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogKustoTokenRefreshSummary)]
+        [Event(3003, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogKustoTokenRefreshSummary)]
         public void LogKustoTokenRefreshSummary(string Source, string Message, long LatencyInMilliseconds, string StartTime, string EndTime, string ExceptionType, string ExceptionDetails)
         {
             WriteDiagnosticsEvent(3003,

--- a/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
+++ b/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
@@ -219,6 +219,22 @@ namespace Diagnostics.Logger
                 EndTime,
                 LatencyInMilliseconds);
         }
+
+        [Event(3003, Level = EventLevel.Warning, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogKustoTokenRefreshSummary)]
+        public void LogKustoTokenRefreshSummary(string RequestId, string Source, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime, string ExceptionType, string ExceptionDetails)
+        {
+            WriteDiagnosticsEvent(3003,
+                RequestId,
+                Source,
+                StatusCode,
+                LatencyInMilliseconds,
+                StartTime,
+                EndTime,
+                ExceptionType,
+                ExceptionDetails);
+        }
+
+
         #endregion
     }
 }

--- a/src/Diagnostics.Logger/ETWProvider/ETWMessageTemplates.cs
+++ b/src/Diagnostics.Logger/ETWProvider/ETWMessageTemplates.cs
@@ -47,6 +47,7 @@ namespace Diagnostics.Logger
         public const string LogDataProviderMessage = "Data Provider Informational Details. Source : {1} Message : {2}";
         public const string LogDataProviderException = "An exception occurred in Source : {1}. ExceptionType : {5} ExceptionDetails : {6}";
         public const string LogDataProviderOperationSummary = "Data Provider Operation. Source : {1} StartTime : {2} EndTime : {3} LatencyInMilliseconds : {4}";
+        public const string LogKustoTokenRefreshSummary = "Kusto Token Refresh Summary";
         #endregion
     }
 }


### PR DESCRIPTION
For whatever reasons, if Kusto token refresh fails, the next token refresh will not happen right now as the service will stop. The fix is to handle exceptions and log. 
There is already alerts now covering this scenario.