### PR TITLE
Account for null row values and throw exception in kusto client

### DIFF
--- a/src/Diagnostics.DataProviders/KustoClient.cs
+++ b/src/Diagnostics.DataProviders/KustoClient.cs
@@ -61,6 +61,7 @@ namespace Diagnostics.DataProviders
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, string.Format(KustoApiEndpoint, cluster));
             request.Headers.Add("Authorization", authorizationToken);
             request.Headers.Add("x-ms-client-request-id", requestId ?? Guid.NewGuid().ToString());
+            request.Headers.UserAgent.ParseAdd("appservice-diagnostics"); 
 
             object requestPayload = new
             {
@@ -94,6 +95,7 @@ namespace Diagnostics.DataProviders
             catch(Exception ex)
             {
                 kustoApiException = ex;
+                throw;
             }
             finally
             {

--- a/src/Diagnostics.ModelsAndUtils/Models/DataTableResponseObject.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/DataTableResponseObject.cs
@@ -63,7 +63,7 @@ namespace Diagnostics.ModelsAndUtils.Models
                 var row = dataTable.NewRow();
                 for (int j = 0; j < dataTable.Columns.Count; j++)
                 {
-                    row[j] = dataTableResponse.Rows[i, j];
+                    row[j] = dataTableResponse.Rows[i, j] ?? DBNull.Value;
                 }
 
                 dataTable.Rows.Add(row);
@@ -87,7 +87,7 @@ namespace Diagnostics.ModelsAndUtils.Models
                 var row = dataTable.NewRow();
                 for (int j = 0; j < dataTable.Columns.Count; j++)
                 {
-                    row[j] = appInsightsDataTableResponse.Rows[i,j];
+                    row[j] = appInsightsDataTableResponse.Rows[i,j] ?? DBNull.Value;
                 }
 
                 dataTable.Rows.Add(row);
@@ -114,7 +114,7 @@ namespace Diagnostics.ModelsAndUtils.Models
             {
                 for(int j = 0; j < table.Columns.Count; j++)
                 {
-                    rows[i, j] = table.Rows[i][j];
+                    rows[i, j] = table.Rows[i][j] == DBNull.Value ? null : table.Rows[i][j];
                 }
             }
 


### PR DESCRIPTION
Fixing exceptions that looked like this:

```
System.AggregateException: One or more errors occurred. (Cannot set Column 'S_siteid' to be null. Please use DBNull instead.) ---> System.ArgumentException: Cannot set Column 'S_siteid' to be null. Please use DBNull instead.
```

Adding user agent to kusto client in kestrel process. 

Throwing exception on failed kusto query. 
