### PR TITLE
Fix mdm

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders.cs
+++ b/src/Diagnostics.DataProviders/DataProviders.cs
@@ -10,7 +10,6 @@ namespace Diagnostics.DataProviders
         public ISupportObserverDataProvider Observer;
         public IGeoMasterDataProvider GeoMaster;
         public IAppInsightsDataProvider AppInsights;
-        public IMdmDataProvider Mdm;
 
         public DataProviders(DataProviderContext context)
         {

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -568,10 +568,13 @@ namespace Diagnostics.RuntimeHost.Controllers
                 if (dataProvider.FieldType.IsInterface)
                 {
                     var metadataProvider = dataProvider.GetValue(dataProviders) as IMetadataProvider;
-                    var metadata = metadataProvider.GetMetadata();
-                    if (metadata != null)
+                    if (metadataProvider != null)
                     {
-                        dataprovidersMetadata.Add(metadata);
+                        var metadata = metadataProvider.GetMetadata();
+                        if (metadata != null)
+                        {
+                            dataprovidersMetadata.Add(metadata);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Unfortunately, not initializing the Mdm field is not enough to disable it. So need to remove the field entirely as there is a piece of code that enumerates on all of the fields of DataProviders class regardless if its initialized or not.