### PR TITLE
Changed in with in~ for case insensitive comparison of hostnames.

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/ScriptUtilities/Utilities.cs
+++ b/src/Diagnostics.ModelsAndUtils/ScriptUtilities/Utilities.cs
@@ -112,7 +112,7 @@ namespace Diagnostics.ModelsAndUtils.ScriptUtilities
 
             if (nonWildCardHostNames.Any())
             {
-                hostNameQuery = $"{hostNameColumn} in ({string.Join(",", nonWildCardHostNames.Select(h => $@"""{h}"""))})";
+                hostNameQuery = $"{hostNameColumn} in~ ({string.Join(",", nonWildCardHostNames.Select(h => $@"""{h}"""))})";
             }
 
             if (wildCardHostNames.Any())


### PR DESCRIPTION
There are times when the site is browsed with upper / lower case characters in the hostname and we log the case as is in Kusto. The where clause in queries fails for such instances.