### PR TITLE
Add field "DiagEnvironment" to every ETW event

### DIFF
--- a/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
+++ b/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // </copyright>
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 
@@ -12,13 +13,20 @@ namespace Diagnostics.Logger
     /// Diagnostics ETW provider.
     /// </summary>
     [EventSource(Name = "Microsoft-Azure-AppService-Diagnostics")]
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1313:Parameter names should begin with lower-case letter", Justification = "Used for Kusto and Jarvis.")]
     public sealed class DiagnosticsETWProvider : DiagnosticsEventSourceBase
     {
+        private static readonly string EnvironmentName;
+        private static readonly Lazy<DiagnosticsETWProvider> _instance = new Lazy<DiagnosticsETWProvider>(() => new DiagnosticsETWProvider());
+
+        static DiagnosticsETWProvider()
+        {
+            EnvironmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        }
+
         /// <summary>
         /// ETW provider instance.
         /// </summary>
-        public static readonly DiagnosticsETWProvider Instance = new DiagnosticsETWProvider();
+        public static DiagnosticsETWProvider Instance { get { return _instance.Value; } }
 
         #region Compile Host Events (ID Range : 1000 - 1999)
 
@@ -27,9 +35,9 @@ namespace Diagnostics.Logger
         /// </summary>
         /// <param name="Message">The message.</param>
         [Event(1000, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogCompilerHostMessage)]
-        public void LogCompilerHostMessage(string Message)
+        public void LogCompilerHostMessage(string Message, string DiagEnvironment = null)
         {
-            WriteDiagnosticsEvent(1000, Message);
+            WriteDiagnosticsEvent(1000, Message, EnvironmentName);
         }
 
         /// <summary>
@@ -40,14 +48,15 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(1001, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogCompilerHostUnhandledException)]
-        public void LogCompilerHostUnhandledException(string RequestId, string Source, string ExceptionType, string ExceptionDetails)
+        public void LogCompilerHostUnhandledException(string RequestId, string Source, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 1001,
                 RequestId,
                 Source,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -61,7 +70,7 @@ namespace Diagnostics.Logger
         /// <param name="StartTime">The start time.</param>
         /// <param name="EndTime">The end time.</param>
         [Event(1002, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogCompilerHostAPISummary)]
-        public void LogCompilerHostAPISummary(string RequestId, string Address, string Verb, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime)
+        public void LogCompilerHostAPISummary(string RequestId, string Address, string Verb, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 1002,
@@ -71,7 +80,8 @@ namespace Diagnostics.Logger
                 StatusCode,
                 LatencyInMilliseconds,
                 StartTime,
-                EndTime);
+                EndTime,
+                EnvironmentName);
         }
 
         #endregion Compile Host Events (ID Range : 1000 - 1999)
@@ -83,9 +93,9 @@ namespace Diagnostics.Logger
         /// </summary>
         /// <param name="Message">The message.</param>
         [Event(2000, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeHostMessage)]
-        public void LogRuntimeHostMessage(string Message)
+        public void LogRuntimeHostMessage(string Message, string DiagEnvironment = null)
         {
-            WriteDiagnosticsEvent(2000, Message);
+            WriteDiagnosticsEvent(2000, Message, EnvironmentName);
         }
 
         /// <summary>
@@ -99,7 +109,7 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(2001, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeHostUnhandledException)]
-        public void LogRuntimeHostUnhandledException(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string ExceptionType, string ExceptionDetails)
+        public void LogRuntimeHostUnhandledException(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 2001,
@@ -109,7 +119,8 @@ namespace Diagnostics.Logger
                 ResourceGroup,
                 Resource,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -128,7 +139,7 @@ namespace Diagnostics.Logger
         /// <param name="EndTime">The end time.</param>
         /// <param name="Content">The headers content received.</param>
         [Event(2002, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeHostAPISummary)]
-        public void LogRuntimeHostAPISummary(string RequestId, string SubscriptionId, string ResourceGroup, string Resource, string Address, string Verb, string OperationName, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime, string Content)
+        public void LogRuntimeHostAPISummary(string RequestId, string SubscriptionId, string ResourceGroup, string Resource, string Address, string Verb, string OperationName, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime, string Content, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 2002,
@@ -143,7 +154,8 @@ namespace Diagnostics.Logger
                 LatencyInMilliseconds,
                 StartTime,
                 EndTime,
-                Content);
+                Content,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -153,13 +165,14 @@ namespace Diagnostics.Logger
         /// <param name="Source">The source.</param>
         /// <param name="Message">The message.</param>
         [Event(2003, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRetryAttemptMessage)]
-        public void LogRetryAttemptMessage(string RequestId, string Source, string Message)
+        public void LogRetryAttemptMessage(string RequestId, string Source, string Message, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 2003,
                 RequestId,
                 Source,
-                Message);
+                Message,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -174,7 +187,7 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(2004, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRetryAttemptSummary)]
-        public void LogRetryAttemptSummary(string RequestId, string Source, string Message, long LatencyInMilliseconds, string StartTime, string EndTime, string ExceptionType, string ExceptionDetails)
+        public void LogRetryAttemptSummary(string RequestId, string Source, string Message, long LatencyInMilliseconds, string StartTime, string EndTime, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 2004,
@@ -185,7 +198,8 @@ namespace Diagnostics.Logger
                 StartTime,
                 EndTime,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -199,7 +213,7 @@ namespace Diagnostics.Logger
         /// <param name="CorrelationId">The correlation id.</param>
         /// <param name="Message">The message.</param>
         [Event(2005, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeHostInsightsCorrelation, Version = 2)]
-        public void LogRuntimeHostInsightCorrelation(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string CorrelationId, string Message)
+        public void LogRuntimeHostInsightCorrelation(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string CorrelationId, string Message, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 2005,
@@ -209,7 +223,8 @@ namespace Diagnostics.Logger
                 ResourceGroup,
                 Resource,
                 CorrelationId,
-                Message);
+                Message,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -223,7 +238,7 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(2006, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeHostHandledException)]
-        public void LogRuntimeHostHandledException(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string ExceptionType, string ExceptionDetails)
+        public void LogRuntimeHostHandledException(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 2006,
@@ -233,7 +248,8 @@ namespace Diagnostics.Logger
                 ResourceGroup,
                 Resource,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -244,14 +260,15 @@ namespace Diagnostics.Logger
         /// <param name="Message">The message.</param>
         /// <param name="Details">The details.</param>
         [Event(2008, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeHostSupportTopicAscInsight)]
-        public void LogFullAscInsight(string RequestId, string Source, string Message, string Details)
+        public void LogFullAscInsight(string RequestId, string Source, string Message, string Details, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 2008,
                 RequestId,
                 Source,
                 Message,
-                Details);
+                Details,
+                EnvironmentName);
         }
 
         #endregion Runtime Host Events (ID Range : 2000 - 2499)
@@ -264,9 +281,9 @@ namespace Diagnostics.Logger
         /// <param name="Source">The source.</param>
         /// <param name="Message">The message.</param>
         [Event(2500, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogSourceWatcherMessage)]
-        public void LogSourceWatcherMessage(string Source, string Message)
+        public void LogSourceWatcherMessage(string Source, string Message, string DiagEnvironment = null)
         {
-            WriteDiagnosticsEvent(2500, Source, Message);
+            WriteDiagnosticsEvent(2500, Source, Message, EnvironmentName);
         }
 
         /// <summary>
@@ -275,9 +292,9 @@ namespace Diagnostics.Logger
         /// <param name="Source">The source.</param>
         /// <param name="Message">The message.</param>
         [Event(2501, Level = EventLevel.Warning, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogSourceWatcherWarning)]
-        public void LogSourceWatcherWarning(string Source, string Message)
+        public void LogSourceWatcherWarning(string Source, string Message, string DiagEnvironment = null)
         {
-            WriteDiagnosticsEvent(2501, Source, Message);
+            WriteDiagnosticsEvent(2501, Source, Message, EnvironmentName);
         }
 
         /// <summary>
@@ -288,9 +305,9 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(2502, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogSourceWatcherException)]
-        public void LogSourceWatcherException(string Source, string Message, string ExceptionType, string ExceptionDetails)
+        public void LogSourceWatcherException(string Source, string Message, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
-            WriteDiagnosticsEvent(2502, Source, Message, ExceptionType, ExceptionDetails);
+            WriteDiagnosticsEvent(2502, Source, Message, ExceptionType, ExceptionDetails, EnvironmentName);
         }
 
         #endregion SourceWatcher Events (ID Range : 2500 - 2599)
@@ -304,9 +321,9 @@ namespace Diagnostics.Logger
         /// <param name="Source">The source.</param>
         /// <param name="Message">The message.</param>
         [Event(2600, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogCompilerHostClientMessage)]
-        public void LogCompilerHostClientMessage(string RequestId, string Source, string Message)
+        public void LogCompilerHostClientMessage(string RequestId, string Source, string Message, string DiagEnvironment = null)
         {
-            WriteDiagnosticsEvent(2600, RequestId, Source, Message);
+            WriteDiagnosticsEvent(2600, RequestId, Source, Message, EnvironmentName);
         }
 
         /// <summary>
@@ -318,9 +335,9 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(2601, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogCompilerHostClientException)]
-        public void LogCompilerHostClientException(string RequestId, string Source, string Message, string ExceptionType, string ExceptionDetails)
+        public void LogCompilerHostClientException(string RequestId, string Source, string Message, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
-            WriteDiagnosticsEvent(2601, RequestId, Source, Message, ExceptionType, ExceptionDetails);
+            WriteDiagnosticsEvent(2601, RequestId, Source, Message, ExceptionType, ExceptionDetails, EnvironmentName);
         }
 
         /// <summary>
@@ -332,9 +349,9 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(2602, Level = EventLevel.Warning, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogCompilerHostClientWarning)]
-        public void LogCompilerHostClientWarning(string RequestId, string Source, string Message, string ExceptionType, string ExceptionDetails)
+        public void LogCompilerHostClientWarning(string RequestId, string Source, string Message, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
-            WriteDiagnosticsEvent(2602, RequestId, Source, Message, ExceptionType, ExceptionDetails);
+            WriteDiagnosticsEvent(2602, RequestId, Source, Message, ExceptionType, ExceptionDetails, EnvironmentName);
         }
 
         #endregion Compiler Host Client Events (ID Range: 2600 - 2699)
@@ -348,13 +365,14 @@ namespace Diagnostics.Logger
         /// <param name="Source">The source.</param>
         /// <param name="Message">The message.</param>
         [Event(3000, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogDataProviderMessage)]
-        public void LogDataProviderMessage(string RequestId, string Source, string Message)
+        public void LogDataProviderMessage(string RequestId, string Source, string Message, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 3000,
                 RequestId,
                 Source,
-                Message);
+                Message,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -368,7 +386,7 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(3001, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogDataProviderException)]
-        public void LogDataProviderException(string RequestId, string Source, string StartTime, string EndTime, long LatencyInMilliseconds, string ExceptionType, string ExceptionDetails)
+        public void LogDataProviderException(string RequestId, string Source, string StartTime, string EndTime, long LatencyInMilliseconds, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 3001,
@@ -378,7 +396,8 @@ namespace Diagnostics.Logger
                 EndTime,
                 LatencyInMilliseconds,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -390,7 +409,7 @@ namespace Diagnostics.Logger
         /// <param name="EndTime">The end time.</param>
         /// <param name="LatencyInMilliseconds">The latency.</param>
         [Event(3002, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogDataProviderOperationSummary)]
-        public void LogDataProviderOperationSummary(string RequestId, string Source, string StartTime, string EndTime, long LatencyInMilliseconds)
+        public void LogDataProviderOperationSummary(string RequestId, string Source, string StartTime, string EndTime, long LatencyInMilliseconds, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 3002,
@@ -398,7 +417,8 @@ namespace Diagnostics.Logger
                 Source,
                 StartTime,
                 EndTime,
-                LatencyInMilliseconds);
+                LatencyInMilliseconds,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -412,7 +432,7 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(3003, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogTokenRefreshSummary)]
-        public void LogTokenRefreshSummary(string Source, string Message, long LatencyInMilliseconds, string StartTime, string EndTime, string ExceptionType, string ExceptionDetails)
+        public void LogTokenRefreshSummary(string Source, string Message, long LatencyInMilliseconds, string StartTime, string EndTime, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 3003,
@@ -422,7 +442,8 @@ namespace Diagnostics.Logger
                 StartTime,
                 EndTime,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -437,7 +458,7 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(3004, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogKustoQueryInformation)]
-        public void LogKustoQueryInformation(string Source, string RequestId, string Message, long LatencyInMilliseconds, string Details, string Content, string ExceptionType, string ExceptionDetails)
+        public void LogKustoQueryInformation(string Source, string RequestId, string Message, long LatencyInMilliseconds, string Details, string Content, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 3004,
@@ -448,7 +469,8 @@ namespace Diagnostics.Logger
                 Details,
                 Content,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -459,14 +481,15 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(3005, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogKustoHeartbeatInformation)]
-        public void LogKustoHeartbeatInformation(string ActivityId, string Message, string ExceptionType, string ExceptionDetails)
+        public void LogKustoHeartbeatInformation(string ActivityId, string Message, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 3005,
                 ActivityId,
                 Message,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         #endregion Data Provider Events (ID Range : 3000 - 3999)
@@ -478,9 +501,9 @@ namespace Diagnostics.Logger
         /// </summary>
         /// <param name="Message">The message.</param>
         [Event(4000, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogInternalAPIMessage)]
-        public void LogInternalAPIMessage(string Message)
+        public void LogInternalAPIMessage(string Message, string DiagEnvironment = null)
         {
-            WriteDiagnosticsEvent(4000, Message);
+            WriteDiagnosticsEvent(4000, Message, EnvironmentName);
         }
 
         /// <summary>
@@ -490,13 +513,14 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(4001, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogInternalAPIUnhandledException)]
-        public void LogInternalAPIUnhandledException(string RequestId, string ExceptionType, string ExceptionDetails)
+        public void LogInternalAPIUnhandledException(string RequestId, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 4001,
                 RequestId,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -510,7 +534,7 @@ namespace Diagnostics.Logger
         /// <param name="EndTime">The end time.</param>
         /// <param name="Content">The headers content received.</param>
         [Event(4002, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogInternalAPISummary)]
-        public void LogInternalAPISummary(string RequestId, string OperationName, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime, string Content)
+        public void LogInternalAPISummary(string RequestId, string OperationName, int StatusCode, long LatencyInMilliseconds, string StartTime, string EndTime, string Content, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 4002,
@@ -520,7 +544,8 @@ namespace Diagnostics.Logger
                 LatencyInMilliseconds,
                 StartTime,
                 EndTime,
-                Content);
+                Content,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -529,12 +554,13 @@ namespace Diagnostics.Logger
         /// <param name="RequestId">The request id.</param>
         /// <param name="Message">The message.</param>
         [Event(4005, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogInternalAPIInsights, Version = 2)]
-        public void LogInternalAPIInsights(string RequestId, string Message)
+        public void LogInternalAPIInsights(string RequestId, string Message, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 4005,
                 RequestId,
-                Message);
+                Message,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -544,13 +570,14 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(4006, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogInternalAPIHandledException)]
-        public void LogInternalAPIHandledException(string RequestId, string ExceptionType, string ExceptionDetails)
+        public void LogInternalAPIHandledException(string RequestId, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 4006,
                 RequestId,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -562,14 +589,15 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         [Event(4020, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogInternalAPITrainingException)]
-        public void LogInternalAPITrainingException(string RequestId, string TrainingId, string ProductId, string ExceptionType, string ExceptionDetails)
+        public void LogInternalAPITrainingException(string RequestId, string TrainingId, string ProductId, string ExceptionType, string ExceptionDetails, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 4020,
                 TrainingId,
                 ProductId,
                 ExceptionType,
-                ExceptionDetails);
+                ExceptionDetails,
+                EnvironmentName);
         }
 
         /// <summary>
@@ -583,7 +611,7 @@ namespace Diagnostics.Logger
         /// <param name="EndTime">End Time</param>
         /// <param name="Content">Summary details.</param>
         [Event(4021, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogInternalAPITrainingSummary)]
-        public void LogInternalAPITrainingSummary(string RequestId, string TrainingId, string ProductId, long LatencyInMilliseconds, string StartTime, string EndTime, string Content)
+        public void LogInternalAPITrainingSummary(string RequestId, string TrainingId, string ProductId, long LatencyInMilliseconds, string StartTime, string EndTime, string Content, string DiagEnvironment = null)
         {
             WriteDiagnosticsEvent(
                 4021,
@@ -592,7 +620,8 @@ namespace Diagnostics.Logger
                 LatencyInMilliseconds,
                 StartTime,
                 EndTime,
-                Content);
+                Content,
+                EnvironmentName);
         }
 
         #endregion Internal AI API Events (ID Range : 4000 - 4199)


### PR DESCRIPTION
- Make DiagnosticsETWProvider thread-safe using Lazy singleton instance and static constructor
- Parameter `DiagEnvironment` is ignored on each logging call, `EnvironmentName` is used instead

This is not a favorable API for the logger, but it seems to be the only way to work with `EventSource`. I'm actively looking for better ways to add a field to every event in a cleaner implementation.