### PR TITLE
Create postbody for site and ase

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
@@ -152,9 +152,9 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(null, _observerDataProvider.GetStampName(subscriptionId, resourceGroupName, siteName));
         }
 
-        public Task<dynamic> GetHostNames(string siteName)
+        public Task<dynamic> GetHostNames(string stampName, string siteName)
         {
-            return MakeDependencyCall(null, _observerDataProvider.GetHostNames(siteName));
+            return MakeDependencyCall(null, _observerDataProvider.GetHostNames(stampName, siteName));
         }
 
         public Task<dynamic> GetSitePostBody(string stampName, string siteName)

--- a/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
@@ -147,6 +147,26 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(null, _observerDataProvider.GetSite(stampName, siteName));
         }
 
+        public Task<string> GetStampName(string subscriptionId, string resourceGroupName, string siteName)
+        {
+            return MakeDependencyCall(null, _observerDataProvider.GetStampName(subscriptionId, resourceGroupName, siteName));
+        }
+
+        public Task<dynamic> GetHostNames(string siteName)
+        {
+            return MakeDependencyCall(null, _observerDataProvider.GetHostNames(siteName));
+        }
+
+        public Task<dynamic> GetSitePostBody(string stampName, string siteName)
+        {
+            return MakeDependencyCall(null, _observerDataProvider.GetSitePostBody(stampName, siteName));
+        }
+
+        public Task<dynamic> GetHostingEnvironmentPostBody(string hostingEnvironmentName)
+        {
+            return MakeDependencyCall(null, _observerDataProvider.GetHostingEnvironmentPostBody(hostingEnvironmentName));
+        }
+
         public Task<string> GetSiteResourceGroupNameAsync(string siteName)
         {
             return MakeDependencyCall(null, _observerDataProvider.GetSiteResourceGroupNameAsync(siteName));

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -123,6 +123,10 @@ namespace Diagnostics.DataProviders
 
         public abstract Task<dynamic> GetSite(string siteName);
         public abstract Task<dynamic> GetSite(string stampName, string siteName);
+        public abstract Task<string> GetStampName(string subscriptionId, string resourceGroupName, string siteName);
+        public abstract Task<dynamic> GetHostNames(string siteName);
+        public abstract Task<dynamic> GetSitePostBody(string stampName, string siteName);
+        public abstract Task<dynamic> GetHostingEnvironmentPostBody(string hostingEnvironmentName);
         public abstract Task<string> GetSiteResourceGroupNameAsync(string siteName);
         public abstract Task<dynamic> GetSitesInResourceGroupAsync(string subscriptionName, string resourceGroupName);
         public abstract Task<dynamic> GetServerFarmsInResourceGroupAsync(string subscriptionName, string resourceGroupName);

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -124,7 +124,7 @@ namespace Diagnostics.DataProviders
         public abstract Task<dynamic> GetSite(string siteName);
         public abstract Task<dynamic> GetSite(string stampName, string siteName);
         public abstract Task<string> GetStampName(string subscriptionId, string resourceGroupName, string siteName);
-        public abstract Task<dynamic> GetHostNames(string siteName);
+        public abstract Task<dynamic> GetHostNames(string stampName, string siteName);
         public abstract Task<dynamic> GetSitePostBody(string stampName, string siteName);
         public abstract Task<dynamic> GetHostingEnvironmentPostBody(string hostingEnvironmentName);
         public abstract Task<string> GetSiteResourceGroupNameAsync(string siteName);

--- a/src/Diagnostics.DataProviders/DataProviders/ISupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/ISupportObserverDataProvider.cs
@@ -24,7 +24,7 @@ namespace Diagnostics.DataProviders
         Task<dynamic> GetHostingEnvironmentPostBody(string hostingEnvironmentName);
         Task<IEnumerable<object>> GetAppServiceEnvironmentDeploymentsAsync(string hostingEnvironmentName);
         Task<string> GetStampName(string subscriptionId, string resourceGroupName, string siteName);
-        Task<dynamic> GetHostNames(string siteName);
+        Task<dynamic> GetHostNames(string stampName, string siteName);
         Task<dynamic> GetSitePostBody(string stampName, string siteName);
         Task<JObject> GetAdminSitesBySiteNameAsync(string stampName, string siteName);
         Task<JObject> GetAdminSitesByHostNameAsync(string stampName, string[] hostNames);

--- a/src/Diagnostics.DataProviders/DataProviders/ISupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/ISupportObserverDataProvider.cs
@@ -21,7 +21,11 @@ namespace Diagnostics.DataProviders
         Task<string> GetSiteWebSpaceNameAsync(string subscriptionId, string siteName);
         Task<dynamic> GetSitesInServerFarmAsync(string subscriptionId, string serverFarmName);
         Task<JObject> GetAppServiceEnvironmentDetailsAsync(string hostingEnvironmentName);
+        Task<dynamic> GetHostingEnvironmentPostBody(string hostingEnvironmentName);
         Task<IEnumerable<object>> GetAppServiceEnvironmentDeploymentsAsync(string hostingEnvironmentName);
+        Task<string> GetStampName(string subscriptionId, string resourceGroupName, string siteName);
+        Task<dynamic> GetHostNames(string siteName);
+        Task<dynamic> GetSitePostBody(string stampName, string siteName);
         Task<JObject> GetAdminSitesBySiteNameAsync(string stampName, string siteName);
         Task<JObject> GetAdminSitesByHostNameAsync(string stampName, string[] hostNames);
         Task<string> GetStorageVolumeForSiteAsync(string stampName, string siteName);

--- a/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
@@ -68,7 +68,7 @@ namespace Diagnostics.DataProviders
             throw new NotImplementedException();
         }
 
-        public override async Task<dynamic> GetHostNames(string siteName)
+        public override async Task<dynamic> GetHostNames(string stampName, string siteName)
         {
             throw new NotImplementedException();
         }

--- a/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
@@ -63,6 +63,25 @@ namespace Diagnostics.DataProviders
             return await GetSiteInternal();
         }
 
+        public override async Task<string> GetStampName(string subscriptionId, string resourceGroupName, string siteName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override async Task<dynamic> GetHostNames(string siteName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<dynamic> GetSitePostBody(string stampName, string siteName)
+        {
+            throw new NotImplementedException();
+        }
+        public override Task<dynamic> GetHostingEnvironmentPostBody(string hostingEnvironmentName)
+        {
+            throw new NotImplementedException();
+        }
+
         private Task<dynamic> GetSiteInternal()
         {
             var siteData = @"

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -127,15 +127,15 @@ namespace Diagnostics.DataProviders
                     .FirstOrDefault(
                         j => (j.ContainsKey("Subscription") && j["Subscription"].ToString() == subscriptionId
                             && j.ContainsKey("ResourceGroupName") && j["ResourceGroupName"].ToString() == resourceGroupName
-                            && j.ContainsKey("stampName")));
+                            && j.ContainsKey("StampName")));
 
-            string stampName = obj2?["stampName"]?.ToString();
+            string stampName = obj2?["StampName"]?.ToString();
             return stampName;
         }
 
-        public override async Task<dynamic> GetHostNames(string siteName)
+        public override async Task<dynamic> GetHostNames(string stampName, string siteName)
         {
-            var response = await Get($"sites/{siteName}/hostnames");
+            var response = await Get($"stamps/{stampName}/sites/{siteName}/hostnames");
             var hostNames = JsonConvert.DeserializeObject(response);
             return hostNames;
         }
@@ -147,7 +147,7 @@ namespace Diagnostics.DataProviders
 
             if (sitePostBody["HostNames"] == null)
             {
-                var hostNames = await GetHostNames(siteName);
+                var hostNames = await GetHostNames(stampName, siteName);
                 List<dynamic> hostNamesList = new List<dynamic>();
                 foreach (var hostName in hostNames)
                 {

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -40,7 +40,7 @@ namespace Diagnostics.DataProviders
 
         public override async Task<dynamic> GetCertificatesInResourceGroupAsync(string subscriptionName, string resourceGroupName)
         {
-            var result = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/certificates");
+            var result = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/certificates?api-version=2.0");
             return JsonConvert.DeserializeObject(result);
         }
 
@@ -56,7 +56,7 @@ namespace Diagnostics.DataProviders
 
         private async Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMapInternal(string stampName, string siteName)
         {
-            var result = await Get(string.IsNullOrWhiteSpace(stampName) ? $"/sites/{siteName}/runtimesiteslotmap" : $"stamp/{stampName}/sites/{siteName}/runtimesiteslotmap");
+            var result = await Get(string.IsNullOrWhiteSpace(stampName) ? $"/sites/{siteName}/runtimesiteslotmap?api-version=2.0" : $"stamp/{stampName}/sites/{siteName}/runtimesiteslotmap?api-version=2.0");
             var slotTimeRangeCaseSensitiveDictionary = JsonConvert.DeserializeObject<Dictionary<string, List<RuntimeSitenameTimeRange>>>(result);
             var slotTimeRange = new Dictionary<string, List<RuntimeSitenameTimeRange>>(slotTimeRangeCaseSensitiveDictionary, StringComparer.CurrentCultureIgnoreCase);
             return slotTimeRange;
@@ -64,35 +64,35 @@ namespace Diagnostics.DataProviders
 
         public override async Task<dynamic> GetServerFarmsInResourceGroupAsync(string subscriptionName, string resourceGroupName)
         {
-            var result = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/serverfarms");
+            var result = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/serverfarms?api-version=2.0");
             return JsonConvert.DeserializeObject(result);
         }
 
         public override async Task<string> GetServerFarmWebspaceName(string subscriptionId, string serverFarm)
         {
-            return await Get($"subscriptionid/{subscriptionId}/serverfarm/{serverFarm}/webspacename");
+            return await Get($"subscriptionid/{subscriptionId}/serverfarm/{serverFarm}/webspacename?api-version=2.0");
         }
 
         public override async Task<string> GetSiteResourceGroupNameAsync(string siteName)
         {
-            return await Get($"sites/{siteName}/resourcegroupname");
+            return await Get($"sites/{siteName}/resourcegroupname?api-version=2.0");
         }
 
         public override async Task<dynamic> GetSitesInResourceGroupAsync(string subscriptionName, string resourceGroupName)
         {
-            var sitesResult = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/sites");
+            var sitesResult = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/sites?api-version=2.0");
             return JsonConvert.DeserializeObject(sitesResult);
         }
 
         public override async Task<dynamic> GetSitesInServerFarmAsync(string subscriptionId, string serverFarmName)
         {
-            var sitesResult = await Get($"subscriptionid/{subscriptionId}/serverfarm/{serverFarmName}/sites");
+            var sitesResult = await Get($"subscriptionid/{subscriptionId}/serverfarm/{serverFarmName}/sites?api-version=2.0");
             return JsonConvert.DeserializeObject(sitesResult);
         }
 
         public override async Task<string> GetSiteWebSpaceNameAsync(string subscriptionId, string siteName)
         {
-            return await Get($"subscriptionid/{subscriptionId}/sitename/{siteName}/webspacename");
+            return await Get($"subscriptionid/{subscriptionId}/sitename/{siteName}/webspacename?api-version=2.0");
         }
 
         public override Task<string> GetStorageVolumeForSiteAsync(string stampName, string siteName)
@@ -102,7 +102,7 @@ namespace Diagnostics.DataProviders
 
         public override async Task<string> GetWebspaceResourceGroupName(string subscriptionId, string webSpaceName)
         {
-            return await Get($"subscriptionid/{subscriptionId}/webspacename/{webSpaceName}/resourcegroupname");
+            return await Get($"subscriptionid/{subscriptionId}/webspacename/{webSpaceName}/resourcegroupname?api-version=2.0");
         }
 
         public override async Task<dynamic> GetSite(string siteName)
@@ -129,13 +129,13 @@ namespace Diagnostics.DataProviders
                             && j.ContainsKey("resource_group_name") && j["resource_group_name"].ToString() == resourceGroupName
                             && j.ContainsKey("stamp")));
 
-            string stampName = obj2?["stamp"]?["name"].ToString();
+            string stampName = obj2?["stamp"]?["name"]?.ToString();
             return stampName;
         }
 
         public override async Task<dynamic> GetHostNames(string stampName, string siteName)
         {
-            var response = await Get($"stamps/{stampName}/sites/{siteName}/hostnames");
+            var response = await Get($"stamps/{stampName}/sites/{siteName}/hostnames?api-version=2.0");
             var hostNames = JsonConvert.DeserializeObject(response);
             return hostNames;
         }
@@ -144,19 +144,6 @@ namespace Diagnostics.DataProviders
         {
             var response = await Get($"stamps/{stampName}/sites/{siteName}/postbody");
             dynamic sitePostBody = JsonConvert.DeserializeObject(response);
-
-            if (sitePostBody["HostNames"] == null)
-            {
-                var hostNames = await GetHostNames(stampName, siteName);
-                List<dynamic> hostNamesList = new List<dynamic>();
-                foreach (var hostName in hostNames)
-                {
-                    hostNamesList.Add(new Dictionary<string, string>() { { "name", hostName.ToString() }, { "type", "0" } });
-                }
-
-                sitePostBody["hostNames"] = JToken.FromObject(hostNamesList);
-            }
-
             return sitePostBody;
         }
 
@@ -180,7 +167,7 @@ namespace Diagnostics.DataProviders
         /// <returns></returns>
         private async Task<string> Get(string path)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"https://support-bay-api.azurewebsites.net/observer/{path}?api-version=2.0");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"https://support-bay-api.azurewebsites.net/observer/{path}");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await _configuration.GetAccessToken(_configuration.RuntimeSiteSlotMapResourceUri));
             var response = await GetObserverClient().SendAsync(request);
             response.EnsureSuccessStatusCode();

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -40,7 +40,7 @@ namespace Diagnostics.DataProviders
 
         public override async Task<dynamic> GetCertificatesInResourceGroupAsync(string subscriptionName, string resourceGroupName)
         {
-            var result = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/certificates?api-version=2.0");
+            var result = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/certificates");
             return JsonConvert.DeserializeObject(result);
         }
 
@@ -56,7 +56,7 @@ namespace Diagnostics.DataProviders
 
         private async Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMapInternal(string stampName, string siteName)
         {
-            var result = await Get(string.IsNullOrWhiteSpace(stampName) ? $"/sites/{siteName}/runtimesiteslotmap?api-version=2.0" : $"stamp/{stampName}/sites/{siteName}/runtimesiteslotmap?api-version=2.0");
+            var result = await Get(string.IsNullOrWhiteSpace(stampName) ? $"/sites/{siteName}/runtimesiteslotmap" : $"stamp/{stampName}/sites/{siteName}/runtimesiteslotmap");
             var slotTimeRangeCaseSensitiveDictionary = JsonConvert.DeserializeObject<Dictionary<string, List<RuntimeSitenameTimeRange>>>(result);
             var slotTimeRange = new Dictionary<string, List<RuntimeSitenameTimeRange>>(slotTimeRangeCaseSensitiveDictionary, StringComparer.CurrentCultureIgnoreCase);
             return slotTimeRange;
@@ -64,35 +64,35 @@ namespace Diagnostics.DataProviders
 
         public override async Task<dynamic> GetServerFarmsInResourceGroupAsync(string subscriptionName, string resourceGroupName)
         {
-            var result = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/serverfarms?api-version=2.0");
+            var result = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/serverfarms");
             return JsonConvert.DeserializeObject(result);
         }
 
         public override async Task<string> GetServerFarmWebspaceName(string subscriptionId, string serverFarm)
         {
-            return await Get($"subscriptionid/{subscriptionId}/serverfarm/{serverFarm}/webspacename?api-version=2.0");
+            return await Get($"subscriptionid/{subscriptionId}/serverfarm/{serverFarm}/webspacename");
         }
 
         public override async Task<string> GetSiteResourceGroupNameAsync(string siteName)
         {
-            return await Get($"sites/{siteName}/resourcegroupname?api-version=2.0");
+            return await Get($"sites/{siteName}/resourcegroupname");
         }
 
         public override async Task<dynamic> GetSitesInResourceGroupAsync(string subscriptionName, string resourceGroupName)
         {
-            var sitesResult = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/sites?api-version=2.0");
+            var sitesResult = await Get($"subscriptions/{subscriptionName}/resourceGroups/{resourceGroupName}/sites");
             return JsonConvert.DeserializeObject(sitesResult);
         }
 
         public override async Task<dynamic> GetSitesInServerFarmAsync(string subscriptionId, string serverFarmName)
         {
-            var sitesResult = await Get($"subscriptionid/{subscriptionId}/serverfarm/{serverFarmName}/sites?api-version=2.0");
+            var sitesResult = await Get($"subscriptionid/{subscriptionId}/serverfarm/{serverFarmName}/sites");
             return JsonConvert.DeserializeObject(sitesResult);
         }
 
         public override async Task<string> GetSiteWebSpaceNameAsync(string subscriptionId, string siteName)
         {
-            return await Get($"subscriptionid/{subscriptionId}/sitename/{siteName}/webspacename?api-version=2.0");
+            return await Get($"subscriptionid/{subscriptionId}/sitename/{siteName}/webspacename");
         }
 
         public override Task<string> GetStorageVolumeForSiteAsync(string stampName, string siteName)
@@ -102,7 +102,7 @@ namespace Diagnostics.DataProviders
 
         public override async Task<string> GetWebspaceResourceGroupName(string subscriptionId, string webSpaceName)
         {
-            return await Get($"subscriptionid/{subscriptionId}/webspacename/{webSpaceName}/resourcegroupname?api-version=2.0");
+            return await Get($"subscriptionid/{subscriptionId}/webspacename/{webSpaceName}/resourcegroupname");
         }
 
         public override async Task<dynamic> GetSite(string siteName)
@@ -135,7 +135,7 @@ namespace Diagnostics.DataProviders
 
         public override async Task<dynamic> GetHostNames(string stampName, string siteName)
         {
-            var response = await Get($"stamps/{stampName}/sites/{siteName}/hostnames?api-version=2.0");
+            var response = await Get($"stamps/{stampName}/sites/{siteName}/hostnames");
             var hostNames = JsonConvert.DeserializeObject(response);
             return hostNames;
         }
@@ -167,7 +167,7 @@ namespace Diagnostics.DataProviders
         /// <returns></returns>
         private async Task<string> Get(string path)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"https://support-bay-api.azurewebsites.net/observer/{path}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"https://support-bay-api.azurewebsites.net/observer/{path}?api-version=2.0");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await _configuration.GetAccessToken(_configuration.RuntimeSiteSlotMapResourceUri));
             var response = await GetObserverClient().SendAsync(request);
             response.EnsureSuccessStatusCode();

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -116,6 +117,54 @@ namespace Diagnostics.DataProviders
             var response = await GetObserverResource($"stamps/{stampName}/sites/{siteName}");
             var siteObject = JsonConvert.DeserializeObject(response);
             return siteObject;
+        }
+
+        public override async Task<string> GetStampName(string subscriptionId, string resourceGroupName, string siteName)
+        {
+            dynamic siteObjects = await GetSite(siteName);
+            JToken obj2 = ((JArray)siteObjects)
+                    .Select(i => (JObject)i)
+                    .FirstOrDefault(
+                        j => (j.ContainsKey("Subscription") && j["Subscription"].ToString() == subscriptionId
+                            && j.ContainsKey("ResourceGroupName") && j["ResourceGroupName"].ToString() == resourceGroupName
+                            && j.ContainsKey("stampName")));
+
+            string stampName = obj2?["stampName"]?.ToString();
+            return stampName;
+        }
+
+        public override async Task<dynamic> GetHostNames(string siteName)
+        {
+            var response = await Get($"sites/{siteName}/hostnames");
+            var hostNames = JsonConvert.DeserializeObject(response);
+            return hostNames;
+        }
+
+        public override async Task<dynamic> GetSitePostBody(string stampName, string siteName)
+        {
+            var response = await Get($"stamps/{stampName}/sites/{siteName}/postbody");
+            dynamic sitePostBody = JsonConvert.DeserializeObject(response);
+
+            if (sitePostBody["HostNames"] == null)
+            {
+                var hostNames = await GetHostNames(siteName);
+                List<dynamic> hostNamesList = new List<dynamic>();
+                foreach (var hostName in hostNames)
+                {
+                    hostNamesList.Add(new Dictionary<string, string>() { { "name", hostName.ToString() }, { "type", "0" } });
+                }
+
+                sitePostBody["hostNames"] = JToken.FromObject(hostNamesList);
+            }
+
+            return sitePostBody;
+        }
+
+        public override async Task<dynamic> GetHostingEnvironmentPostBody(string hostingEnvironmentName)
+        {
+            var response = await Get($"hostingEnvironments/{hostingEnvironmentName}/postbody");
+            var hostingEnvironmentPostBody = JsonConvert.DeserializeObject(response);
+            return hostingEnvironmentPostBody;
         }
 
         public override HttpClient GetObserverClient()

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -125,11 +125,11 @@ namespace Diagnostics.DataProviders
             JToken obj2 = ((JArray)siteObjects)
                     .Select(i => (JObject)i)
                     .FirstOrDefault(
-                        j => (j.ContainsKey("Subscription") && j["Subscription"].ToString() == subscriptionId
-                            && j.ContainsKey("ResourceGroupName") && j["ResourceGroupName"].ToString() == resourceGroupName
-                            && j.ContainsKey("StampName")));
+                        j => (j.ContainsKey("subscription") && j["subscription"]["name"].ToString() == subscriptionId
+                            && j.ContainsKey("resource_group_name") && j["resource_group_name"].ToString() == resourceGroupName
+                            && j.ContainsKey("stamp")));
 
-            string stampName = obj2?["StampName"]?.ToString();
+            string stampName = obj2?["stamp"]?["name"].ToString();
             return stampName;
         }
 

--- a/src/Diagnostics.RuntimeHost/Controllers/HostingEnvironment/HostingEnvironmentController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/HostingEnvironment/HostingEnvironmentController.cs
@@ -20,6 +20,13 @@ namespace Diagnostics.RuntimeHost.Controllers
         {
         }
 
+        public async Task<dynamic> GetHostingEnvironmentPostBody(string hostingEnvironmentName)
+        {
+            var dataProviders = new DataProviders.DataProviders(_dataSourcesConfigService.Config);
+            dynamic postBody = await dataProviders.Observer.GetHostingEnvironmentPostBody(hostingEnvironmentName);
+            return postBody;
+        }
+
         [HttpPost(UriElements.Query)]
         public async Task<IActionResult> ExecuteQuery(string subscriptionId, string resourceGroupName, string hostingEnvironmentName, string[] hostNames, string stampName, [FromBody]CompilationBostBody<DiagnosticStampData> jsonBody, string startTime = null, string endTime = null, string timeGrain = null)
         {
@@ -30,7 +37,7 @@ namespace Diagnostics.RuntimeHost.Controllers
             
             if (jsonBody.Resource == null)
             {
-                return BadRequest("Missing Hosting Enviroment Data in body");
+                jsonBody.Resource = await GetHostingEnvironmentPostBody(hostingEnvironmentName);
             }
 
             if (!DateTimeHelper.PrepareStartEndTimeWithTimeGrain(startTime, endTime, timeGrain, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage))
@@ -47,7 +54,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         {
             if (postBody == null)
             {
-                return BadRequest("Post Body missing.");
+                postBody = await GetHostingEnvironmentPostBody(hostingEnvironmentName);
             }
 
             DateTimeHelper.PrepareStartEndTimeWithTimeGrain(string.Empty, string.Empty, string.Empty, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage);
@@ -60,7 +67,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         {
             if (postBody == null)
             {
-                return BadRequest("Post Body missing.");
+                postBody = await GetHostingEnvironmentPostBody(hostingEnvironmentName);
             }
 
             if (!DateTimeHelper.PrepareStartEndTimeWithTimeGrain(startTime, endTime, timeGrain, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage))
@@ -90,7 +97,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         {
             if (postBody == null)
             {
-                return BadRequest("Post Body missing.");
+                postBody = await GetHostingEnvironmentPostBody(hostingEnvironmentName);
             }
 
             if (!DateTimeHelper.PrepareStartEndTimeWithTimeGrain(startTime, endTime, timeGrain, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage))

--- a/src/Diagnostics.RuntimeHost/Controllers/HostingEnvironment/HostingEnvironmentController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/HostingEnvironment/HostingEnvironmentController.cs
@@ -4,6 +4,7 @@ using Diagnostics.RuntimeHost.Services;
 using Diagnostics.RuntimeHost.Services.SourceWatcher;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,11 +21,13 @@ namespace Diagnostics.RuntimeHost.Controllers
         {
         }
 
-        public async Task<dynamic> GetHostingEnvironmentPostBody(string hostingEnvironmentName)
+        private async Task<DiagnosticStampData> GetHostingEnvironmentPostBody(string hostingEnvironmentName)
         {
             var dataProviders = new DataProviders.DataProviders(_dataSourcesConfigService.Config);
             dynamic postBody = await dataProviders.Observer.GetHostingEnvironmentPostBody(hostingEnvironmentName);
-            return postBody;
+            JObject bodyObject = (JObject)postBody;
+            var hostingEnvironmentPostBody = bodyObject.ToObject<DiagnosticStampData>();
+            return hostingEnvironmentPostBody;
         }
 
         [HttpPost(UriElements.Query)]

--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
@@ -5,6 +5,7 @@ using Diagnostics.RuntimeHost.Services;
 using Diagnostics.RuntimeHost.Services.SourceWatcher;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,12 +22,14 @@ namespace Diagnostics.RuntimeHost.Controllers
         {
         }
 
-        public async Task<dynamic> GetSitePostBody (string subscriptionId, string resourceGroupName, string siteName)
+        private async Task<DiagnosticSiteData> GetSitePostBody (string subscriptionId, string resourceGroupName, string siteName)
         {
             var dataProviders = new DataProviders.DataProviders(_dataSourcesConfigService.Config);
             string stampName = await dataProviders.Observer.GetStampName(subscriptionId, resourceGroupName, siteName);
             dynamic postBody = await dataProviders.Observer.GetSitePostBody(stampName, siteName);
-            return postBody;
+            JObject bodyObject = (JObject)postBody;
+            var sitePostBody = bodyObject.ToObject<DiagnosticSiteData>();
+            return sitePostBody;
         }
 
         [HttpPost(UriElements.Query)]

--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
@@ -21,6 +21,14 @@ namespace Diagnostics.RuntimeHost.Controllers
         {
         }
 
+        public async Task<dynamic> GetSitePostBody (string subscriptionId, string resourceGroupName, string siteName)
+        {
+            var dataProviders = new DataProviders.DataProviders(_dataSourcesConfigService.Config);
+            string stampName = await dataProviders.Observer.GetStampName(subscriptionId, resourceGroupName, siteName);
+            dynamic postBody = await dataProviders.Observer.GetSitePostBody(stampName, siteName);
+            return postBody;
+        }
+
         [HttpPost(UriElements.Query)]
         public async Task<IActionResult> Post(string subscriptionId, string resourceGroupName, string siteName, [FromBody]CompilationBostBody<DiagnosticSiteData> jsonBody, string startTime = null, string endTime = null, string timeGrain = null)
         {
@@ -31,7 +39,7 @@ namespace Diagnostics.RuntimeHost.Controllers
             
             if (jsonBody.Resource == null)
             {
-                return BadRequest("Missing Site data in body");
+                jsonBody.Resource = await GetSitePostBody(subscriptionId, resourceGroupName, siteName);
             }
 
             if (!DateTimeHelper.PrepareStartEndTimeWithTimeGrain(startTime, endTime, timeGrain, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage))
@@ -48,7 +56,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         {
             if (postBody == null)
             {
-                return BadRequest("Post Body missing.");
+                postBody = await GetSitePostBody(subscriptionId, resourceGroupName, siteName);
             }
 
             DateTimeHelper.PrepareStartEndTimeWithTimeGrain(string.Empty, string.Empty, string.Empty, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage);
@@ -61,7 +69,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         {
             if (postBody == null)
             {
-                return BadRequest("Post Body missing.");
+                postBody = await GetSitePostBody(subscriptionId, resourceGroupName, siteName);
             }
 
             if (!DateTimeHelper.PrepareStartEndTimeWithTimeGrain(startTime, endTime, timeGrain, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage))
@@ -91,7 +99,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         {
             if (postBody == null)
             {
-                return BadRequest("Post Body missing.");
+                postBody = await GetSitePostBody(subscriptionId, resourceGroupName, siteName);
             }
 
             if (!DateTimeHelper.PrepareStartEndTimeWithTimeGrain(startTime, endTime, timeGrain, out DateTime startTimeUtc, out DateTime endTimeUtc, out TimeSpan timeGrainTimeSpan, out string errorMessage))


### PR DESCRIPTION
Create postbody for site and ASE controller, so we don't need to construct ASE and site specific postbody from client side each time, which will also make all the resource types requests in consistency.