### PR TITLE
Nmallick1/utilize kusto query cache

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/SiteService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/SiteService.cs
@@ -22,7 +22,8 @@ namespace Diagnostics.RuntimeHost.Services
             if (string.IsNullOrWhiteSpace(siteName)) throw new ArgumentNullException("siteName");
 
             string queryTemplate =
-                $@"WawsAn_dailyentity
+                $@"set query_results_cache_max_age = time(12h);
+                WawsAn_dailyentity
                 | where pdate >= ago(5d) and sitename =~ ""{siteName}"" and sitesubscription =~ ""{subscriptionId}"" and resourcegroup =~ ""{resourceGroup}""
                 | where sitestack !contains ""unknown"" and sitestack !contains ""no traffic"" and sitestack  !contains ""undefined""
                 | top 1 by pdate desc

--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/SiteService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/SiteService.cs
@@ -22,7 +22,7 @@ namespace Diagnostics.RuntimeHost.Services
             if (string.IsNullOrWhiteSpace(siteName)) throw new ArgumentNullException("siteName");
 
             string queryTemplate =
-                $@"set query_results_cache_max_age = time(12h);
+                $@"set query_results_cache_max_age = time(1d);
                 WawsAn_dailyentity
                 | where pdate >= ago(5d) and sitename =~ ""{siteName}"" and sitesubscription =~ ""{subscriptionId}"" and resourcegroup =~ ""{resourceGroup}""
                 | where sitestack !contains ""unknown"" and sitestack !contains ""no traffic"" and sitestack  !contains ""undefined""

--- a/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/ResourceService/StampService.cs
@@ -115,7 +115,8 @@ namespace Diagnostics.RuntimeHost.Services
             string megaStampRegexPublicHost = $"{stamp}([a-z{{1}}]).cloudapp.net";
             string vmssRegexPublicHost = $"{stamp}-([a-z0-9\\\\.]+).cloudapp.azure.com";
             return
-                $@"{tableName}
+                $@"set query_results_cache_max_age = time(1d);
+                {tableName}
                 | where TIMESTAMP >= datetime({startTimeStr}) and TIMESTAMP <= datetime({endTimeStr})
                 | where PublicHost =~ ""{stamp}.cloudapp.net"" or PublicHost matches regex ""{megaStampRegexPublicHost}"" or PublicHost matches regex ""{vmssRegexPublicHost}""
                 | summarize by Tenant, PublicHost";


### PR DESCRIPTION
Updating some of our queries to utilize Kusto query caching. The caching is enabled only on wawseusfollower.

Once we are sure that things are working, we can replicate the changes across regions.