### PR TITLE
Send Additional headers to support CheckAccess ClassAdmin Validation

### DIFF
--- a/src/Diagnostics.DataProviders/ChangeAnalysisClient.cs
+++ b/src/Diagnostics.DataProviders/ChangeAnalysisClient.cs
@@ -11,8 +11,10 @@ using Diagnostics.DataProviders.Interfaces;
 using Diagnostics.DataProviders.TokenService;
 using Diagnostics.Logger;
 using Diagnostics.ModelsAndUtils.Models.ChangeAnalysis;
+using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using static Diagnostics.Logger.HeaderConstants;
+using Diagnostics.Logger; 
 
 namespace Diagnostics.DataProviders
 {
@@ -60,15 +62,21 @@ namespace Diagnostics.DataProviders
         }
 
         /// <summary>
+        /// List of x-ms headers received during an incoming request.
+        /// </summary>
+        public IHeaderDictionary receivedHeaders { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ChangeAnalysisClient"/> class.
         /// </summary>
-        public ChangeAnalysisClient(ChangeAnalysisDataProviderConfiguration configuration, string requestTrackingId, string clientObjectId, string clientPrincipalName = "")
+        public ChangeAnalysisClient(ChangeAnalysisDataProviderConfiguration configuration, string requestTrackingId, string clientObjectId,  IHeaderDictionary incomingRequestHeaders, string clientPrincipalName = "")
         {
             clientObjectIdHeader = clientObjectId;
             clientPrincipalNameHeader = clientPrincipalName;
             changeAnalysisEndPoint = configuration.Endpoint;
             apiVersion = configuration.Apiversion;
             requestId = requestTrackingId;
+            receivedHeaders = incomingRequestHeaders;
         }
 
         /// <inheritdoc/>
@@ -308,6 +316,46 @@ namespace Diagnostics.DataProviders
             if (!string.IsNullOrWhiteSpace(clientPrincipalNameHeader))
             {
                 requestMessage.Headers.Add(ClientPrincipalNameHeader, clientPrincipalNameHeader);
+            }
+
+            string clientIssuer = string.Empty;
+            if(receivedHeaders.ContainsKey(ClientIssuerHeader))
+            {
+                clientIssuer = receivedHeaders[ClientIssuerHeader];
+            }
+            if(!string.IsNullOrWhiteSpace(clientIssuer))
+            {
+                requestMessage.Headers.Add(ClientIssuerHeader, clientIssuer);
+            }
+
+            string clientPuid = string.Empty;
+            if(receivedHeaders.ContainsKey(ClientPuidHeader))
+            {
+                clientPuid = receivedHeaders[ClientPuidHeader];
+            }
+            if(!string.IsNullOrWhiteSpace(clientPuid))
+            {
+                requestMessage.Headers.Add(ClientPuidHeader, clientPuid);
+            }
+
+            string clientAltSecId = string.Empty;
+            if(receivedHeaders.ContainsKey(ClientAltSecIdHeader))
+            {
+                clientAltSecId = receivedHeaders[ClientAltSecIdHeader];
+            }
+            if(!string.IsNullOrWhiteSpace(clientAltSecId))
+            {
+                requestMessage.Headers.Add(ClientAltSecIdHeader, clientAltSecId);
+            }
+
+            string clientIdentityProvider = string.Empty;
+            if(receivedHeaders.ContainsKey(ClientIdentityProviderHeader))
+            {
+                clientIdentityProvider = receivedHeaders[ClientIdentityProviderHeader];
+            }
+            if(!string.IsNullOrWhiteSpace(clientIdentityProvider))
+            {
+                requestMessage.Headers.Add(ClientIdentityProviderHeader, clientIdentityProvider);
             }
 
             if (postBody != null)

--- a/src/Diagnostics.DataProviders/DataProviderContext.cs
+++ b/src/Diagnostics.DataProviders/DataProviderContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using Microsoft.AspNetCore.Http;
 
 namespace Diagnostics.DataProviders
 {
@@ -27,7 +28,12 @@ namespace Diagnostics.DataProviders
         /// </summary>
         public string clientPrincipalName { get; private set; }
 
-        public DataProviderContext(DataSourcesConfiguration dataSourceConfiguration, string requestId = null, CancellationToken dataSourceCancellationToken = default(CancellationToken), DateTime queryStartTime = default(DateTime), DateTime queryEndTime = default(DateTime), IWawsObserverTokenService wawsObserverTokenService = null, ISupportBayApiObserverTokenService supportBayApiObserverTokenService = null, string objectId = "", string principalName = "", IKustoHeartBeatService kustoHeartBeatService = null, string geoMasterHostName = null, string geomasterName = null, string cloudDomain = null)
+        /// <summary>
+        /// List of headers received during an incoming request.
+        /// </summary>
+        public IHeaderDictionary receivedHeaders { get; private set; }
+
+        public DataProviderContext(DataSourcesConfiguration dataSourceConfiguration, string requestId = null, CancellationToken dataSourceCancellationToken = default(CancellationToken), DateTime queryStartTime = default(DateTime), DateTime queryEndTime = default(DateTime), IWawsObserverTokenService wawsObserverTokenService = null, ISupportBayApiObserverTokenService supportBayApiObserverTokenService = null, string objectId = "", string principalName = "", IKustoHeartBeatService kustoHeartBeatService = null, string geoMasterHostName = null, string geomasterName = null, string cloudDomain = null, IHeaderDictionary incomingHeaders = null)
         {
             Configuration = dataSourceConfiguration;
             RequestId = requestId ?? Guid.NewGuid().ToString();
@@ -42,6 +48,7 @@ namespace Diagnostics.DataProviders
             GeomasterHostName = geoMasterHostName;
             GeomasterName = geomasterName;
             CloudDomain = cloudDomain;
+            receivedHeaders = incomingHeaders;
         }
     }
 }

--- a/src/Diagnostics.DataProviders/DataProviders.cs
+++ b/src/Diagnostics.DataProviders/DataProviders.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Diagnostics.DataProviders.Interfaces;
 
+
 namespace Diagnostics.DataProviders
 {
     public class DataProviders
@@ -21,7 +22,7 @@ namespace Diagnostics.DataProviders
             Observer = new ObserverLogDecorator(context, SupportObserverDataProviderFactory.GetDataProvider(_cache, context.Configuration, context));
             GeoMaster = new GeoMasterLogDecorator(context, new GeoMasterDataProvider(_cache, context));
             AppInsights = new AppInsightsLogDecorator(context, new AppInsightsDataProvider(_cache, context.Configuration.AppInsightsConfiguration));
-            ChangeAnalysis = new ChangeAnalysisLogDecorator(context, new ChangeAnalysisDataProvider(_cache, context.Configuration.ChangeAnalysisDataProviderConfiguration, context.RequestId, context.clientObjectId, context.clientPrincipalName, Kusto));
+            ChangeAnalysis = new ChangeAnalysisLogDecorator(context, new ChangeAnalysisDataProvider(_cache, context.Configuration.ChangeAnalysisDataProviderConfiguration, context.RequestId, context.clientObjectId, context.clientPrincipalName, Kusto, context.receivedHeaders));
             Asc = new AscLogDecorator(context, new AscDataProvider(_cache, context.Configuration.AscDataProviderConfiguration, context.RequestId));
             Mdm = (MdmDataSource ds) =>
             {

--- a/src/Diagnostics.DataProviders/DataProviders/ChangeAnalysisDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/ChangeAnalysisDataProvider.cs
@@ -9,6 +9,7 @@ using Diagnostics.DataProviders.Interfaces;
 using Diagnostics.ModelsAndUtils.Models;
 using Diagnostics.ModelsAndUtils.Models.ChangeAnalysis;
 using Diagnostics.Logger;
+using Microsoft.AspNetCore.Http;
 
 namespace Diagnostics.DataProviders
 {
@@ -21,12 +22,12 @@ namespace Diagnostics.DataProviders
         private string dataProviderRequestId;
 
         private IKustoDataProvider kustoDataProvider;
-
-        public ChangeAnalysisDataProvider(OperationDataCache cache, ChangeAnalysisDataProviderConfiguration configuration, string requestId, string clientObjectId, string principalName, IKustoDataProvider kustoDataProvider) : base(cache)
+        
+        public ChangeAnalysisDataProvider(OperationDataCache cache, ChangeAnalysisDataProviderConfiguration configuration, string requestId, string clientObjectId, string principalName, IKustoDataProvider kustoDataProvider, IHeaderDictionary incomingRequestHeaders) : base(cache)
         {
             dataProviderConfiguration = configuration;
             dataProviderRequestId = requestId;
-            changeAnalysisClient = new ChangeAnalysisClient(configuration, requestId, clientObjectId, principalName);
+            changeAnalysisClient = new ChangeAnalysisClient(configuration, requestId, clientObjectId, incomingRequestHeaders, principalName);
             this.kustoDataProvider = kustoDataProvider;
         }
 

--- a/src/Diagnostics.Logger/HeaderConstants.cs
+++ b/src/Diagnostics.Logger/HeaderConstants.cs
@@ -74,5 +74,25 @@ namespace Diagnostics.Logger
         /// Json Content type header.
         /// </summary>
         public static readonly string JsonContentType = "application/json";
+
+        /// <summary>
+        /// Client Issuer header.
+        /// </summary>
+        public static readonly string ClientIssuerHeader = "x-ms-client-issuer";
+
+        /// <summary>
+        /// Client Puid header.
+        /// </summary>
+        public static readonly string ClientPuidHeader = "x-ms-client-puid";
+
+        /// <summary>
+        /// Client Alt SecId header.
+        /// </summary>
+        public static readonly string ClientAltSecIdHeader = "x-ms-client-alt-sec-id";
+
+        /// <summary>
+        /// Client Identity Provider header.
+        /// </summary>
+        public static readonly string ClientIdentityProviderHeader = "x-ms-client-identity-provider";
     }
 }

--- a/src/Diagnostics.RuntimeHost/Middleware/DiagnosticsRequestMiddleware.cs
+++ b/src/Diagnostics.RuntimeHost/Middleware/DiagnosticsRequestMiddleware.cs
@@ -122,7 +122,7 @@ namespace Diagnostics.RuntimeHost.Middleware
                 geomasterName = httpContext.Request.Headers[GeomasterNameHeader];
             }
 
-            httpContext.Items.Add(HostConstants.DataProviderContextKey, new DataProviderContext(dataSourcesConfigurationService.Config, values.FirstOrDefault() ?? string.Empty, cTokenSource.Token, startTimeUtc, endTimeUtc, wawsObserverTokenService, supportBayApiObserverTokenService, clientObjId, clientPrincipalName, kustoHeartBeatService, geomasterHostName, geomasterName));
+            httpContext.Items.Add(HostConstants.DataProviderContextKey, new DataProviderContext(dataSourcesConfigurationService.Config, values.FirstOrDefault() ?? string.Empty, cTokenSource.Token, startTimeUtc, endTimeUtc, wawsObserverTokenService, supportBayApiObserverTokenService, clientObjId, clientPrincipalName, kustoHeartBeatService, geomasterHostName, geomasterName, null, httpContext.Request.Headers));
         }
 
         private void EndRequestHandle(HttpContext httpContext)


### PR DESCRIPTION
Change Analysis API requires 4 additional headers : x-ms-client-issuer, x-ms-client-puid, x-ms-client-alt-sec-id, x-ms-client-identity-provider. 

Passing the incoming request headers from DiagnosticRequestMiddleware to ChangeAnalysisClient which adds these headers.