### PR TITLE
Remove PII for app settings value

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -51,7 +51,7 @@ namespace Diagnostics.DataProviders
         public string RemovePIIFromSettings(string content)
         {
             // Mask SAS Uri
-            if (Regex.Match(content, @"https*:\/\/.*\.core\.windows\.net.*sig=.*", RegexOptions.IgnoreCase).Success)
+            if (Regex.Match(content, @"https*:\/\/[\w.]*[\w]+.core.windows.net?.*sig=.*", RegexOptions.IgnoreCase).Success)
             {
                 content = "https://*.core.windows.net/*";
             }

--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -48,6 +48,17 @@ namespace Diagnostics.DataProviders
             return geoMasterClient;
         }
 
+        public string RemovePIIFromSettings(string content)
+        {
+            // Mask SAS Uri
+            if (Regex.Match(content, @"https*:\/\/.*\.core\.windows\.net.*sig=.*", RegexOptions.IgnoreCase).Success)
+            {
+                content = "https://*.core.windows.net/*";
+            }
+
+            return content;
+        }
+
         /// <summary>
         /// Gets all the APP SETTINGS for the Web App that start with prefixes like WEBSITE_, FUNCTION_ etc, filtering out
         /// the sensitive settings like connectionstrings, tokens, secrets, keys, content shares etc.
@@ -87,8 +98,8 @@ namespace Diagnostics.DataProviders
                 if (AllowedlistAppSettingsStartingWith.Any(x => item.Key.StartsWith(x)) && !SensitiveAppSettingsEndingWith.Any(x => item.Key.EndsWith(x))
                     || RegexMatchingPatterns.Any(x => (Regex.Match(item.Key, x).Success)))
                 {
-                    
-                    appSettings.Add(item.Key, item.Value);
+                    string value = RemovePIIFromSettings(item.Value);
+                    appSettings.Add(item.Key, value);
                 }
                 else if (AppSettingsExistenceCheckList.Any(x => String.Compare(item.Key, x, true) == 0))
                 {


### PR DESCRIPTION
There could be SAS Uri value for the settings "WEBSITE_RUN_FROM_PACKAGE". Mask the SAS URI before returning it to detector.