### PR TITLE
Protect runtimehost with AAD

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/ApiManagement/ApiManagementController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ApiManagement/ApiManagementController.cs
@@ -5,9 +5,11 @@ using Diagnostics.ModelsAndUtils.Models.ResponseExtensions;
 using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
+    [Authorize]
     [Produces("application/json")]
     [Route(UriElements.ApiManagementServiceResource)]
     public sealed class ApiManagementController : DiagnosticControllerBase<ApiManagementService>

--- a/src/Diagnostics.RuntimeHost/Controllers/AppServiceCertificate/AppServiceCertificateController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/AppServiceCertificate/AppServiceCertificateController.cs
@@ -5,9 +5,11 @@ using Diagnostics.ModelsAndUtils.Models.ResponseExtensions;
 using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
+    [Authorize]
     [Produces("application/json")]
     [Route(UriElements.AppServiceCertResource)]
     public sealed class AppServiceCertificateController : DiagnosticControllerBase<AppServiceCertificate>

--- a/src/Diagnostics.RuntimeHost/Controllers/AppServiceDomain/AppServiceDomainController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/AppServiceDomain/AppServiceDomainController.cs
@@ -5,9 +5,11 @@ using Diagnostics.ModelsAndUtils.Models.ResponseExtensions;
 using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
+    [Authorize]
     [Produces("application/json")]
     [Route(UriElements.AppServiceDomainResource)]
     public sealed class AppServiceDomainController : DiagnosticControllerBase<AppServiceDomain>

--- a/src/Diagnostics.RuntimeHost/Controllers/ArmResource/ArmResourceController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ArmResource/ArmResourceController.cs
@@ -5,12 +5,14 @@ using Diagnostics.ModelsAndUtils.Models.ResponseExtensions;
 using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
     /// <summary>
     /// Arm resource controller.
     /// </summary>
+    [Authorize]
     [Produces("application/json")]
     [Route(UriElements.ArmResource)]
     public class ArmResourceController : DiagnosticControllerBase<ArmResource>

--- a/src/Diagnostics.RuntimeHost/Controllers/AzureKubernetesService/AzureKubernetesServiceController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/AzureKubernetesService/AzureKubernetesServiceController.cs
@@ -5,9 +5,10 @@ using Diagnostics.ModelsAndUtils.Models.ResponseExtensions;
 using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
-
+using Microsoft.AspNetCore.Authorization;
 namespace Diagnostics.RuntimeHost.Controllers
 {
+    [Authorize]
     [Produces("application/json")]
     [Route(UriElements.AzureKubernetesServiceResource)]
     public class AzureKubernetesServiceController : DiagnosticControllerBase<AzureKubernetesService>

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -26,9 +26,11 @@ using Diagnostics.Scripts.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
+    [Authorize]
     public abstract class DiagnosticControllerBase<TResource> : Controller where TResource : IResource
     {
         protected ICompilerHostClient _compilerHostClient;

--- a/src/Diagnostics.RuntimeHost/Controllers/HostingEnvironment/HostingEnvironmentController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/HostingEnvironment/HostingEnvironmentController.cs
@@ -7,9 +7,11 @@ using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
+    [Authorize]
     [Produces("application/json")]
     [Route(UriElements.HostingEnvironmentResource)]
     public sealed class HostingEnvironmentController : DiagnosticControllerBase<HostingEnvironment>

--- a/src/Diagnostics.RuntimeHost/Controllers/InternalAPIController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/InternalAPIController.cs
@@ -12,10 +12,12 @@ using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
     // Internal API to be used to communicate with internal processes on the diag role e.g. python processes for Search API
+    [Authorize]
     [Produces("application/json")]
     [Route(UriElements.Internal)]
     public class InternalAPIController : Controller

--- a/src/Diagnostics.RuntimeHost/Controllers/LogicApp/LogicAppController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/LogicApp/LogicAppController.cs
@@ -5,9 +5,11 @@ using Diagnostics.ModelsAndUtils.Models.ResponseExtensions;
 using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
+    [Authorize]
     [Produces("application/json")]
     [Route(UriElements.LogicAppResource)]
     public sealed class LogicAppController : DiagnosticControllerBase<LogicApp>

--- a/src/Diagnostics.RuntimeHost/Controllers/ObserverController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ObserverController.cs
@@ -5,12 +5,14 @@ using System.Threading.Tasks;
 using Diagnostics.DataProviders;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
     /// <summary>
     /// This API is used to get resource informatio directly from the observer data provider.
     /// </summary>
+    [Authorize]
     [Produces("application/json")]
     [Route(UriElements.Observer)]
     public class ObserverController : Controller

--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SiteControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SiteControllerBase.cs
@@ -8,11 +8,9 @@ using Diagnostics.ModelsAndUtils.Models;
 using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Services;
 using Diagnostics.RuntimeHost.Utilities;
-using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
-    [Authorize]
     public abstract class SiteControllerBase : DiagnosticControllerBase<App>
     {
         protected ISiteService _siteService;

--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SiteControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SiteControllerBase.cs
@@ -8,9 +8,11 @@ using Diagnostics.ModelsAndUtils.Models;
 using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Services;
 using Diagnostics.RuntimeHost.Utilities;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
+    [Authorize]
     public abstract class SiteControllerBase : DiagnosticControllerBase<App>
     {
         protected ISiteService _siteService;

--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
@@ -7,12 +7,14 @@ using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
     /// <summary>
     /// Sites controller.
     /// </summary>
+    [Authorize]
     [Produces("application/json")]
     [Route(UriElements.SitesResource)]
     public sealed class SitesController : SiteControllerBase

--- a/src/Diagnostics.RuntimeHost/Diagnostics.RuntimeHost.csproj
+++ b/src/Diagnostics.RuntimeHost/Diagnostics.RuntimeHost.csproj
@@ -17,6 +17,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="5.5.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.5.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.5.0" />
     <PackageReference Include="Octokit" Version="0.31.0" />
   </ItemGroup>
 

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -35,7 +35,7 @@ namespace Diagnostics.RuntimeHost
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            var openIdConfigEndpoint = $"{Configuration["AzureAd:AADAuthority"]}/.well-known/openid-configuration";
+            var openIdConfigEndpoint = $"{Configuration["SecuritySettings:AADAuthority"]}/.well-known/openid-configuration";
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(openIdConfigEndpoint, new OpenIdConnectConfigurationRetriever());
             var config = configManager.GetConfigurationAsync().Result;
             var issuer = config.Issuer;
@@ -45,7 +45,7 @@ namespace Diagnostics.RuntimeHost
             options.TokenValidationParameters = new TokenValidationParameters
             {
                 ValidateAudience = true,
-                ValidAudience = Configuration["AzureAd:ClientId"],
+                ValidAudience = Configuration["SecuritySettings:ClientId"],
                 ValidateIssuer = true,
                 ValidIssuers = new[] { issuer, $"{issuer}/v2.0" },
                 ValidateLifetime = true,
@@ -57,7 +57,7 @@ namespace Diagnostics.RuntimeHost
             {
                 OnTokenValidated = context =>
                 {
-                var allowedAppIds = Configuration["AzureAd:AllowedAppIds"].Split(",").Select(p => p.Trim()).ToList();
+                var allowedAppIds = Configuration["SecuritySettings:AllowedAppIds"].Split(",").Select(p => p.Trim()).ToList();
                 var claimPrincipal = context.Principal;
                 var incomingAppId = claimPrincipal.Claims.FirstOrDefault(c => c.Type.Equals("appid", StringComparison.CurrentCultureIgnoreCase));
                 if(incomingAppId == null || !allowedAppIds.Exists(p => p.Equals(incomingAppId.Value, StringComparison.OrdinalIgnoreCase)))

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -86,6 +86,6 @@
   "AzureAD": {
     "AADAuthority": "https://login.microsoftonline.com/microsoft.onmicrosoft.com",
     "ClientId": "b9a1efcd-32ee-4330-834c-c04eb00f4b33",
-    "AllowedAppIds": "9633e90a-48cc-4b8c-be36-5d751fa9e66a,feb361ea-e998-4696-bf87-532b215ebad3,a9157c17-6528-449e-bb50-0910c79662e9,7cd684f4-8a78-49b0-91ec-6a35d38739ba,7319c514-987d-4e9b-ac3d-d38c4f427f4c,f682e8da-0b23-42af-a2ee-ca1e7513cf1f,13c3dcd5-c6a3-4642-8b49-e45d9b7080fc,3f8e2ed0-5d7c-4b04-831b-b30f13fd9eab"
+    "AllowedAppIds": "9633e90a-48cc-4b8c-be36-5d751fa9e66a"
   }
 }

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -87,9 +87,9 @@
   "SearchAPI": {
     "SearchAPIEnabled": false
   },
-  "AzureAD": {
-    "AADAuthority": "https://login.microsoftonline.com/microsoft.onmicrosoft.com",
-    "ClientId": "b9a1efcd-32ee-4330-834c-c04eb00f4b33",
-    "AllowedAppIds": "9633e90a-48cc-4b8c-be36-5d751fa9e66a"
+  "SecuritySettings": {
+    "AADAuthority": "",
+    "ClientId": "",
+    "AllowedAppIds": ""
   }
 }

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -82,5 +82,10 @@
   },
   "SearchAPI": {
     "SearchAPIEnabled": false
+  },
+  "AzureAD": {
+    "AADAuthority": "https://login.microsoftonline.com/microsoft.onmicrosoft.com",
+    "ClientId": "b9a1efcd-32ee-4330-834c-c04eb00f4b33",
+    "AllowedAppIds": "9633e90a-48cc-4b8c-be36-5d751fa9e66a,feb361ea-e998-4696-bf87-532b215ebad3,a9157c17-6528-449e-bb50-0910c79662e9,7cd684f4-8a78-49b0-91ec-6a35d38739ba,7319c514-987d-4e9b-ac3d-d38c4f427f4c,f682e8da-0b23-42af-a2ee-ca1e7513cf1f,13c3dcd5-c6a3-4642-8b49-e45d9b7080fc,3f8e2ed0-5d7c-4b04-831b-b30f13fd9eab"
   }
 }


### PR DESCRIPTION
- Runtimehost is protected with aad to allow request only from applens
- Healthping controller has not changed so that we can test it to see if the app is up
- In the future sprint, runtimehost will be protected to allow requests from partner app ids as well.