### PR TITLE
Reduce Bad Requests To Observer Missing Stamp Name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -317,3 +317,5 @@ aot/
 
 # Appsettings file that may contain secrets
 appsettings.*.json
+
+DetectorsCache

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -231,9 +231,7 @@ namespace Diagnostics.DataProviders
         public abstract Task<JArray> GetAdminSitesAsync(string siteName);
 
         public abstract Task<string> GetStorageVolumeForSiteAsync(string stampName, string siteName);
-
-        public abstract Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string siteName);
-
+        
         public abstract Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string stampName, string siteName);
 
         public abstract Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string stampName, string siteName, string slotName);
@@ -245,6 +243,11 @@ namespace Diagnostics.DataProviders
         public DataProviderMetadata GetMetadata()
         {
             return null;
+        }
+
+        public Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string siteName)
+        {
+            throw new NotImplementedException("Cannot retrieve slot map without a stamp name.");
         }
     }
 }

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -244,10 +244,5 @@ namespace Diagnostics.DataProviders
         {
             return null;
         }
-
-        public Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string siteName)
-        {
-            throw new NotImplementedException("Cannot retrieve slot map without a stamp name.");
-        }
     }
 }

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -228,6 +228,8 @@ namespace Diagnostics.DataProviders
 
         public abstract Task<JObject> GetAdminSitesByHostNameAsync(string stampName, string[] hostNames);
 
+        public abstract Task<JArray> GetAdminSitesAsync(string siteName);
+
         public abstract Task<string> GetStorageVolumeForSiteAsync(string stampName, string siteName);
 
         public abstract Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string siteName);

--- a/src/Diagnostics.DataProviders/DataProviders/ISupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/ISupportObserverDataProvider.cs
@@ -47,9 +47,7 @@ namespace Diagnostics.DataProviders
         Task<JObject> GetAdminSitesByHostNameAsync(string stampName, string[] hostNames);
 
         Task<string> GetStorageVolumeForSiteAsync(string stampName, string siteName);
-
-        Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string siteName);
-
+        
         Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string stampName, string siteName);
 
         Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string stampName, string siteName, string slotName);

--- a/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
@@ -192,6 +192,11 @@ namespace Diagnostics.DataProviders
             return new MockHttpClient();
         }
 
+        public override Task<JArray> GetAdminSitesAsync(string siteName)
+        {
+            throw new NotImplementedException();
+        }
+
         private class MockHttpClient : HttpClient
         {
             public MockHttpClient()

--- a/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/MockSupportObserverDataProvider.cs
@@ -20,21 +20,16 @@ namespace Diagnostics.DataProviders
         {
         }
 
-        public override Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string siteName)
-        {
-            return GetRuntimeSiteSlotMap(null, siteName);
-        }
-
         public override Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string stampName, string siteName)
         {
             if (string.IsNullOrWhiteSpace(siteName))
             {
-                throw new ArgumentNullException("siteName");
+                throw new ArgumentNullException(nameof(siteName));
             }
 
             if (string.IsNullOrWhiteSpace(stampName))
             {
-                throw new ArgumentNullException("stampName");
+                throw new ArgumentNullException(nameof(stampName));
             }
 
             var mock = new Dictionary<string, List<RuntimeSitenameTimeRange>>();

--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -39,6 +39,11 @@ namespace Diagnostics.DataProviders
             var path = $"sites/{siteName}/adminsites";
             
             var response = await GetObserverResource(path);
+            if (response == null)
+            {
+                return new JArray();
+            }
+
             var siteObject = JsonConvert.DeserializeObject<JArray>(response);
             return siteObject;
         }

--- a/src/Diagnostics.DataProviders/ObserverLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/ObserverLogDecorator.cs
@@ -45,12 +45,7 @@ namespace Diagnostics.DataProviders
 		{
 			return MakeDependencyCall(DataProvider.GetResource(wawsObserverUrl));
 		}
-
-        public Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string siteName)
-        {
-            throw new NotImplementedException("Cannot retrieve slot map without a stamp name.");
-        }
-
+        
 		public Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string stampName, string siteName)
 		{
 			return MakeDependencyCall(DataProvider.GetRuntimeSiteSlotMap(stampName, siteName));

--- a/src/Diagnostics.DataProviders/ObserverLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/ObserverLogDecorator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
 using Diagnostics.ModelsAndUtils.Models;
@@ -45,10 +46,10 @@ namespace Diagnostics.DataProviders
 			return MakeDependencyCall(DataProvider.GetResource(wawsObserverUrl));
 		}
 
-		public Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string siteName)
-		{
-			return MakeDependencyCall(DataProvider.GetRuntimeSiteSlotMap(siteName));
-		}
+        public Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string siteName)
+        {
+            throw new NotImplementedException("Cannot retrieve slot map without a stamp name.");
+        }
 
 		public Task<Dictionary<string, List<RuntimeSitenameTimeRange>>> GetRuntimeSiteSlotMap(string stampName, string siteName)
 		{
@@ -139,5 +140,5 @@ namespace Diagnostics.DataProviders
 		{
 			return MakeDependencyCall(DataProvider.ExecuteSqlQueryAsync(cloudServiceName, query));
 		}
-	}
+    }
 }

--- a/src/Diagnostics.RuntimeHost/Controllers/ObserverController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ObserverController.cs
@@ -18,12 +18,27 @@ namespace Diagnostics.RuntimeHost.Controllers
         [HttpGet(UriElements.ObserverGetSites)]
         public async Task<IActionResult> GetSiteDetails(string siteName)
         {
+            if (string.IsNullOrWhiteSpace(siteName))
+            {
+                throw new ArgumentNullException(nameof(siteName));
+            }
+
             return await GetResultAsync($"/sites/{siteName}/adminsites");
         }
 
         [HttpGet(UriElements.ObserverGetSiteWithStamp)]
         public async Task<IActionResult> GetSiteWithStampDetails(string stampName, string siteName)
         {
+            if (string.IsNullOrWhiteSpace(stampName))
+            {
+                throw new ArgumentNullException(nameof(stampName));
+            }
+
+            if (string.IsNullOrWhiteSpace(siteName))
+            {
+                throw new ArgumentNullException(nameof(siteName));
+            }
+
             return await GetResultAsync($"/stamps/{stampName}/sites/{siteName}/adminsites");
         }
 

--- a/src/Diagnostics.RuntimeHost/Controllers/ObserverController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ObserverController.cs
@@ -18,27 +18,12 @@ namespace Diagnostics.RuntimeHost.Controllers
         [HttpGet(UriElements.ObserverGetSites)]
         public async Task<IActionResult> GetSiteDetails(string siteName)
         {
-            if (string.IsNullOrWhiteSpace(siteName))
-            {
-                throw new ArgumentNullException(nameof(siteName));
-            }
-
             return await GetResultAsync($"/sites/{siteName}/adminsites");
         }
 
         [HttpGet(UriElements.ObserverGetSiteWithStamp)]
         public async Task<IActionResult> GetSiteWithStampDetails(string stampName, string siteName)
         {
-            if (string.IsNullOrWhiteSpace(stampName))
-            {
-                throw new ArgumentNullException(nameof(stampName));
-            }
-
-            if (string.IsNullOrWhiteSpace(siteName))
-            {
-                throw new ArgumentNullException(nameof(siteName));
-            }
-
             return await GetResultAsync($"/stamps/{stampName}/sites/{siteName}/adminsites");
         }
 


### PR DESCRIPTION
- Use GetAdminSites instead of GetSite for faster stamp name lookup
- Reduce 404 requests to Observer by requiring stamp name for GET RuntimeSiteSlotMap
  - Observer does not accept requests to this route without a stamp name
- Check for null or empty stamp name inputs before sending Observer requests to prevent 404 response
  - The route `/api/stamps/sites/{sitename}/{resource}` was commonly created, causing 404 responses