### PR TITLE
Direct /minienvironment Routes to WawsObserver

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -95,15 +95,16 @@ namespace Diagnostics.DataProviders
                 throw new ArgumentNullException(nameof(url));
             }
 
-            var uri = new Uri(url);
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
 
             // TODO: remove redirect to wawsobserver when Geomaster API implements GeoRegion connection strings
-            if (url.Contains("/api/minienvironments/"))
+            if (url.StartsWith("minienvironments/"))
             {
-                uri = new Uri(new Uri("https://wawsobserver.azurewebsites.windows.net"), uri.PathAndQuery);
+                url = $"api/{url}";
+                var uri = new Uri(new Uri("https://wawsobserver.azurewebsites.windows.net"), url);
+                request = new HttpRequestMessage(HttpMethod.Get, uri);
             }
 
-            var request = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await SendObserverRequestAsync(request, resourceId);
             var result = await response.Content.ReadAsStringAsync();
 
@@ -123,6 +124,8 @@ namespace Diagnostics.DataProviders
             {
                 Logger.LogDataProviderMessage(RequestId, "ObserverDataProvider",
                     $"url:{new Uri(_httpClient.BaseAddress, request.RequestUri)}, response:{loggingMessage}, statusCode:{(int)response.StatusCode}");
+
+                request.Dispose();
             }
 
             return result;

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -156,7 +156,7 @@ namespace Diagnostics.DataProviders
         {
             var httpClient = new HttpClient
             {
-                BaseAddress = new Uri("https://wawsobserver.azurewebsites.windows.net/api")
+                BaseAddress = new Uri("https://wawsobserver.azurewebsites.windows.net")
             };
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -90,7 +90,20 @@ namespace Diagnostics.DataProviders
 
         protected async Task<string> GetObserverResource(string url, string resourceId = null)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            var uri = new Uri(url);
+
+            // TODO: remove redirect to wawsobserver when Geomaster API implements GeoRegion connection strings
+            if (url.Contains("/api/minienvironments/"))
+            {
+                uri = new Uri(new Uri("https://wawsobserver.azurewebsites.windows.net"), uri.PathAndQuery);
+            }
+
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await SendObserverRequestAsync(request, resourceId);
             var result = await response.Content.ReadAsStringAsync();
 

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -25,6 +25,7 @@ namespace Diagnostics.RuntimeHost
 
         public IConfiguration Configuration { get; }
         public IHostingEnvironment Environment { get; }
+
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
@@ -56,7 +57,7 @@ namespace Diagnostics.RuntimeHost
             {
                 services.AddSingleton<ISearchService, SearchServiceDisabled>();
             }
-            
+
             var servicesProvider = services.BuildServiceProvider();
             var dataSourcesConfigService = servicesProvider.GetService<IDataSourcesConfigurationService>();
             var observerConfiguration = dataSourcesConfigService.Config.SupportObserverConfiguration;
@@ -64,14 +65,11 @@ namespace Diagnostics.RuntimeHost
 
             services.AddSingleton<IKustoHeartBeatService>(new KustoHeartBeatService(kustoConfiguration));
 
-            if (!observerConfiguration.ObserverLocalHostEnabled)
-            {
-                observerConfiguration.AADAuthority = dataSourcesConfigService.Config.KustoConfiguration.AADAuthority;
-                var wawsObserverTokenService = new ObserverTokenService(observerConfiguration.WawsObserverResourceId, observerConfiguration);
-                var supportBayApiObserverTokenService = new ObserverTokenService(observerConfiguration.SupportBayApiObserverResourceId, observerConfiguration);
-                services.AddSingleton<IWawsObserverTokenService>(wawsObserverTokenService);
-                services.AddSingleton<ISupportBayApiObserverTokenService>(supportBayApiObserverTokenService);
-            }
+            observerConfiguration.AADAuthority = dataSourcesConfigService.Config.KustoConfiguration.AADAuthority;
+            var wawsObserverTokenService = new ObserverTokenService(observerConfiguration.WawsObserverResourceId, observerConfiguration);
+            var supportBayApiObserverTokenService = new ObserverTokenService(observerConfiguration.SupportBayApiObserverResourceId, observerConfiguration);
+            services.AddSingleton<IWawsObserverTokenService>(wawsObserverTokenService);
+            services.AddSingleton<ISupportBayApiObserverTokenService>(supportBayApiObserverTokenService);
 
             KustoTokenService.Instance.Initialize(dataSourcesConfigService.Config.KustoConfiguration);
             ChangeAnalysisTokenService.Instance.Initialize(dataSourcesConfigService.Config.ChangeAnalysisDataProviderConfiguration);


### PR DESCRIPTION
- SelfHost Observer cannot pull Georegion connection string from geomaster
- WawsObserver gets the connection string from Service Health Dashboard, a dependency we don't want to add to SelfHost Observer