### PR TITLE
Check For Kusto "Response Too Large" Error

### DIFF
--- a/src/Diagnostics.DataProviders/Interfaces/IKustoClient.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoClient.cs
@@ -1,9 +1,4 @@
-﻿using Diagnostics.ModelsAndUtils;
-using Diagnostics.ModelsAndUtils.Models;
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Text;
+﻿using System.Data;
 using System.Threading.Tasks;
 
 namespace Diagnostics.DataProviders

--- a/src/Diagnostics.DataProviders/KustoClient.cs
+++ b/src/Diagnostics.DataProviders/KustoClient.cs
@@ -22,6 +22,9 @@ namespace Diagnostics.DataProviders
     {
         private string _requestId;
         private string KustoApiQueryEndpoint;
+        private static readonly string _dataSizeExceededMessage = "Query result set has exceeded the internal data size limit";
+        private static readonly string _recordCountExceededMessage = "Query result set has exceeded the internal record count limit";
+        private static readonly string _queryLimitDocsLink = "https://docs.microsoft.com/en-us/azure/kusto/concepts/querylimits";
 
         private readonly Lazy<HttpClient> _client = new Lazy<HttpClient>(() =>
         {
@@ -77,7 +80,7 @@ namespace Diagnostics.DataProviders
                 }
                 else
                 {
-                    dataSet = JsonConvert.DeserializeObject<DataTableResponseObjectCollection>(responseContent);
+                    dataSet = ProcessKustoResponse(responseContent);
                 }
             }
             catch (Exception ex)
@@ -95,6 +98,20 @@ namespace Diagnostics.DataProviders
             LogKustoQuery(query, cluster, operationName, timeTakenStopWatch, kustoClientId, null, dataSet);
 
             return dataSet?.Tables == null ? new DataTable() : dataSet.Tables.FirstOrDefault().ToDataTable();
+        }
+
+        private DataTableResponseObjectCollection ProcessKustoResponse(string responseContent)
+        {
+            if (responseContent.Contains(_dataSizeExceededMessage))
+            {
+                throw new Exception($"Kusto query response exceeded the Kusto data size limit: {_queryLimitDocsLink}");
+            }
+            else if (responseContent.Contains(_recordCountExceededMessage))
+            {
+                throw new Exception($"Kusto query response exceeded the Kusto record count limit: {_queryLimitDocsLink}");
+            }
+
+            return JsonConvert.DeserializeObject<DataTableResponseObjectCollection>(responseContent);
         }
 
         private void LogKustoQuery(string query, string cluster, string operationName, Stopwatch timeTakenStopWatch, string kustoClientId, Exception kustoApiException, DataTableResponseObjectCollection dataSet)


### PR DESCRIPTION
- JSON was failing to deserialize because of additional error object in response
- Check for Kusto error message on response and throw a different exception
- Applens should handle exception to show why the detector was unable to run