### PR TITLE
fixing a bug in heartbeat logging

### DIFF
--- a/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
+++ b/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
@@ -162,7 +162,7 @@ namespace Diagnostics.DataProviders
             Exception exceptionForLog = null;
             try
             {
-                var failoverHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOutInSeconds, activityId);
+                var failoverHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, FailoverCluster, _configuration.HeartBeatTimeOutInSeconds, activityId);
 
                 if (failoverHeartBeat.Rows.Count >= 1)
                 {


### PR DESCRIPTION
It turns out that the logging for the failover heartbeat was not actually testing the failover cluster instead it was also testing the primary cluster.

This change fixes that bug.