### PR TITLE
Analysis is not showing up because deserialize issue

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Attributes/Definition.cs
+++ b/src/Diagnostics.ModelsAndUtils/Attributes/Definition.cs
@@ -75,6 +75,18 @@ namespace Diagnostics.ModelsAndUtils.Attributes
                     return AnalysisType.Split(',').ToList();
                 }
             }
+
+            set
+            {
+                if (value == null)
+                {
+                    AnalysisType = string.Empty;
+                }
+                else
+                {
+                    AnalysisType = string.Join(",", value);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Currently we are using Json SerializeObject and DeserializeObject to make sure we are not overwriting the author info in our InvokerCache:

        private Definition RemovePIIFromDefinition(Definition definition, bool isInternal)
        { 
            string definitionString = JsonConvert.SerializeObject(definition);
            Definition definitionCopy = JsonConvert.DeserializeObject<Definition>(definitionString);
            if (!isInternal)
            {
                definitionCopy.Author = string.Empty;
            }
            return definitionCopy;
        }

However in Definition.cs, AnalysisType is defined as [JsonIgnore], thus the value of  AnalysisTypes we get from AnalysisType property will be null after SerializeObject and DeserializeObject in the above function. Add the set method to set back value from AnalysisTypes to AnalysisType.