### PR TITLE
 Log x-ms headers received to Kusto

### DIFF
--- a/src/Diagnostics.Logger/ApiMetricsLogger.cs
+++ b/src/Diagnostics.Logger/ApiMetricsLogger.cs
@@ -49,6 +49,16 @@ namespace Diagnostics.Logger
 
             endTime = DateTime.UtcNow;
             latencyInMs = Convert.ToInt64((endTime - startTime).TotalMilliseconds);
+            var headers = context.Request.Headers;
+            var headersContent = "Headers received: ";
+            foreach (var header in headers)
+            {
+                if (header.Key.StartsWith("x-ms", StringComparison.OrdinalIgnoreCase))
+                {
+                    headersContent += $"{header.Key} - ";
+                    headersContent += string.IsNullOrWhiteSpace(header.Value.FirstOrDefault()) ? string.Empty : "****";
+                }
+            }
 
             DiagnosticsETWProvider.Instance.LogRuntimeHostAPISummary(
                 requestId ?? string.Empty,
@@ -61,7 +71,8 @@ namespace Diagnostics.Logger
                 context.Response.StatusCode,
                 latencyInMs,
                 startTime.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture),
-                endTime.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
+                endTime.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture),
+                headersContent);
         }
 
         /// <summary>

--- a/src/Diagnostics.Logger/ApiMetricsLogger.cs
+++ b/src/Diagnostics.Logger/ApiMetricsLogger.cs
@@ -4,12 +4,13 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
-
+using Newtonsoft.Json;
 namespace Diagnostics.Logger
 {
     /// <summary>
@@ -50,16 +51,23 @@ namespace Diagnostics.Logger
             endTime = DateTime.UtcNow;
             latencyInMs = Convert.ToInt64((endTime - startTime).TotalMilliseconds);
             var headers = context.Request.Headers;
-            var headersContent = "Headers received: ";
+            List<object> headersContent = new List<object>();
             foreach (var header in headers)
             {
                 if (header.Key.StartsWith("x-ms", StringComparison.OrdinalIgnoreCase))
                 {
-                    headersContent += $"{header.Key} - ";
-                    headersContent += string.IsNullOrWhiteSpace(header.Value.FirstOrDefault()) ? string.Empty : "****";
+                    headersContent.Add(new
+                    {
+                        name = $"{header.Key}",
+                        value = string.IsNullOrWhiteSpace(header.Value.FirstOrDefault()) ? string.Empty : "****"
+                    });
                 }
             }
 
+            string contentString = JsonConvert.SerializeObject(new
+            {
+                requestHeaders = headersContent
+            });
             DiagnosticsETWProvider.Instance.LogRuntimeHostAPISummary(
                 requestId ?? string.Empty,
                 subscriptionId ?? string.Empty,
@@ -72,7 +80,7 @@ namespace Diagnostics.Logger
                 latencyInMs,
                 startTime.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture),
                 endTime.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture),
-                headersContent);
+                contentString);
         }
 
         /// <summary>

--- a/src/Diagnostics.Logger/Diagnostics.Logger.csproj
+++ b/src/Diagnostics.Logger/Diagnostics.Logger.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="2.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.108" />
   </ItemGroup>
 

--- a/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
+++ b/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
@@ -126,6 +126,7 @@ namespace Diagnostics.Logger
         /// <param name="LatencyInMilliseconds">The latency.</param>
         /// <param name="StartTime">The start time.</param>
         /// <param name="EndTime">The end time.</param>
+        /// <param name="Content">The headers content received.</param>
         [Event(2002, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeHostAPISummary)]
         public void LogRuntimeHostAPISummary(string RequestId, string SubscriptionId, string ResourceGroup, string Resource, string Address, string Verb, string OperationName, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime, string Content)
         {

--- a/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
+++ b/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
@@ -127,7 +127,7 @@ namespace Diagnostics.Logger
         /// <param name="StartTime">The start time.</param>
         /// <param name="EndTime">The end time.</param>
         [Event(2002, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeHostAPISummary)]
-        public void LogRuntimeHostAPISummary(string RequestId, string SubscriptionId, string ResourceGroup, string Resource, string Address, string Verb, string OperationName, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime)
+        public void LogRuntimeHostAPISummary(string RequestId, string SubscriptionId, string ResourceGroup, string Resource, string Address, string Verb, string OperationName, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime, string Content)
         {
             WriteDiagnosticsEvent(
                 2002,
@@ -141,7 +141,8 @@ namespace Diagnostics.Logger
                 StatusCode,
                 LatencyInMilliseconds,
                 StartTime,
-                EndTime);
+                EndTime,
+                Content);
         }
 
         /// <summary>


### PR DESCRIPTION
Screenshot of headers content logged:

![image](https://user-images.githubusercontent.com/46545195/54968005-525a7900-4f36-11e9-9272-17aad8508567.png)
