### PR TITLE
Fix Guid creation in Kusto client request id generation

### DIFF
--- a/src/Diagnostics.DataProviders/KustoClient.cs
+++ b/src/Diagnostics.DataProviders/KustoClient.cs
@@ -64,7 +64,7 @@ namespace Diagnostics.DataProviders
         {
             var timeTakenStopWatch = new Stopwatch();
             var authorizationToken = await KustoTokenService.Instance.GetAuthorizationTokenAsync();
-            var kustoClientId = $"Diagnostics.{operationName ?? "Query"};{_requestId}##{0}_{(new Guid()).ToString()}";
+            var kustoClientId = $"Diagnostics.{operationName ?? "Query"};{_requestId}##{0}_{Guid.NewGuid().ToString()}";
             var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
             var request = new HttpRequestMessage(HttpMethod.Post, KustoApiQueryEndpoint.Replace("{cluster}", cluster));            
             request.Headers.Add("Authorization", authorizationToken);


### PR DESCRIPTION
Changed to using the Static NewGuid method to create an actual Guid instead of an empty Guid object.