### PR TITLE
ChangeAnalysis gist migration

### DIFF
--- a/src/Diagnostics.DataProviders/ChangeAnalysisClient.cs
+++ b/src/Diagnostics.DataProviders/ChangeAnalysisClient.cs
@@ -287,13 +287,14 @@ namespace Diagnostics.DataProviders
             }
         }
 
+
         /// <summary>
         /// Prepares httpwebrequest to <paramref name="requestUri"/> with <paramref name="postBody"/> as body of the request.
         /// </summary>
         /// <param name="requestUri">Change Analysis Request URI</param>
         /// <param name="postBody">Body of the request</param>
         /// <returns>JSON string received from <paramref name="requestUri"/>.</returns>
-        private async Task<string> PrepareAndSendRequest(string requestUri, object postBody = null, HttpMethod httpMethod = null)
+        public async Task<string> PrepareAndSendRequest(string requestUri, object postBody = null, HttpMethod httpMethod = null)
         {
             HttpMethod requestedHttpMethod = httpMethod == null ? HttpMethod.Post : httpMethod;
             HttpRequestMessage requestMessage = new HttpRequestMessage(requestedHttpMethod, requestUri);
@@ -319,6 +320,8 @@ namespace Diagnostics.DataProviders
             string content = await responseMessage.Content.ReadAsStringAsync();
             if (!responseMessage.IsSuccessStatusCode)
             {
+                var message = $"HTTP Request failed endpoint: {requestUri}, StatusCode : {responseMessage.StatusCode}, Content: {content}";
+                DiagnosticsETWProvider.Instance.LogDataProviderMessage(requestId, "ChangeAnalysisClient", message);
                 HttpRequestException ex = new HttpRequestException($"Status Code : {responseMessage.StatusCode}, Content : {content}");
                 ex.Data.Add(ExceptionStatusCode, responseMessage.StatusCode);
                 throw ex;

--- a/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
@@ -438,9 +438,9 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(changeAnalysisDataProvider.ScanActionRequest(resourceId, scanAction));
         }
 
-        public Task<string> ForwardRequestToClient(string requestUri, object postBody = null, HttpMethod method = null)
+        public Task<string> InvokeChangeAnalysisRequest(string requestUri, object postBody = null, HttpMethod method = null)
         {
-            return MakeDependencyCall(changeAnalysisDataProvider.ForwardRequestToClient(requestUri, postBody, method));
+            return MakeDependencyCall(changeAnalysisDataProvider.InvokeChangeAnalysisRequest(requestUri, postBody, method));
         }
 
         #endregion ChangeAnalysisDataProvider

--- a/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/DataProviderLogDecorator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -437,6 +438,11 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(changeAnalysisDataProvider.ScanActionRequest(resourceId, scanAction));
         }
 
+        public Task<string> ForwardRequestToClient(string requestUri, object postBody = null, HttpMethod method = null)
+        {
+            return MakeDependencyCall(changeAnalysisDataProvider.ForwardRequestToClient(requestUri, postBody, method));
+        }
+
         #endregion ChangeAnalysisDataProvider
 
         #region ASC_DataProvider
@@ -527,5 +533,6 @@ namespace Diagnostics.DataProviders
                 }
             }
         }
+
     }
 }

--- a/src/Diagnostics.DataProviders/DataProviders/ChangeAnalysisDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/ChangeAnalysisDataProvider.cs
@@ -7,6 +7,7 @@ using Diagnostics.DataProviders.DataProviderConfigurations;
 using Diagnostics.DataProviders.Interfaces;
 using Diagnostics.ModelsAndUtils.Models;
 using Diagnostics.ModelsAndUtils.Models.ChangeAnalysis;
+using System.Net.Http;
 
 namespace Diagnostics.DataProviders
 {
@@ -198,6 +199,18 @@ namespace Diagnostics.DataProviders
             }
 
             return hostnames;
+        }
+
+        /// <summary>
+        /// Forwards the request to Change Analysis Client
+        /// </summary>
+        /// <param name="requestUri">Request URI</param>
+        /// <param name="postBody">Post body</param>
+        /// <param name="method">HTTP Method.</param>
+        /// <returns>JSON string</returns>
+        public async Task<string> ForwardRequestToClient(string requestUri, object postBody = null, HttpMethod method = null)
+        {
+            return await changeAnalysisClient.PrepareAndSendRequest(requestUri, postBody, method);
         }
     }
 }

--- a/src/Diagnostics.DataProviders/DataProviders/ChangeAnalysisDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/ChangeAnalysisDataProvider.cs
@@ -208,7 +208,7 @@ namespace Diagnostics.DataProviders
         /// <param name="postBody">Post body</param>
         /// <param name="method">HTTP Method.</param>
         /// <returns>JSON string</returns>
-        public async Task<string> ForwardRequestToClient(string requestUri, object postBody = null, HttpMethod method = null)
+        public async Task<string> InvokeChangeAnalysisRequest(string requestUri, object postBody = null, HttpMethod method = null)
         {
             return await changeAnalysisClient.PrepareAndSendRequest(requestUri, postBody, method);
         }

--- a/src/Diagnostics.DataProviders/Interfaces/IChangeAnalysisDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IChangeAnalysisDataProvider.cs
@@ -67,6 +67,6 @@ namespace Diagnostics.DataProviders.Interfaces
         /// <param name="postBody">Post body</param>
         /// <param name="method">HTTP Method.</param>
         /// <returns>JSON string</returns>
-        Task<string> ForwardRequestToClient(string requestUri, object postBody = null, HttpMethod method = null);
+        Task<string> InvokeChangeAnalysisRequest(string requestUri, object postBody = null, HttpMethod method = null);
     }
 }

--- a/src/Diagnostics.DataProviders/Interfaces/IChangeAnalysisDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IChangeAnalysisDataProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Diagnostics.ModelsAndUtils.Models;
 using Diagnostics.ModelsAndUtils.Models.ChangeAnalysis;
@@ -58,5 +59,14 @@ namespace Diagnostics.DataProviders.Interfaces
         /// <param name="scanAction">Scan action: It is "submitscan" or "checkscan".</param>
         /// <returns>Contains info about the scan request with submissions state and time.</returns>
         Task<ChangeScanModel> ScanActionRequest(string resourceId, string scanAction);
+
+        /// <summary>
+        /// Forwards the request to Change Analysis Client
+        /// </summary>
+        /// <param name="requestUri">Request URI</param>
+        /// <param name="postBody">Post body</param>
+        /// <param name="method">HTTP Method.</param>
+        /// <returns>JSON string</returns>
+        Task<string> ForwardRequestToClient(string requestUri, object postBody = null, HttpMethod method = null);
     }
 }

--- a/src/Diagnostics.RuntimeHost/Models/FormModelBinder.cs
+++ b/src/Diagnostics.RuntimeHost/Models/FormModelBinder.cs
@@ -56,7 +56,7 @@ namespace Diagnostics.RuntimeHost.Models
                     bindingContext.ModelState.TryAddModelError("inpId", "Input Id must be an integer.");
                     return Task.CompletedTask;
                 }
-                if (inputValues[i].Length > 50)
+                if (inputValues[i].Length > 150)
                 {
                     bindingContext.ModelState.TryAddModelError("val", "Length of val cannot exceed 50 characters.");
                     return Task.CompletedTask;


### PR DESCRIPTION
These changes will make Change Analysis Data Provider easily consumed by Gist. 

- We can maintain models and logic in the gist and call the Data Provider to forward the request. (Like what ASC Data Provider gist does)
- Logs the exception message if status code is not successful. 
- Increased the form input value to 150 characters so that we can pass detector query params from the UI and it can be consumed in the gist. 
