### PR TITLE
Only Cache TenantIds for Public Stamps

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -344,7 +344,7 @@ namespace Diagnostics.RuntimeHost.Controllers
 
             string stampName = !string.IsNullOrWhiteSpace(hostingEnv.InternalName) ? hostingEnv.InternalName : hostingEnv.Name;
 
-            var result = await this._stampService.GetTenantIdForStamp(stampName, startTime, endTime, (DataProviderContext)HttpContext.Items[HostConstants.DataProviderContextKey]);
+            var result = await this._stampService.GetTenantIdForStamp(stampName, hostingEnv.HostingEnvironmentType == HostingEnvironmentType.None,  startTime, endTime, (DataProviderContext)HttpContext.Items[HostConstants.DataProviderContextKey]);
             hostingEnv.TenantIdList = result.Item1;
             hostingEnv.PlatformType = result.Item2;
 

--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
@@ -59,8 +59,8 @@ namespace Diagnostics.RuntimeHost.Services
             
             result = new Tuple<List<string>, PlatformType>(tenantIds, type);
 
-            // Only cache TenantIds for Public stamps
-            if (isPublicStamp)
+            // Only cache TenantIds if not empty
+            if (tenantIds != null && tenantIds.Any())
             {
                 _tenantCache.TryAdd(stamp.ToLower(), result);
             }           

--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
@@ -14,7 +14,7 @@ namespace Diagnostics.RuntimeHost.Services
 {
     public interface IStampService
     {
-        Task<Tuple<List<string>, PlatformType>> GetTenantIdForStamp(string stamp, DateTime startTime, DateTime endTime, DataProviderContext dataProviderContext);
+        Task<Tuple<List<string>, PlatformType>> GetTenantIdForStamp(string stamp, bool isPublicStamp, DateTime startTime, DateTime endTime, DataProviderContext dataProviderContext);
     }
 
     public class StampService : IStampService
@@ -26,7 +26,7 @@ namespace Diagnostics.RuntimeHost.Services
             _tenantCache = new ConcurrentDictionary<string, Tuple<List<string>, PlatformType>>();
         }
 
-        public async Task<Tuple<List<string>, PlatformType>> GetTenantIdForStamp(string stamp, DateTime startTime, DateTime endTime, DataProviderContext dataProviderContext)
+        public async Task<Tuple<List<string>, PlatformType>> GetTenantIdForStamp(string stamp, bool isPublicStamp, DateTime startTime, DateTime endTime, DataProviderContext dataProviderContext)
         {
             var dp = new DataProviders.DataProviders(dataProviderContext);
             if (string.IsNullOrWhiteSpace(stamp))
@@ -59,7 +59,12 @@ namespace Diagnostics.RuntimeHost.Services
             
             result = new Tuple<List<string>, PlatformType>(tenantIds, type);
 
-            _tenantCache.TryAdd(stamp.ToLower(), result);
+            // Only cache TenantIds for Public stamps
+            if (isPublicStamp)
+            {
+                _tenantCache.TryAdd(stamp.ToLower(), result);
+            }           
+
             return result;
         }
 


### PR DESCRIPTION
In V2, I was not caching TenantIds for ASE because they can change if ASE gets recreated.
However, somehow missed that fact while coding up for V3. Hence Updating the TenantId code to only cache the value for Public Stamps (as they will not change)