### PR TITLE
Cmaher/kusto failover improovments

### DIFF
--- a/src/Diagnostics.DataProviders/ConfigurationFactory.cs
+++ b/src/Diagnostics.DataProviders/ConfigurationFactory.cs
@@ -74,6 +74,7 @@ namespace Diagnostics.DataProviders
                     case "KustoRegionGroupings":
                         return "mockstamp";
                     case "HeartBeatConsecutiveFailureLimit":
+                    case "HeartBeatConsecutiveSuccessLimit":
                         return "1";
                     case "HeartBeatQuery":
                         return "Heartbeat";

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
@@ -62,6 +62,12 @@ namespace Diagnostics.DataProviders
         public int HeartBeatConsecutiveFailureLimit { get; set; }
 
         /// <summary>
+        /// Number of consecutive successes before returning to the primary cluster.
+        /// </summary>
+        [ConfigurationName("HeartBeatConsecutiveSuccessLimit")]
+        public int HeartBeatConsecutiveSuccessLimit { get; set; }
+
+        /// <summary>
         /// Query to run against each cluster to check health
         /// </summary>
         [ConfigurationName("HeartBeatQuery")]
@@ -70,14 +76,14 @@ namespace Diagnostics.DataProviders
         /// <summary>
         /// Timeout of the query
         /// </summary>
-        [ConfigurationName("HeartBeatTimeOut")]
-        public int HeartBeatTimeOut { get; set; }
+        [ConfigurationName("HeartBeatTimeOutInSeconds")]
+        public int HeartBeatTimeOutInSeconds { get; set; }
 
         /// <summary>
         /// Delay between each heart beat
         /// </summary>
-        [ConfigurationName("HeartBeatDelay")]
-        public int HeartBeatDelay { get; set; }
+        [ConfigurationName("HeartBeatDelayInSeconds")]
+        public int HeartBeatDelayInSeconds { get; set; }
 
         /// <summary>
         /// Region Specific Cluster Names.

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
@@ -137,7 +137,7 @@ namespace Diagnostics.DataProviders
             var separator = new char[] { ',' };
             var regionGroupingParts = KustoRegionGroupings.Split(separator);
             var clusterNameGroupingParts = KustoClusterNameGroupings.Split(separator);
-            var clusterFailoverGroupingParts = KustoClusterFailoverGroupings.Split(separator);
+            var clusterFailoverGroupingParts = string.IsNullOrWhiteSpace(KustoClusterFailoverGroupings) ? new string[0] : KustoClusterFailoverGroupings.Split(separator);
 
             if (regionGroupingParts.Length != clusterNameGroupingParts.Length)
             {

--- a/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
+++ b/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
@@ -113,86 +113,91 @@ namespace Diagnostics.DataProviders
             _configuration = configuration;
         }
 
+        private async Task RunHeartBeatPrimary(string activityId)
+        {
+            bool primaryHeartBeatSuccess = false;
+            Exception exceptionForLog = null;
+            try
+            {
+                var primaryHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOut, activityId);
+
+                if (primaryHeartBeat.Rows.Count >= 1)
+                {
+                    primaryHeartBeatSuccess = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                exceptionForLog = ex;
+            }
+
+            if (primaryHeartBeatSuccess)
+            {
+                _ConsecutiveFailureCount = 0;
+                _ConsecutiveSuccessCount++;
+            }
+            else
+            {
+                _ConsecutiveFailureCount++;
+                _ConsecutiveSuccessCount = 0;
+            }
+
+            // if not in failover state
+            //  should failover?
+            if (UsePrimaryCluster && _ConsecutiveFailureCount >= _configuration.HeartBeatConsecutiveFailureLimit)
+            {
+                UsePrimaryCluster = false;
+            } // else should stop failover
+            else if (!UsePrimaryCluster && _ConsecutiveSuccessCount >= _configuration.HeartBeatConsecutiveFailureLimit)
+            {
+                UsePrimaryCluster = true;
+            }
+
+            LogHeartBeatInformation("Primary", primaryHeartBeatSuccess, PrimaryCluster, activityId, UsePrimaryCluster, exceptionForLog);
+        }
+
+        private async Task RunHeartBeatFailover(string activityId)
+        {
+            bool failoverHeartBeatSuccess = false;
+            Exception exceptionForLog = null;
+            try
+            {
+                var failoverHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOut, activityId);
+
+                if (failoverHeartBeat.Rows.Count >= 1)
+                {
+                    failoverHeartBeatSuccess = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                exceptionForLog = ex;
+            }
+
+            LogHeartBeatInformation("Failover", failoverHeartBeatSuccess, FailoverCluster, activityId, UsePrimaryCluster, exceptionForLog);
+        }
+
         public async Task RunHeartBeatTask(CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested) {
-                bool primaryHeartBeatSuccess = false;
-                bool failoverHeartBeatSuccess = false;
-                Exception exceptionForLog = null;
+                
                 string activityId = Guid.NewGuid().ToString();
-                try
-                {
-                    // Run kusto query with time out
-                    if (string.IsNullOrEmpty(FailoverCluster))
-                    {
-                        var primaryTask = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOut, activityId);
 
-                        if (primaryTask.Rows.Count >= 1)
-                        {
-                            primaryHeartBeatSuccess = true;
-                        }
-                    }
-                    else
-                    {
-                        var primaryTask = _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOut, activityId);
-                        var failoverTask = _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, FailoverCluster, _configuration.HeartBeatTimeOut, activityId);
-                        await Task.WhenAll(new Task[] { primaryTask, failoverTask });
-
-                        var result = await primaryTask;
-                        if (result.Rows.Count >= 1)
-                        {
-                            primaryHeartBeatSuccess = true;
-                        }
-
-                        var failoverResult = await failoverTask;
-                        if (failoverResult.Rows.Count >= 1)
-                        {
-                            failoverHeartBeatSuccess = true;
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    exceptionForLog = ex;
-                }
-
-                if (primaryHeartBeatSuccess)
-                {
-                    _ConsecutiveFailureCount = 0;
-                    _ConsecutiveSuccessCount++;
-                }
-                else
-                {
-                    _ConsecutiveFailureCount++;
-                    _ConsecutiveSuccessCount = 0;
-                }
-
-                // if not in failover state
-                //  should failover?
-                if (UsePrimaryCluster && _ConsecutiveFailureCount >= _configuration.HeartBeatConsecutiveFailureLimit)
-                {
-                    UsePrimaryCluster = false;
-                } // else should stop failover
-                else if (!UsePrimaryCluster && _ConsecutiveSuccessCount >= _configuration.HeartBeatConsecutiveFailureLimit)
-                {
-                    UsePrimaryCluster = true;
-                }
-
-                LogHeartBeatInformation(primaryHeartBeatSuccess, failoverHeartBeatSuccess, PrimaryCluster, FailoverCluster, activityId, _ConsecutiveSuccessCount, _ConsecutiveFailureCount, exceptionForLog);
+                var primaryTask = RunHeartBeatPrimary(activityId);
+                var failoverTask = RunHeartBeatFailover(activityId);
+                await Task.WhenAll(new Task[] { primaryTask, failoverTask });
 
                 await Task.Delay(TimeSpan.FromSeconds(_configuration.HeartBeatDelay), cancellationToken);
             }
         }
 
-        private void LogHeartBeatInformation(bool primaryClustersuccess, bool failoverClusterSuccess, string cluster, string failoverCluster, string invocationId, int successCount, int failureCount, Exception exception)
+        private void LogHeartBeatInformation(string primaryOrFailover, bool clustersuccess, string cluster, string activityId, bool usingPrimaryCluster, Exception exception)
         {
-            var primaryClusterStatus = primaryClustersuccess ? "Success" : "Failed";
-            var failoverClusterStatus = failoverClusterSuccess ? "Success" : "Failed";
-
+            var clusterStatus = clustersuccess ? "Success" : "Failed";
 
             DiagnosticsETWProvider.Instance.LogKustoHeartbeatInformation(
-               invocationId,
-               $"PrimaryClusterStatus:{primaryClusterStatus},FailoverClusterStatus:{failoverClusterStatus},PrimaryCluster:{cluster},FailoverCluster:{failoverCluster},PrimaryClusterConsecutiveSuccessCount:{successCount},PrimaryClusterConsecutiveFailureCount:{failureCount}",
+               activityId,
+               $"ClusterType:{primaryOrFailover},ClusterStatus:{clusterStatus},Cluster:{cluster},UsingPrimaryCluster:{usingPrimaryCluster}",
                exception != null ? exception.GetType().ToString() : string.Empty,
                exception != null ? exception.ToString() : string.Empty);
         }

--- a/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
+++ b/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
@@ -183,10 +183,16 @@ namespace Diagnostics.DataProviders
                 
                 string activityId = Guid.NewGuid().ToString();
 
-                var primaryTask = RunHeartBeatPrimary(activityId);
-                var failoverTask = RunHeartBeatFailover(activityId);
-                await Task.WhenAll(new Task[] { primaryTask, failoverTask });
-
+                if (string.IsNullOrEmpty(FailoverCluster))
+                {
+                    await RunHeartBeatPrimary(activityId);
+                }
+                else
+                {
+                    var primaryTask = RunHeartBeatPrimary(activityId);
+                    var failoverTask = RunHeartBeatFailover(activityId);
+                    await Task.WhenAll(new Task[] { primaryTask, failoverTask });
+                }
                 await Task.Delay(TimeSpan.FromSeconds(_configuration.HeartBeatDelay), cancellationToken);
             }
         }

--- a/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
+++ b/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
@@ -119,7 +119,7 @@ namespace Diagnostics.DataProviders
             Exception exceptionForLog = null;
             try
             {
-                var primaryHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOut, activityId);
+                var primaryHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOutInSeconds, activityId);
 
                 if (primaryHeartBeat.Rows.Count >= 1)
                 {
@@ -148,7 +148,7 @@ namespace Diagnostics.DataProviders
             {
                 UsePrimaryCluster = false;
             } // else should stop failover
-            else if (!UsePrimaryCluster && _ConsecutiveSuccessCount >= _configuration.HeartBeatConsecutiveFailureLimit)
+            else if (!UsePrimaryCluster && _ConsecutiveSuccessCount >= _configuration.HeartBeatConsecutiveSuccessLimit)
             {
                 UsePrimaryCluster = true;
             }
@@ -162,7 +162,7 @@ namespace Diagnostics.DataProviders
             Exception exceptionForLog = null;
             try
             {
-                var failoverHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOut, activityId);
+                var failoverHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOutInSeconds, activityId);
 
                 if (failoverHeartBeat.Rows.Count >= 1)
                 {
@@ -193,13 +193,13 @@ namespace Diagnostics.DataProviders
                     var failoverTask = RunHeartBeatFailover(activityId);
                     await Task.WhenAll(new Task[] { primaryTask, failoverTask });
                 }
-                await Task.Delay(TimeSpan.FromSeconds(_configuration.HeartBeatDelay), cancellationToken);
+                await Task.Delay(TimeSpan.FromSeconds(_configuration.HeartBeatDelayInSeconds), cancellationToken);
             }
         }
 
-        private void LogHeartBeatInformation(string primaryOrFailover, bool clustersuccess, string cluster, string activityId, bool usingPrimaryCluster, Exception exception)
+        private void LogHeartBeatInformation(string primaryOrFailover, bool clusterSuccess, string cluster, string activityId, bool usingPrimaryCluster, Exception exception)
         {
-            var clusterStatus = clustersuccess ? "Success" : "Failed";
+            var clusterStatus = clusterSuccess ? "Success" : "Failed";
 
             DiagnosticsETWProvider.Instance.LogKustoHeartbeatInformation(
                activityId,

--- a/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
+++ b/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
@@ -65,7 +65,7 @@ namespace Diagnostics.DataProviders
                 }
             }
 
-            if (!string.IsNullOrEmpty(_heartbeats[kustoClusterName].FailoverCluster))
+            if (!string.IsNullOrWhiteSpace(_heartbeats[kustoClusterName].FailoverCluster))
             {
                 if (!_heartbeats[kustoClusterName].UsePrimaryCluster)
                 {
@@ -183,7 +183,7 @@ namespace Diagnostics.DataProviders
                 
                 string activityId = Guid.NewGuid().ToString();
 
-                if (string.IsNullOrEmpty(FailoverCluster))
+                if (string.IsNullOrWhiteSpace(FailoverCluster))
                 {
                     await RunHeartBeatPrimary(activityId);
                 }

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -40,9 +40,10 @@
     "KustoClusterNameGroupings": "",
     "KustoClusterFailoverGroupings": "",
     "HeartBeatConsecutiveFailureLimit": 5,
+    "HeartBeatConsecutiveSuccessLimit": 5,
     "HeartBeatQuery": "",
-    "HeartBeatTimeOut": 10,
-    "HeartBeatDelay": 20,
+    "HeartBeatTimeOutInSeconds": 10,
+    "HeartBeatDelayInSeconds": 20,
     "AADAuthority": "https://login.windows.net/microsoft.com",
     "AADKustoResource": "https://wawskustotest.kusto.windows.net"
   },

--- a/tests/DataProviderTests/DataProviderTests.cs
+++ b/tests/DataProviderTests/DataProviderTests.cs
@@ -206,9 +206,18 @@ namespace Diagnostics.Tests.DataProviderTests
             var configFactory = new MockDataProviderConfigurationFactory();
             var config = configFactory.LoadConfigurations();
             var kustoHeartBeatService = new KustoHeartBeatService(config.KustoConfiguration);
-            
-            MockKustoClient.ShouldHeartbeatSucceed = false;
+
+            MockKustoClient.ShouldHeartbeatSucceed = true;
             int startingHeartBeatRuns = MockKustoClient.HeartBeatRuns;
+            do
+            {
+                await Task.Delay(100);
+            } while (startingHeartBeatRuns == MockKustoClient.HeartBeatRuns);
+            Assert.Equal(config.KustoConfiguration.KustoClusterNameGroupings, kustoHeartBeatService.GetClusterNameFromStamp("waws-prod-mockstamp"));
+
+
+            MockKustoClient.ShouldHeartbeatSucceed = false;
+            startingHeartBeatRuns = MockKustoClient.HeartBeatRuns;
             do
             {
                 await Task.Delay(100);


### PR DESCRIPTION
this change makes heartbeat still log information where there is no fail over.

this change also aims to fix a bug where an exception of the secondary heart beat would cause the primary heart beat to fail. now both heart beats exceptions are caught and logged separately.