### PR TITLE
Fixing bug in HostNamesFilterQuery function for multiple wildcards

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/ScriptUtilities/Utilities.cs
+++ b/src/Diagnostics.ModelsAndUtils/ScriptUtilities/Utilities.cs
@@ -116,7 +116,7 @@ namespace Diagnostics.ModelsAndUtils.ScriptUtilities
 
             if (wildCardHostNames.Any())
             {
-                string wildCardQuery = string.Join("or", wildCardHostNames.Select(w => $@"{hostNameColumn} endswith ""{w}"""));
+                string wildCardQuery = string.Join("or", wildCardHostNames.Select(w => $@" {hostNameColumn} endswith ""{w}"""));
                 hostNameQuery = $"{hostNameQuery} or {wildCardQuery}";
             }
 


### PR DESCRIPTION
If a site has multiple wildcards, then this function is breaking because the string constructed is like this

`or Cs_host endswith "*.firsthost.com"orCs_host endswith "*.secondhost.com"orCs_host endswith "*.thirdhost.com"`

Only an additional space is needed...

FYI - @ShekharGupta1988 , @hforeste , @stevenernst131 , @cindylovescoding if you see some detectors failing if a site has multiple wildcard domains