### PR TITLE
Change TenantIdQuery to also query with EventStampName column

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/NationalCloudStampService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/NationalCloudStampService.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Diagnostics.DataProviders;
+using Diagnostics.ModelsAndUtils.Attributes;
+
+namespace Diagnostics.RuntimeHost.Services
+{
+    public sealed class NationalCloudStampService : StampService
+    {
+        protected override async Task<List<string>> GetTenantIdsAsync(string stamp, DateTime startTime, DateTime endTime, DataProviderContext dataProviderContext, PlatformType platformType)
+        {
+            if (platformType == PlatformType.Windows)
+            {
+                return await base.GetTenantIdsAsync(stamp, startTime, endTime, dataProviderContext, platformType);
+            }
+            else
+            {
+                return await Task.FromResult(new List<string>());
+            }
+        }
+
+        protected override string GetTenantIdQuery(string stamp, string startTimeStr, string endTimeStr, string tableName)
+        {
+            return
+                $@"{RoleInstanceHeartBeatTableName}
+                | where TIMESTAMP >= datetime({startTimeStr}) and TIMESTAMP <= datetime({endTimeStr}) and where EventStampName =~ ""{stamp}""
+                | summarize by Tenant, PublicHost";
+        }
+    }
+}

--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/NationalCloudStampService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/NationalCloudStampService.cs
@@ -24,7 +24,7 @@ namespace Diagnostics.RuntimeHost.Services
         {
             return
                 $@"{RoleInstanceHeartBeatTableName}
-                | where TIMESTAMP >= datetime({startTimeStr}) and TIMESTAMP <= datetime({endTimeStr}) and where EventStampName =~ ""{stamp}""
+                | where TIMESTAMP >= datetime({startTimeStr}) and TIMESTAMP <= datetime({endTimeStr}) and EventStampName =~ ""{stamp}""
                 | summarize by Tenant, PublicHost";
         }
     }

--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
@@ -104,7 +104,7 @@ namespace Diagnostics.RuntimeHost.Services
             return
                 $@"{tableName}
                 | where TIMESTAMP >= datetime({startTimeStr}) and TIMESTAMP <= datetime({endTimeStr})
-                | where PublicHost =~ ""{stamp}.cloudapp.net"" or PublicHost matches regex ""{stamp}([a-z{{1}}]).cloudapp.net""
+                | where PublicHost =~ ""{stamp}.cloudapp.net"" or PublicHost matches regex ""{stamp}([a-z{{1}}]).cloudapp.net"" or EventStampName =~ ""{stamp}""
                 | summarize by Tenant, PublicHost";
         }
     }

--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
@@ -21,6 +21,8 @@ namespace Diagnostics.RuntimeHost.Services
     public class StampService : IStampService
     {
         private ConcurrentDictionary<string, Tuple<List<string>, PlatformType>> _tenantCache;
+        protected const string RoleInstanceHeartBeatTableName = "RoleInstanceHeartbeat";
+        protected const string LinuxRoleInstanceHeartBeatTableName = "LinuxRoleInstanceHeartBeats";
 
         public StampService()
         {
@@ -41,17 +43,10 @@ namespace Diagnostics.RuntimeHost.Services
                 return result;
             }
 
-            List<string> windowsTenantIds = new List<string>();
-            List<string> linuxTenantIds = new List<string>();
-
-            string windowsQuery = GetTenantIdQuery(stamp, startTime, endTime, PlatformType.Windows);
-            string linuxQuery = GetTenantIdQuery(stamp, startTime, endTime, PlatformType.Linux);
-
-            var windowsTask = dp.Kusto.ExecuteQuery(windowsQuery, stamp, operationName: KustoOperations.GetTenantIdForWindows);
-            var linuxTask = dp.Kusto.ExecuteQuery(linuxQuery, stamp, operationName: KustoOperations.GetTenantIdForLinux);
-
-            windowsTenantIds = GetTenantIdsFromTable(await windowsTask);
-            linuxTenantIds = GetTenantIdsFromTable(await linuxTask);
+            var windowsTenantIdsTask = GetTenantIdsAsync(stamp, startTime, endTime, dataProviderContext, PlatformType.Windows);
+            var linuxTenantIdsTask = GetTenantIdsAsync(stamp, startTime, endTime, dataProviderContext, PlatformType.Linux);
+            var windowsTenantIds = await windowsTenantIdsTask;
+            var linuxTenantIds = await linuxTenantIdsTask;
 
             PlatformType type = PlatformType.Windows;
             List<string> tenantIds = windowsTenantIds.Union(linuxTenantIds).ToList();
@@ -76,6 +71,16 @@ namespace Diagnostics.RuntimeHost.Services
             return result;
         }
 
+        protected virtual async Task<List<string>> GetTenantIdsAsync(string stamp, DateTime startTime, DateTime endTime, DataProviderContext dataProviderContext, PlatformType platformType)
+        {
+            var dp = new DataProviders.DataProviders(dataProviderContext);
+            var tenantIds = new List<string>();
+            var kustoQuery = GetTenantIdQuery(stamp, startTime, endTime, platformType);
+            var kustoTask = dp.Kusto.ExecuteQuery(kustoQuery, stamp, operationName: platformType == PlatformType.Windows ? KustoOperations.GetTenantIdForWindows : KustoOperations.GetTenantIdForLinux);
+            tenantIds = GetTenantIdsFromTable(await kustoTask);
+            return tenantIds;
+        }
+
         private List<string> GetTenantIdsFromTable(DataTable dt)
         {
             List<string> tenantIds = new List<string>();
@@ -95,16 +100,21 @@ namespace Diagnostics.RuntimeHost.Services
         {
             string startTimeStr = DateTimeHelper.GetDateTimeInUtcFormat(startTime).ToString(DataProviderConstants.KustoTimeFormat);
             string endTimeStr = DateTimeHelper.GetDateTimeInUtcFormat(endTime).ToString(DataProviderConstants.KustoTimeFormat);
-            string tableName = "RoleInstanceHeartbeat";
+            string tableName = RoleInstanceHeartBeatTableName;
             if (type == PlatformType.Linux)
             {
-                tableName = "LinuxRoleInstanceHeartBeats";
+                tableName = LinuxRoleInstanceHeartBeatTableName;
             }
 
+            return GetTenantIdQuery(stamp, startTimeStr, endTimeStr, tableName);
+        }
+
+        protected virtual string GetTenantIdQuery(string stamp, string startTimeStr, string endTimeStr, string tableName)
+        {
             return
                 $@"{tableName}
                 | where TIMESTAMP >= datetime({startTimeStr}) and TIMESTAMP <= datetime({endTimeStr})
-                | where PublicHost =~ ""{stamp}.cloudapp.net"" or PublicHost matches regex ""{stamp}([a-z{{1}}]).cloudapp.net"" or EventStampName =~ ""{stamp}""
+                | where PublicHost =~ ""{stamp}.cloudapp.net"" or PublicHost matches regex ""{stamp}([a-z{{1}}]).cloudapp.net""
                 | summarize by Tenant, PublicHost";
         }
     }

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -37,7 +37,18 @@ namespace Diagnostics.RuntimeHost
             services.AddSingleton<IInvokerCacheService, InvokerCacheService>();
             services.AddSingleton<IGistCacheService, GistCacheService>();
             services.AddSingleton<ISiteService, SiteService>();
-            services.AddSingleton<IStampService, StampService>();
+            services.AddSingleton<IStampService>((serviceProvider) =>
+            {
+                var cloudDomain = serviceProvider.GetService<IDataSourcesConfigurationService>().Config.KustoConfiguration.CloudDomain;
+                switch (cloudDomain)
+                {
+                    case DataProviderConstants.AzureChinaCloud:
+                    case DataProviderConstants.AzureUSGovernment:
+                        return new NationalCloudStampService();
+                    default:
+                        return new StampService();
+                }
+            });
             services.AddSingleton<IAssemblyCacheService, AssemblyCacheService>();
 
             bool searchIsEnabled = false;


### PR DESCRIPTION
Cloud service domain name suffix is different across clouds, instead of coding for multiple domain names eg., `*.cloudapp.net, *.chinacloudapp.cn` and etc, we should use EventStampName instead which is the SourceMoniker equivalent.