### PR TITLE
Local host observer

### DIFF
--- a/data/templates/Detector_OpenShiftManagedClusters.csx
+++ b/data/templates/Detector_OpenShiftManagedClusters.csx
@@ -22,8 +22,8 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
     {
         Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt)),
         RenderingProperties = new Rendering(RenderingType.Table){
-            Title = Sample Table, 
-            Description = Some description here
+            Title = "Sample Table", 
+            Description = "Some description here"
         }
     });
 

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
@@ -6,10 +6,6 @@ namespace Diagnostics.DataProviders
     [DataSourceConfiguration("Kusto")]
     public class KustoDataProviderConfiguration : IDataProviderConfiguration
     {
-        public const string AzureCloud = "Public Azure";
-        public const string AzureChinaCloud = "China";
-        public const string AzureUSGovernment = "Government";
-
         /// <summary>
         /// Client Id
         /// </summary>
@@ -63,15 +59,15 @@ namespace Diagnostics.DataProviders
             {
                 if (AADKustoResource.Contains("windows.net"))
                 {
-                    return AzureCloud;
+                    return DataProviderConstants.AzureCloud;
                 }
                 else if (AADKustoResource.Contains("chinacloudapi.cn"))
                 {
-                    return AzureChinaCloud;
+                    return DataProviderConstants.AzureChinaCloud;
                 }
                 else
                 {
-                    return AzureUSGovernment;
+                    return DataProviderConstants.AzureUSGovernment;
                 }
             }
         }

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
@@ -57,6 +57,9 @@ namespace Diagnostics.DataProviders
             }
         }
 
+        [ConfigurationName("ObserverLocalHostEnabled", DefaultValue = false)]
+        public bool ObserverLocalHostEnabled { get; set; }
+
         /// <summary>
         /// Gets or sets tenant to authenticate with.
         /// </summary>

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
@@ -10,8 +10,6 @@ namespace Diagnostics.DataProviders
     [DataSourceConfiguration("SupportObserver")]
     public class SupportObserverDataProviderConfiguration : IDataProviderConfiguration
     {
-        private string cloudDomain;
-
         public SupportObserverDataProviderConfiguration()
         {
         }
@@ -38,25 +36,8 @@ namespace Diagnostics.DataProviders
         public bool IsMockConfigured { get; set; }
 
         /// <summary>
-        /// Gets or sets the cloud environment.
+        /// Is the local host version of observer enabled.
         /// </summary>
-        [ConfigurationName("CloudDomain", DefaultValue = false)]
-        public string CloudDomain
-        {
-            get
-            {
-                return cloudDomain;
-            }
-
-            set
-            {
-                if (string.IsNullOrWhiteSpace(value))
-                {
-                    cloudDomain = DataProviderConstants.AzureCloud;
-                }
-            }
-        }
-
         [ConfigurationName("ObserverLocalHostEnabled", DefaultValue = false)]
         public bool ObserverLocalHostEnabled { get; set; }
 

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
@@ -10,6 +10,8 @@ namespace Diagnostics.DataProviders
     [DataSourceConfiguration("SupportObserver")]
     public class SupportObserverDataProviderConfiguration : IDataProviderConfiguration
     {
+        private string cloudDomain;
+
         public SupportObserverDataProviderConfiguration()
         {
         }
@@ -34,6 +36,26 @@ namespace Diagnostics.DataProviders
 
         [ConfigurationName("IsMockConfigured", DefaultValue = false)]
         public bool IsMockConfigured { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cloud environment.
+        /// </summary>
+        [ConfigurationName("CloudDomain", DefaultValue = false)]
+        public string CloudDomain
+        {
+            get
+            {
+                return cloudDomain;
+            }
+
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    cloudDomain = DataProviderConstants.AzureCloud;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets tenant to authenticate with.

--- a/src/Diagnostics.DataProviders/DataProviderConstants.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConstants.cs
@@ -7,8 +7,14 @@ namespace Diagnostics.DataProviders
     public class DataProviderConstants
     {
         public const int TokenRefreshIntervalInMs = 15 * 60 * 1000;
-        
+
         public const int DefaultTimeoutInSeconds = 60;
+
+        public const string AzureCloud = "PublicAzure";
+
+        public const string AzureChinaCloud = "China";
+
+        public const string AzureUSGovernment = "Government";
 
         #region Kusto Constants
 

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -95,7 +95,11 @@ namespace Diagnostics.DataProviders
         protected async Task<string> GetObserverResource(string url, string resourceId = null)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            request.Headers.TryAddWithoutValidation("Authorization", await GetToken(resourceId));
+            if (!Configuration.ObserverLocalHostEnabled)
+            {
+                request.Headers.TryAddWithoutValidation("Authorization", await GetToken(resourceId));
+            }
+
             var cancelToken = new CancellationToken();
             var response = await _httpClient.SendAsync(request, cancelToken);
             response.EnsureSuccessStatusCode();

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -95,6 +95,7 @@ namespace Diagnostics.DataProviders
         protected async Task<string> GetObserverResource(string url, string resourceId = null)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.TryAddWithoutValidation("x-ms-requestid", RequestId);
             if (!Configuration.ObserverLocalHostEnabled)
             {
                 request.Headers.TryAddWithoutValidation("Authorization", await GetToken(resourceId));

--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/SiteService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/SiteService.cs
@@ -36,7 +36,7 @@ namespace Diagnostics.RuntimeHost.Services
             DataTable stackTable = null;
             
             try{
-                if (dataProviderContext.Configuration.KustoConfiguration.CloudDomain == KustoDataProviderConfiguration.AzureCloud)
+                if (dataProviderContext.Configuration.KustoConfiguration.CloudDomain == DataProviderConstants.AzureCloud)
                 {
                     stackTable = await dp.Kusto.ExecuteQuery(queryTemplate, DataProviderConstants.FakeStampForAnalyticsCluster, operationName: "GetApplicationStack");
                 }

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -38,12 +38,15 @@ namespace Diagnostics.RuntimeHost
             var servicesProvider = services.BuildServiceProvider();
             var dataSourcesConfigService = servicesProvider.GetService<IDataSourcesConfigurationService>();
             var observerConfiguration = dataSourcesConfigService.Config.SupportObserverConfiguration;
-            observerConfiguration.AADAuthority = dataSourcesConfigService.Config.KustoConfiguration.AADAuthority;
-            var wawsObserverTokenService = new ObserverTokenService(observerConfiguration.WawsObserverResourceId, observerConfiguration);
-            var supportBayApiObserverTokenService = new ObserverTokenService(observerConfiguration.SupportBayApiObserverResourceId, observerConfiguration);
 
-            services.AddSingleton<IWawsObserverTokenService>(wawsObserverTokenService);
-            services.AddSingleton<ISupportBayApiObserverTokenService>(supportBayApiObserverTokenService);
+            if (!observerConfiguration.ObserverLocalHostEnabled)
+            {
+                observerConfiguration.AADAuthority = dataSourcesConfigService.Config.KustoConfiguration.AADAuthority;
+                var wawsObserverTokenService = new ObserverTokenService(observerConfiguration.WawsObserverResourceId, observerConfiguration);
+                var supportBayApiObserverTokenService = new ObserverTokenService(observerConfiguration.SupportBayApiObserverResourceId, observerConfiguration);
+                services.AddSingleton<IWawsObserverTokenService>(wawsObserverTokenService);
+                services.AddSingleton<ISupportBayApiObserverTokenService>(supportBayApiObserverTokenService);
+            }
 
             // TODO : Not sure what's the right place for the following code piece.
             #region Custom Start up Code

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -44,7 +44,8 @@
   "SupportObserver": {
     "ClientId": "",
     "AppKey": "",
-    "Endpoint": "https://wawsobserver-prod.azurewebsites.net"
+    "Endpoint": "https://wawsobserver-prod.azurewebsites.net",
+    "ObserverLocalHostEnabled": false
   },
   "GeoMaster": {
     "GeoCertThumbprint": "",


### PR DESCRIPTION
Made some modifications to the project when targeting observer on local host
1. Disable token service for observer as the request to local host will just be HTTP requests
2. Add a feature flag behind local host observer so that we can turn on/off anytime. (This would require diagnostic role config update)

Note this also includes the changes from another pull requests https://github.com/Azure/Azure-AppServices-Diagnostics/pull/151.