### PR TITLE
Remove the wawsobserver path validation

### DIFF
--- a/tests/DataProviderTests/SupportObserverTests.cs
+++ b/tests/DataProviderTests/SupportObserverTests.cs
@@ -96,8 +96,6 @@ namespace Diagnostics.Tests.DataProviderTests
                         Trace.WriteLine(output);
                     }
                 }
-
-                
             }
         }
 
@@ -129,29 +127,23 @@ namespace Diagnostics.Tests.DataProviderTests
             await Assert.ThrowsAsync<ArgumentNullException>(async() => await dataProviders.Observer.GetResource(null));
         }
 
-        [Fact]
-        public async void TestRouteMatchLogic()
+        internal async void TestObserver()
         {
-            var configFactory = new MockDataProviderConfigurationFactory();
-            var config = configFactory.LoadConfigurations();
+            var dataSourceConfiguration = new MockDataProviderConfigurationFactory();
+            var config = dataSourceConfiguration.LoadConfigurations();
+            config.SupportObserverConfiguration = new SupportObserverDataProviderConfiguration()
+            {
+                AppKey = "",
+                ClientId = "",
+                IsMockConfigured = false
+            };
+
             var dataProviders = new DataProviders.DataProviders(new DataProviderContext(config));
+            var wawsObserverData = await dataProviders.Observer.GetResource("https://wawsobserver.azurewebsites.windows.net/sites/highcpuscenario");
+            var supportBayData = await dataProviders.Observer.GetResource("https://support-bay-api.azurewebsites.net/observer/stamps/waws-prod-bay-073/sites/highcpuscenario/postbody");
 
-            //basic test
-            var site123Data = await dataProviders.Observer.GetResource("https://wawsobserver.azurewebsites.windows.net/stamps/stamp123/sites/site123");
-
-            //basic test with different resource
-            var certData = await dataProviders.Observer.GetResource("https://wawsobserver.azurewebsites.windows.net/certificates/123456789");
-
-            //test where parameter value is middle of url and not end of url
-            var domainData = await dataProviders.Observer.GetResource("https://wawsobserver.azurewebsites.windows.net/subscriptions/1111-2222-3333-4444-5555/domains");
-
-            //test with multiple parameter values
-            var storageVolumeData = await dataProviders.Observer.GetResource("https://wawsobserver.azurewebsites.windows.net/stamps/waws-prod-mock1-001/storagevolumes/volume-19");
-
-            Assert.Equal("site123", (string)site123Data.siteName);
-            Assert.Equal("IPSSL", (string)certData.type);
-            Assert.Equal("foo_bar.com", (string)domainData[0].name);
-            Assert.Equal("volume-19", (string)storageVolumeData.name);
+            Assert.True(wawsObserverData != null);
+            Assert.True(supportBayData != null);
         }
     }
 }


### PR DESCRIPTION
I removed logic that checked that a path in observer exist. Recently I added new APIs for Mahatab and he couldn't access them through the observer data provider because the path did not exist in the static list of paths written in the SupportObserverDataProviderBase class. Unfortunately I did some over engineering there.

In this pull request, anytime someone sends a request to observer with dp.Observer.GetResource, all this class will do is validate the host is in fact WawsObsever and then it will just send the request via HttpClient. If it doesn't exist, then the detector will get a 404 as expected.