### PR TITLE
Removing * from hostname in case of wildcard

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/ScriptUtilities/Utilities.cs
+++ b/src/Diagnostics.ModelsAndUtils/ScriptUtilities/Utilities.cs
@@ -117,7 +117,7 @@ namespace Diagnostics.ModelsAndUtils.ScriptUtilities
 
             if (wildCardHostNames.Any())
             {
-                string wildCardQuery = string.Join("or", wildCardHostNames.Select(w => $@" {hostNameColumn} endswith ""{w}"""));
+                string wildCardQuery = string.Join("or", wildCardHostNames.Select(w => $@" {hostNameColumn} endswith ""{w.Replace("*.",".")}"""));
                 hostNameQuery = $"{hostNameQuery} or {wildCardQuery}";
             }
 


### PR DESCRIPTION
Fixing a bug in HostNamesFilterQuery function. our queries for wildcard hostnames are incorrect currently...