### PR TITLE
Return null for Change Analysis meta data

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/ChangeAnalysisDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/ChangeAnalysisDataProvider.cs
@@ -163,10 +163,7 @@ namespace Diagnostics.DataProviders
 
         public DataProviderMetadata GetMetadata()
         {
-            return new DataProviderMetadata
-            {
-                ProviderName = "ChangeAnalysis"
-            };
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
Change Analysis title was appearing in the data source tab without any information. Removed it. 