### PR TITLE
Add new rendering type for application dependencies

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
@@ -218,7 +218,12 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <summary>
         /// Data rendered as Changes
         /// </summary>
-        ChangesView
+        ChangesView,
+
+        /// <summary>
+        /// Dependent resources of web app rendered as graph.
+        /// </summary>
+        DependencyGraph
     }
 
     /// <summary>


### PR DESCRIPTION
Added new Rendering type for Application Dependency.
The method to add the DataTable to the response object will be maintained in the gist so that in future if we have to add/remove fields sent to the UI, we can do easily. 