### PR TITLE
Relax char min limit in search from 4 down to 2 chars

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -576,7 +576,7 @@ namespace Diagnostics.RuntimeHost.Controllers
             await this._sourceWatcherService.Watcher.WaitForFirstCompletion();
             var allDetectors = _invokerCache.GetEntityInvokerList<TResource>(context).ToList();
 
-            if (queryText != null && queryText.Length > 3)
+            if (queryText != null && queryText.Length > 1)
             {
                 SearchResults searchResults = null;
                 var resourceParams = _internalApiHelper.GetResourceParams(context.OperationContext.Resource as IResourceFilter);


### PR DESCRIPTION
To support error codes and other symbolic queries, relaxing the min char limit from 4 characters to 2 in backend.