### PR TITLE
Kusto and geochanges - Method to call DAAS and detectors to get Kusto Query 

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
@@ -68,6 +68,11 @@ namespace Diagnostics.DataProviders
             return ExecuteQuery(query, DataProviderConstants.FakeStampForAnalyticsCluster, requestId, operationName);
         }
 
+        public Task<KustoQuery> GetKustoQuery(string query, string stampName)
+        {
+            return MakeDependencyCall(_kustoDataProvider.GetKustoQuery(query, stampName));
+        }
+
         public Task<JObject> GetAdminSitesByHostNameAsync(string stampName, string[] hostNames)
         {
             return MakeDependencyCall(_observerDataProvider.GetAdminSitesByHostNameAsync(stampName, hostNames));
@@ -228,6 +233,11 @@ namespace Diagnostics.DataProviders
         public Task<string> GetLinuxContainerLogs(string subscriptionId, string resourceGroupName, string name, string slotName)
         {
             return MakeDependencyCall(_geomasterDataProvider.GetLinuxContainerLogs(subscriptionId, resourceGroupName, name, slotName));
+        }
+
+        public Task<T> InvokeDaasExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string daasApiPath, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return MakeDependencyCall(_geomasterDataProvider.InvokeDaasExtension<T>(subscriptionId, resourceGroupName, name, slotName, daasApiPath, apiVersion, cancellationToken));
         }
 
         public Task<VnetValidationRespone> VerifyHostingEnvironmentVnet(string subscriptionId, string vnetResourceGroup, string vnetName, string vnetSubnetName, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
@@ -72,6 +72,10 @@ namespace Diagnostics.DataProviders
         {
             return MakeDependencyCall(_kustoDataProvider.GetKustoQuery(query, stampName));
         }
+        public Task<KustoQuery> GetKustoClusterQuery(string query)
+        {
+            return MakeDependencyCall(_kustoDataProvider.GetKustoClusterQuery(query));
+        }
 
         public Task<JObject> GetAdminSitesByHostNameAsync(string stampName, string[] hostNames)
         {
@@ -294,5 +298,7 @@ namespace Diagnostics.DataProviders
                 }
             }
         }
+
+       
     }
 }

--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -77,7 +77,7 @@ namespace Diagnostics.DataProviders
             Dictionary<string, string> appSettings = new Dictionary<string, string>();
             foreach (var item in properties)
             {
-                if (item.Key.StartsWith("WEBSITE_"))
+                if (item.Key.StartsWith("WEBSITE_") || item.Key.StartsWith("WEBSITES_"))
                 {
                     if (!SensitiveAppSettingsEndingWith.Any(x => item.Key.EndsWith(x)))
                     {

--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -380,7 +380,7 @@ namespace Diagnostics.DataProviders
         {
             if (string.IsNullOrWhiteSpace(fullPath))
             {
-                throw new ArgumentNullException(fullPath);
+                throw new ArgumentNullException("fullPath");
             }
 
             var geoMasterResponse = await HttpGet<T>(fullPath, queryString, apiVersion);
@@ -451,7 +451,7 @@ namespace Diagnostics.DataProviders
         {
             if (string.IsNullOrWhiteSpace(extension))
             {
-                throw new ArgumentNullException(extension);
+                throw new ArgumentNullException("extension");
             }
 
             string path = SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name, slotName) + SiteExtensionResource.Replace("{*extensionApiMethod}", extension);
@@ -492,7 +492,7 @@ namespace Diagnostics.DataProviders
         {
             if (string.IsNullOrWhiteSpace(daasApiPath))
             {
-                throw new ArgumentNullException(daasApiPath);
+                throw new ArgumentNullException("daasApiPath");
             }
 
             if (daasApiPath.StartsWith("api/databasetest", StringComparison.OrdinalIgnoreCase))

--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -459,6 +459,54 @@ namespace Diagnostics.DataProviders
             return result;
         }
 
+        /// <summary>
+        /// Using this method you can invoke an API on the DaaS SiteExtension that is installed on the Web App
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="subscriptionId">Subscription Id for the resource</param>
+        /// <param name="resourceGroupName">The resource group that the resource is part of </param>
+        /// <param name="name">The resource name</param>
+        /// <param name="slotName">slot name (if querying for a slot, defaults to production slot)</param>
+        /// <param name="daasApiPath">Full path to the DAAS API </param>
+        /// <param name="apiVersion">(Optional Parameter) Pass an API version if required, 2016-08-01 is the default value</param>
+        /// <param name="cancellationToken">(Optional Parameter) Cancellation token </param>
+        /// <example>
+        /// This sample shows how to call the <see cref="InvokeDaasExtension"/> method in a detector
+        /// <code>
+        /// public async static Task<![CDATA[<Response>]]> Run(DataProviders dp, OperationContext<![CDATA[<App>]]> cxt, Response res)
+        /// {
+        ///     var resp = await dp.GeoMaster.InvokeDaasExtension<![CDATA[<dynamic>]]>(cxt.Resource.SubscriptionId, 
+        ///                     cxt.Resource.ResourceGroup, 
+        ///                     cxt.Resource.Name,
+        ///                     cxt.Resource.Slot,
+        ///                     "api/diagnosers");
+        /// 
+        ///     // do something with the response object
+        ///     var responseFromDaaS = resp.ToString();
+        ///     return res;
+        /// }
+        /// </code>
+        /// </example>
+        /// <returns></returns>
+        public async Task<T> InvokeDaasExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string daasApiPath, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (string.IsNullOrWhiteSpace(daasApiPath))
+            {
+                throw new ArgumentNullException(daasApiPath);
+            }
+
+            if (daasApiPath.StartsWith("api/databasetest", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Accessing DatabaseTestController under DAAS is not allowed as it contains PII");
+            }
+
+            string extensionPath = $"daas/{daasApiPath}";
+
+            string path = SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name, slotName) + SiteExtensionResource.Replace("{*extensionApiMethod}", extensionPath);
+            var result = await HttpGet<T>(path, string.Empty, apiVersion, cancellationToken);
+            return result;
+        }
+
         #region HttpMethods
 
         private async Task<R> HttpGet<R>(string path, string queryString = "", string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -41,9 +41,14 @@ namespace Diagnostics.DataProviders
             return await _kustoClient.ExecuteQueryAsync(query, stampName, requestId, operationName);
         }
 
+        public Task<KustoQuery> GetKustoClusterQuery(string query)
+        {
+            return GetKustoQuery(query, DataProviderConstants.FakeStampForAnalyticsCluster);
+        }
+
         public async Task<KustoQuery> GetKustoQuery(string query, string stampName)
         {
-            var kustoQuery = await _kustoClient.GetKustoQueryAsync(stampName, query);
+            var kustoQuery = await _kustoClient.GetKustoQueryAsync(query, stampName);
             return kustoQuery;
         }
 
@@ -54,7 +59,7 @@ namespace Diagnostics.DataProviders
 
         private async Task AddQueryInformationToMetadata(string query, string stampName)
         {
-            var kustoQuery = await _kustoClient.GetKustoQueryAsync(stampName, query);
+            var kustoQuery = await _kustoClient.GetKustoQueryAsync(query, stampName);
             bool queryExists = false;
             
             queryExists = Metadata.PropertyBag.Any(x => x.Key == "Query" &&

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -13,6 +13,7 @@ namespace Diagnostics.DataProviders
     {
         public string Text;
         public string Url;
+        public string KustoDesktopUrl;
     }
     public class KustoDataProvider: DiagnosticDataProvider, IDiagnosticDataProvider, IKustoDataProvider
     {
@@ -35,11 +36,15 @@ namespace Diagnostics.DataProviders
         }
 
         public async Task<DataTable> ExecuteQuery(string query, string stampName, string requestId = null, string operationName = null)
-        {
-
-            var queryUrl = await _kustoClient.GetKustoQueryUriAsync(stampName, query);
-            AddQueryInformationToMetadata(query, queryUrl, stampName);
+        {           
+            await AddQueryInformationToMetadata(query, stampName);
             return await _kustoClient.ExecuteQueryAsync(query, stampName, requestId, operationName);
+        }
+
+        public async Task<KustoQuery> GetKustoQuery(string query, string stampName)
+        {
+            var kustoQuery = await _kustoClient.GetKustoQueryAsync(stampName, query);
+            return kustoQuery;
         }
 
         public DataProviderMetadata GetMetadata()
@@ -47,21 +52,17 @@ namespace Diagnostics.DataProviders
             return Metadata;
         }
 
-        private void AddQueryInformationToMetadata(string query, string queryUrl, string stampName)
+        private async Task AddQueryInformationToMetadata(string query, string stampName)
         {
+            var kustoQuery = await _kustoClient.GetKustoQueryAsync(stampName, query);
             bool queryExists = false;
-            KustoQuery q = new KustoQuery
-            {
-                Text = query,
-                Url = queryUrl
-            };
-
+            
             queryExists = Metadata.PropertyBag.Any(x => x.Key == "Query" &&
                                                         x.Value.GetType() == typeof(KustoQuery) &&
-                                                        x.Value.CastTo<KustoQuery>().Url.Equals(q.Url, StringComparison.OrdinalIgnoreCase));
+                                                        x.Value.CastTo<KustoQuery>().Url.Equals(kustoQuery.Url, StringComparison.OrdinalIgnoreCase));
             if (!queryExists)
             {
-                Metadata.PropertyBag.Add(new KeyValuePair<string, object>("Query", q));
+                Metadata.PropertyBag.Add(new KeyValuePair<string, object>("Query", kustoQuery));
             }
         }
     }

--- a/src/Diagnostics.DataProviders/Interfaces/IGeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IGeoMasterDataProvider.cs
@@ -27,5 +27,7 @@ namespace Diagnostics.DataProviders
         Task<T> MakeHttpGetRequestWithFullPath<T>(string fullPath, string queryString = "", string apiVersion = GeoMasterConstants.August2016Version);
 
         Task<string> GetLinuxContainerLogs(string subscriptionId, string resourceGroupName, string name, string slotName);
+
+        Task<T> InvokeDaasExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string daasApiPath, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoClient.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoClient.cs
@@ -12,6 +12,6 @@ namespace Diagnostics.DataProviders
     {
         Task<DataTable> ExecuteQueryAsync(string query, string stampName, string requestId = null, string operationName = null);
 
-        Task<string> GetKustoQueryUriAsync(string stampName, string query);
+        Task<KustoQuery> GetKustoQueryAsync(string stampName, string query);
     }
 }

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoClient.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoClient.cs
@@ -12,6 +12,6 @@ namespace Diagnostics.DataProviders
     {
         Task<DataTable> ExecuteQueryAsync(string query, string stampName, string requestId = null, string operationName = null);
 
-        Task<KustoQuery> GetKustoQueryAsync(string stampName, string query);
+        Task<KustoQuery> GetKustoQueryAsync(string query, string stampName);
     }
 }

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -8,5 +8,7 @@ namespace Diagnostics.DataProviders
         Task<DataTable> ExecuteClusterQuery(string query, string requestId = null, string operationName = null);
 
         Task<DataTable> ExecuteQuery(string query, string stampName, string requestId = null, string operationName = null);
+
+        Task<KustoQuery> GetKustoQuery(string query, string stampName);
     }
 }

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -10,5 +10,7 @@ namespace Diagnostics.DataProviders
         Task<DataTable> ExecuteQuery(string query, string stampName, string requestId = null, string operationName = null);
 
         Task<KustoQuery> GetKustoQuery(string query, string stampName);
+
+        Task<KustoQuery> GetKustoClusterQuery(string query);
     }
 }

--- a/src/Diagnostics.DataProviders/KustoClient.cs
+++ b/src/Diagnostics.DataProviders/KustoClient.cs
@@ -87,7 +87,7 @@ namespace Diagnostics.DataProviders
             }
         }
 
-        public async Task<KustoQuery> GetKustoQueryAsync(string stampName, string query)
+        public async Task<KustoQuery> GetKustoQueryAsync(string query, string stampName)
         {
             string kustoClusterName = null;
             try

--- a/src/Diagnostics.DataProviders/KustoClient.cs
+++ b/src/Diagnostics.DataProviders/KustoClient.cs
@@ -87,15 +87,21 @@ namespace Diagnostics.DataProviders
             }
         }
 
-        public async Task<string> GetKustoQueryUriAsync(string stampName, string query)
+        public async Task<KustoQuery> GetKustoQueryAsync(string stampName, string query)
         {
             string kustoClusterName = null;
             try
             {
                 kustoClusterName = GetClusterNameFromStamp(stampName);
                 string encodedQuery = await EncodeQueryAsBase64UrlAsync(query);
-                var url = string.Format("https://web.kusto.windows.net/clusters/{0}.kusto.windows.net/databases/{1}?q={2}", kustoClusterName, _configuration.DBName, encodedQuery);
-                return url;
+                
+                KustoQuery kustoQuery = new KustoQuery
+                {
+                    Text = query,
+                    Url = string.Format("https://web.kusto.windows.net/clusters/{0}.kusto.windows.net/databases/{1}?q={2}", kustoClusterName, _configuration.DBName, encodedQuery),
+                    KustoDesktopUrl = $"https://{kustoClusterName}.kusto.windows.net:443/{_configuration.DBName}?query={encodedQuery}&web=0"
+                };
+                return kustoQuery;
             }
             catch (Exception ex)
             {

--- a/src/Diagnostics.DataProviders/MockKustoClient.cs
+++ b/src/Diagnostics.DataProviders/MockKustoClient.cs
@@ -81,7 +81,7 @@ namespace Diagnostics.DataProviders
             return Task.FromResult(table);
         }
 
-        public Task<string> GetKustoQueryUriAsync(string stampName, string query)
+        public Task<KustoQuery> GetKustoQueryAsync(string stampName, string query)
         {
             if (string.IsNullOrWhiteSpace(stampName))
             {
@@ -91,7 +91,13 @@ namespace Diagnostics.DataProviders
             {
                 throw new ArgumentNullException("query");
             }
-            return Task.FromResult("https://fakekusto.windows.net/q=somequery");
+            KustoQuery k = new KustoQuery
+            {
+                Url = "https://fakekusto.windows.net/q=somequery",
+                KustoDesktopUrl = "https://fakekusto.windows.net/q=somequery",
+                Text = query
+            };
+            return Task.FromResult(k);
         }
     }
 }

--- a/src/Diagnostics.DataProviders/MockKustoClient.cs
+++ b/src/Diagnostics.DataProviders/MockKustoClient.cs
@@ -81,7 +81,7 @@ namespace Diagnostics.DataProviders
             return Task.FromResult(table);
         }
 
-        public Task<KustoQuery> GetKustoQueryAsync(string stampName, string query)
+        public Task<KustoQuery> GetKustoQueryAsync(string query, string stampName)
         {
             if (string.IsNullOrWhiteSpace(stampName))
             {


### PR DESCRIPTION
With this PR, there are two methods that I am adding

1.  **dp.Kusto.GetKustoQuery** - This is for internal detectors that just need KUSTO query information and don't want to execute the query (Basically just give a link for further diagnostics)

   ```
   var k = await dp.Kusto.GetKustoQuery(GetQuery(cxt), cxt.Resource.Stamp.Name);
   var kustoDesktop = k.KustoDesktopUrl;
```

2. **Ability to call DAAS API's (GET only)**. This will allow us to get information about site properties in future (like ASP.NET Core versions , Diagnosers supported etc.)

   ```
   var resp = await dp.GeoMaster.InvokeDaasExtension<object>(cxt.Resource.SubscriptionId, cxt.Resource.ResourceGroup, cxt.Resource.Name, cxt.Resource.Slot, "api/diagnosers");
   ```