### PR TITLE
Make kusto client request id's unique to aid in investigation

### DIFF
--- a/src/Diagnostics.DataProviders/KustoClient.cs
+++ b/src/Diagnostics.DataProviders/KustoClient.cs
@@ -76,7 +76,7 @@ namespace Diagnostics.DataProviders
                 csl = query,
                 properties = new
                 {
-                    ClientRequestId = kustoClientId,
+                    ClientRequestId = $"{kustoClientId}_{(new Guid()).ToString()}",
                     Options = new
                     {
                         servertimeout = new TimeSpan(0, 1, 0)


### PR DESCRIPTION
Append a new Guid to ClientRequestId to make the request id unique in Kusto. This helps in investigating Kusto issues by the Kusto team.

Intentionally creating a new request id only while sending the request to Kusto without impacting the logging so that we don't need to change any of our exiting dashboards / monitoring.