### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: csharp
 mono: none
+dist: xenial
 dotnet: 2.1.3
 script:
  - dotnet build Diagnostics.sln


### PR DESCRIPTION
Builds are failing to download the .NET core packages in Travis CI. Switching machines from Ubuntu 14.04 LTS to Ubuntu 16.04 as a workaround successfully fixes the issue. Also seems to be an ongoing and longstanding problem in Travis CI. See https://travis-ci.community/t/dotnet-core-2-2/1216/12