### PR TITLE
Add slotname as parameter for observer GetSite call

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
@@ -141,14 +141,14 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(_observerDataProvider.GetServerFarmWebspaceName(subscriptionId, serverFarm));
         }
 
-        public Task<dynamic> GetSite(string siteName)
+        public Task<dynamic> GetSite(string siteName, string slotName = GeoMasterConstants.ProductionSlot)
         {
-            return MakeDependencyCall(_observerDataProvider.GetSite(siteName));
+            return MakeDependencyCall(_observerDataProvider.GetSite(siteName, slotName));
         }
 
-        public Task<dynamic> GetSite(string stampName, string siteName)
+        public Task<dynamic> GetSite(string stampName, string siteName, string slotName = GeoMasterConstants.ProductionSlot)
         {
-            return MakeDependencyCall(_observerDataProvider.GetSite(stampName, siteName));
+            return MakeDependencyCall(_observerDataProvider.GetSite(stampName, siteName, slotName));
         }
 
         public Task<string> GetStampName(string subscriptionId, string resourceGroupName, string siteName)

--- a/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
@@ -141,12 +141,17 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(_observerDataProvider.GetServerFarmWebspaceName(subscriptionId, serverFarm));
         }
 
-        public Task<dynamic> GetSite(string siteName, string slotName = GeoMasterConstants.ProductionSlot)
+        public Task<dynamic> GetSite(string siteName)
         {
-            return MakeDependencyCall(_observerDataProvider.GetSite(siteName, slotName));
+            return MakeDependencyCall(_observerDataProvider.GetSite(siteName));
         }
 
-        public Task<dynamic> GetSite(string stampName, string siteName, string slotName = GeoMasterConstants.ProductionSlot)
+        public Task<dynamic> GetSite(string stampName, string siteName)
+        {
+            return MakeDependencyCall(_observerDataProvider.GetSite(stampName, siteName));
+        }
+
+        public Task<dynamic> GetSite(string stampName, string siteName, string slotName)
         {
             return MakeDependencyCall(_observerDataProvider.GetSite(stampName, siteName, slotName));
         }

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -121,8 +121,9 @@ namespace Diagnostics.DataProviders
             return result;
         }
 
-        public abstract Task<dynamic> GetSite(string siteName, string slotName = GeoMasterConstants.ProductionSlot);
-        public abstract Task<dynamic> GetSite(string stampName, string siteName, string slotName = GeoMasterConstants.ProductionSlot);
+        public abstract Task<dynamic> GetSite(string siteName);
+        public abstract Task<dynamic> GetSite(string stampName, string siteName);
+        public abstract Task<dynamic> GetSite(string stampName, string siteName, string slotName);
         public abstract Task<string> GetStampName(string subscriptionId, string resourceGroupName, string siteName);
         public abstract Task<dynamic> GetHostNames(string stampName, string siteName);
         public abstract Task<dynamic> GetSitePostBody(string stampName, string siteName);

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -121,8 +121,8 @@ namespace Diagnostics.DataProviders
             return result;
         }
 
-        public abstract Task<dynamic> GetSite(string siteName);
-        public abstract Task<dynamic> GetSite(string stampName, string siteName);
+        public abstract Task<dynamic> GetSite(string siteName, string slotName = GeoMasterConstants.ProductionSlot);
+        public abstract Task<dynamic> GetSite(string stampName, string siteName, string slotName = GeoMasterConstants.ProductionSlot);
         public abstract Task<string> GetStampName(string subscriptionId, string resourceGroupName, string siteName);
         public abstract Task<dynamic> GetHostNames(string stampName, string siteName);
         public abstract Task<dynamic> GetSitePostBody(string stampName, string siteName);

--- a/src/Diagnostics.DataProviders/DataProviders/ISupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/ISupportObserverDataProvider.cs
@@ -9,8 +9,9 @@ namespace Diagnostics.DataProviders
 {
     public interface ISupportObserverDataProvider:IMetadataProvider
     {
-        Task<dynamic> GetSite(string siteName, string slotName = GeoMasterConstants.ProductionSlot);
-        Task<dynamic> GetSite(string stampName, string siteName, string slotName = GeoMasterConstants.ProductionSlot);
+        Task<dynamic> GetSite(string siteName);
+        Task<dynamic> GetSite(string stampName, string siteName);
+        Task<dynamic> GetSite(string stampName, string siteName, string slotName);
         Task<string> GetSiteResourceGroupNameAsync(string siteName);
         Task<dynamic> GetSitesInResourceGroupAsync(string subscriptionName, string resourceGroupName);
         Task<dynamic> GetServerFarmsInResourceGroupAsync(string subscriptionName, string resourceGroupName);

--- a/src/Diagnostics.DataProviders/DataProviders/ISupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/ISupportObserverDataProvider.cs
@@ -9,8 +9,8 @@ namespace Diagnostics.DataProviders
 {
     public interface ISupportObserverDataProvider:IMetadataProvider
     {
-        Task<dynamic> GetSite(string siteName);
-        Task<dynamic> GetSite(string stampName, string siteName);
+        Task<dynamic> GetSite(string siteName, string slotName = GeoMasterConstants.ProductionSlot);
+        Task<dynamic> GetSite(string stampName, string siteName, string slotName = GeoMasterConstants.ProductionSlot);
         Task<string> GetSiteResourceGroupNameAsync(string siteName);
         Task<dynamic> GetSitesInResourceGroupAsync(string subscriptionName, string resourceGroupName);
         Task<dynamic> GetServerFarmsInResourceGroupAsync(string subscriptionName, string resourceGroupName);

--- a/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
@@ -53,12 +53,12 @@ namespace Diagnostics.DataProviders
             return Task.FromResult(mock);
         }
 
-        public override async Task<dynamic> GetSite(string siteName)
+        public override async Task<dynamic> GetSite(string siteName, string slotName = GeoMasterConstants.ProductionSlot)
         {
             throw new NotImplementedException();
         }
 
-        public override async Task<dynamic> GetSite(string stampName, string siteName)
+        public override async Task<dynamic> GetSite(string stampName, string siteName, string slotName = GeoMasterConstants.ProductionSlot)
         {
             return await GetSiteInternal();
         }

--- a/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
@@ -53,12 +53,17 @@ namespace Diagnostics.DataProviders
             return Task.FromResult(mock);
         }
 
-        public override async Task<dynamic> GetSite(string siteName, string slotName = GeoMasterConstants.ProductionSlot)
+        public override async Task<dynamic> GetSite(string siteName)
         {
             throw new NotImplementedException();
         }
 
-        public override async Task<dynamic> GetSite(string stampName, string siteName, string slotName = GeoMasterConstants.ProductionSlot)
+        public override async Task<dynamic> GetSite(string stampName, string siteName)
+        {
+            return await GetSiteInternal();
+        }
+
+        public override async Task<dynamic> GetSite(string stampName, string siteName, string slotName)
         {
             return await GetSiteInternal();
         }

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -129,7 +129,7 @@ namespace Diagnostics.DataProviders
                 path = $"stamps/{stampName}/";
             }
 
-            path = slotName == null ? path + $"sites/{siteName}" : path + $"sites/{siteName}({slotName})";
+            path = string.IsNullOrWhiteSpace(slotName) ? path + $"sites/{siteName}" : path + $"sites/{siteName}({slotName})";
 
             var response = await GetObserverResource(path);
             var siteObject = JsonConvert.DeserializeObject(response);

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -105,16 +105,33 @@ namespace Diagnostics.DataProviders
             return await Get($"subscriptionid/{subscriptionId}/webspacename/{webSpaceName}/resourcegroupname");
         }
 
-        public override async Task<dynamic> GetSite(string siteName, string slotName = GeoMasterConstants.ProductionSlot)
+        public override async Task<dynamic> GetSite(string siteName)
         {
-            var response = slotName == GeoMasterConstants.ProductionSlot ? await GetObserverResource($"sites/{siteName}") :  await GetObserverResource($"sites/{siteName}({slotName})");
-            var siteObject = JsonConvert.DeserializeObject(response);
-            return siteObject;
+            return await GetSiteInternal(null, siteName, null);
         }
 
-        public override async Task<dynamic> GetSite(string stampName, string siteName, string slotName = GeoMasterConstants.ProductionSlot)
+        public override async Task<dynamic> GetSite(string stampName, string siteName)
         {
-            var response = slotName == GeoMasterConstants.ProductionSlot ? await GetObserverResource($"stamps/{stampName}/sites/{siteName}") : await GetObserverResource($"stamps/{stampName}/sites/{siteName}({slotName})");
+            return await GetSiteInternal(stampName, siteName, null);
+        }
+
+        public override async Task<dynamic> GetSite(string stampName, string siteName, string slotName)
+        {
+            return await GetSiteInternal(stampName, siteName, slotName);
+        }
+
+        private async Task<dynamic> GetSiteInternal(string stampName, string siteName, string slotName)
+        {
+            string path = null;
+
+            if (!string.IsNullOrWhiteSpace(stampName))
+            {
+                path = "stamps/";
+            }
+
+            path = slotName == null ? path + $"sites/{siteName}" : path + $"sites/{siteName}({slotName})";
+
+            var response = await GetObserverResource(path);
             var siteObject = JsonConvert.DeserializeObject(response);
             return siteObject;
         }

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -122,11 +122,11 @@ namespace Diagnostics.DataProviders
 
         private async Task<dynamic> GetSiteInternal(string stampName, string siteName, string slotName)
         {
-            string path = null;
+            string path = "";
 
             if (!string.IsNullOrWhiteSpace(stampName))
             {
-                path = "stamps/";
+                path = $"stamps/{stampName}";
             }
 
             path = slotName == null ? path + $"sites/{siteName}" : path + $"sites/{siteName}({slotName})";

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -105,16 +105,16 @@ namespace Diagnostics.DataProviders
             return await Get($"subscriptionid/{subscriptionId}/webspacename/{webSpaceName}/resourcegroupname");
         }
 
-        public override async Task<dynamic> GetSite(string siteName)
+        public override async Task<dynamic> GetSite(string siteName, string slotName = GeoMasterConstants.ProductionSlot)
         {
-            var response = await GetObserverResource($"sites/{siteName}");
+            var response = slotName == GeoMasterConstants.ProductionSlot ? await GetObserverResource($"sites/{siteName}") :  await GetObserverResource($"sites/{siteName}({slotName})");
             var siteObject = JsonConvert.DeserializeObject(response);
             return siteObject;
         }
 
-        public override async Task<dynamic> GetSite(string stampName, string siteName)
+        public override async Task<dynamic> GetSite(string stampName, string siteName, string slotName = GeoMasterConstants.ProductionSlot)
         {
-            var response = await GetObserverResource($"stamps/{stampName}/sites/{siteName}");
+            var response = slotName == GeoMasterConstants.ProductionSlot ? await GetObserverResource($"stamps/{stampName}/sites/{siteName}") : await GetObserverResource($"stamps/{stampName}/sites/{siteName}({slotName})");
             var siteObject = JsonConvert.DeserializeObject(response);
             return siteObject;
         }

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -126,7 +126,7 @@ namespace Diagnostics.DataProviders
 
             if (!string.IsNullOrWhiteSpace(stampName))
             {
-                path = $"stamps/{stampName}";
+                path = $"stamps/{stampName}/";
             }
 
             path = slotName == null ? path + $"sites/{siteName}" : path + $"sites/{siteName}({slotName})";


### PR DESCRIPTION
**Allows detector authors to get site data from WawsObserver for a slot.**
-Add slotname to Observer GetSite call
-Since the slotname is an optional parameter it won't break existing detectors and it doesn't require recompilation of all the detectors.

*note:detector authors can technically still get slot data without this change by calling `dp.Observer.GetSite(cxt.Resource.Stamp.Name, $"{cxt.Resource.Name}({cxt.Resource.Slot})")`