### PR TITLE
API for getting App Stack

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
@@ -226,6 +226,19 @@ namespace Diagnostics.RuntimeHost.Controllers
             return await base.GetGist(app, gistId, startTime, endTime, timeGrain);
         }
 
+        /// <summary>
+        /// Get site diagnostics properties
+        /// </summary>
+        /// <param name="subscriptionId">Subscription Id.</param>
+        /// <param name="resourceGroupName">Resource Group Name.</param>
+        /// <param name="siteName">Site name.</param
+        /// <returns>Site Stack.</returns>
+        [HttpPost(UriElements.AppStack)]        
+        public async Task<IActionResult> GetAppStack(string subscriptionId, string resourceGroupName, string siteName)
+        {
+            return Ok(await _siteService.GetApplicationStack(subscriptionId, resourceGroupName, siteName, (DataProviderContext)HttpContext.Items[HostConstants.DataProviderContextKey]));  
+        }
+
         private static bool IsPostBodyMissing(DiagnosticSiteData postBody)
         {
             return postBody == null || string.IsNullOrWhiteSpace(postBody.Name);

--- a/src/Diagnostics.RuntimeHost/Utilities/UriElements.cs
+++ b/src/Diagnostics.RuntimeHost/Utilities/UriElements.cs
@@ -41,6 +41,7 @@
         public const string Statistics = "/statistics";
         public const string StatisticsResource = "/{invokerId}";
         public const string StatisticsQuery = "/statisticsQuery";
+        public const string AppStack = "appstack";
 
         // Constants for internal api interactions
         public const string Internal = "/internal";


### PR DESCRIPTION
Currently DiagnosticRole has an api for getting site properties which GeoMaster calls. Creating API in runtime host which gets the stack. Other properties can be fetched in GeoMaster. 