### PR TITLE
Rekha/log querystring

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/ChangeAnalysisDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/ChangeAnalysisDataProvider.cs
@@ -8,6 +8,7 @@ using Diagnostics.DataProviders.Interfaces;
 using Diagnostics.ModelsAndUtils.Models;
 using Diagnostics.ModelsAndUtils.Models.ChangeAnalysis;
 using System.Net.Http;
+using Diagnostics.Logger;
 
 namespace Diagnostics.DataProviders
 {
@@ -91,6 +92,7 @@ namespace Diagnostics.DataProviders
                 throw new ArgumentNullException(nameof(resourceUri));
             }
 
+            DiagnosticsETWProvider.Instance.LogDataProviderMessage(dataProviderRequestId, "ChangeAnalysisDataProvider", $"Changeset id before calling api : {changeSetId}");
             ChangeRequest request = new ChangeRequest
             {
                 ResourceId = resourceUri,

--- a/src/Diagnostics.Logger/ApiMetricsLogger.cs
+++ b/src/Diagnostics.Logger/ApiMetricsLogger.cs
@@ -158,7 +158,7 @@ namespace Diagnostics.Logger
 
             startTime = DateTime.UtcNow;
             verb = context.Request.Method;
-            address = context.Request.Path.ToString();
+            address = context.Request.Path.ToString() + context.Request.QueryString;
 
             try
             {

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -888,7 +888,6 @@ namespace Diagnostics.RuntimeHost.Controllers
         private async Task<Response> GetChangesByChangeSetId(string changeSetId, string resourceId, IChangeAnalysisDataProvider changeAnalysisDataProvider)
         {
             changeSetId = changeSetId.Replace(" ", "+");
-            DiagnosticsETWProvider.Instance.LogRuntimeHostMessage($"Changeset id before calling api : {changeSetId}");
             var changes = await changeAnalysisDataProvider.GetChangesByChangeSetId(changeSetId, resourceId);
             if (changes == null || changes.Count <= 0)
             {

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -639,6 +639,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                 var resourceUriFromQuery = queryParams.Where(s => s.Key.Equals("resourceUri")).Select(pair => pair.Value);
                 var resourceUri = context.OperationContext.Resource.ResourceUri;
                 var changeSetIdValue = changeSetId.First();
+                DiagnosticsETWProvider.Instance.LogRuntimeHostMessage($"Change set id received - {changeSetIdValue}");
                 if (resourceUriFromQuery.Any())
                 {
                     resourceUri = resourceUriFromQuery.First();
@@ -886,6 +887,8 @@ namespace Diagnostics.RuntimeHost.Controllers
         /// <returns>Changes for given change set id.</returns>
         private async Task<Response> GetChangesByChangeSetId(string changeSetId, string resourceId, IChangeAnalysisDataProvider changeAnalysisDataProvider)
         {
+            changeSetId = changeSetId.Replace(" ", "+");
+            DiagnosticsETWProvider.Instance.LogRuntimeHostMessage($"Changeset id before calling api : {changeSetId}");
             var changes = await changeAnalysisDataProvider.GetChangesByChangeSetId(changeSetId, resourceId);
             if (changes == null || changes.Count <= 0)
             {


### PR DESCRIPTION
- Log the full uri (path and query string)

- Log change set id received from query param string 

- Replace space in changeset id with '+' because the url coming from GeoMaster is not encoded so runtime host receives it as space. Until GeoMaster change gets deployed space character will get replaced with '+'. Once GeoMaster change gets in, we wont receive space character. 