### PR TITLE
Refactor GeoMasterDataProvider

### DIFF
--- a/src/Diagnostics.DataProviders/ArmClient.cs
+++ b/src/Diagnostics.DataProviders/ArmClient.cs
@@ -7,22 +7,24 @@ namespace Diagnostics.DataProviders
     internal class ArmClient : IGeoMasterClient
     {
         private const string CsmEndpointUrl = "https://management.azure.com/";
-        public HttpClient Client { get; }
-        public Uri BaseUri { get; }
+        private static readonly HttpClient _client = new HttpClient();
+        public HttpClient Client => _client;
+        public Uri BaseUri => _client.BaseAddress;
+        public string AuthenticationToken { get; }
+
+        static ArmClient()
+        {
+            _client.BaseAddress = new Uri(CsmEndpointUrl);
+            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        }
 
         public ArmClient(GeoMasterDataProviderConfiguration configuration)
         {
-            var handler = new HttpClientHandler();
-            BaseUri = new Uri(CsmEndpointUrl);
-
-            Client = new HttpClient(handler)
+            if (configuration.Token == null)
             {
-                BaseAddress = BaseUri
-            };
-
-            Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", configuration.Token);
-            Client.BaseAddress = BaseUri;
+                throw new ArgumentNullException("NULL TOKEN!!");
+            }
+            this.AuthenticationToken = configuration.Token;
         }
     }
 }

--- a/src/Diagnostics.DataProviders/ArmClient.cs
+++ b/src/Diagnostics.DataProviders/ArmClient.cs
@@ -20,9 +20,9 @@ namespace Diagnostics.DataProviders
 
         public ArmClient(GeoMasterDataProviderConfiguration configuration)
         {
-            if (configuration.Token == null)
+            if (string.IsNullOrWhiteSpace(configuration.Token))
             {
-                throw new ArgumentException("configuration.Token is null");
+                throw new ArgumentException("configuration.Token is null or empty");
             }
             this.AuthenticationToken = configuration.Token;
         }

--- a/src/Diagnostics.DataProviders/ArmClient.cs
+++ b/src/Diagnostics.DataProviders/ArmClient.cs
@@ -22,7 +22,7 @@ namespace Diagnostics.DataProviders
         {
             if (configuration.Token == null)
             {
-                throw new ArgumentNullException("NULL TOKEN!!");
+                throw new ArgumentException("configuration.Token is null");
             }
             this.AuthenticationToken = configuration.Token;
         }

--- a/src/Diagnostics.DataProviders/ConfigurationFactory.cs
+++ b/src/Diagnostics.DataProviders/ConfigurationFactory.cs
@@ -107,6 +107,16 @@ namespace Diagnostics.DataProviders
                         return string.Empty;
                 }
             }
+            else if (prefix == "GeoMaster")
+            {
+                switch (name)
+                {
+                    case "Token":
+                        return "DUMMYTOKEN";
+                    default:
+                        return string.Empty;
+                }
+            }
 
             return string.Empty;
         }

--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -584,11 +584,12 @@ namespace Diagnostics.DataProviders
         private async Task<R> PerformHttpRequest<R>(HttpMethod method, string path, string queryString, string content, string apiVersion, CancellationToken cancellationToken)
         {
             var query = SitePathUtility.CsmAnnotateQueryString(queryString, apiVersion);
+            var uri = new Uri(_geoMasterClient.BaseUri, path + query);
             HttpResponseMessage response = null;
 
             try
             {
-                using (var request = new HttpRequestMessage(method, path + query))
+                using (var request = new HttpRequestMessage(method, uri))
                 {
                     try
                     {

--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -112,9 +113,9 @@ namespace Diagnostics.DataProviders
             return appSettings;
         }
 
-        public async Task<IDictionary<string, string>> GetAppSettings(string subscriptionId, string resourceGroupName, string name)
+        public Task<IDictionary<string, string>> GetAppSettings(string subscriptionId, string resourceGroupName, string name)
         {
-            return await GetAppSettings(subscriptionId, resourceGroupName, name, GeoMasterConstants.ProductionSlot);
+            return GetAppSettings(subscriptionId, resourceGroupName, name, GeoMasterConstants.ProductionSlot);
         }
 
         /// <summary>
@@ -200,12 +201,11 @@ namespace Diagnostics.DataProviders
         /// }
         /// </code>
         /// </example>
-        public async Task<VnetValidationRespone> VerifyHostingEnvironmentVnet(string subscriptionId, string vnetResourceGroup, string vnetName, string vnetSubnetName, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<VnetValidationRespone> VerifyHostingEnvironmentVnet(string subscriptionId, string vnetResourceGroup, string vnetName, string vnetSubnetName, CancellationToken cancellationToken = default(CancellationToken))
         {
             var path = string.Format(@"subscriptions/{0}/providers/Microsoft.Web/verifyHostingEnvironmentVnet", subscriptionId);
             var vnetParameters = new VnetParameters { VnetResourceGroup = vnetResourceGroup, VnetName = vnetName, VnetSubnetName = vnetSubnetName };
-            var result = await HttpPost<VnetValidationRespone, VnetParameters>(path, vnetParameters, "", GeoMasterConstants.March2016Version, cancellationToken);
-            return result;
+            return HttpPost<VnetValidationRespone, VnetParameters>(path, vnetParameters, "", GeoMasterConstants.March2016Version, cancellationToken);
         }
 
         /// <summary>
@@ -242,12 +242,11 @@ namespace Diagnostics.DataProviders
         /// }
         /// </code>
         /// </example>
-        public async Task<VnetConfiguration> CollectVirtualNetworkConfig(string subscriptionId, string vnetResourceGroup, string vnetName, string vnetSubnetName, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<VnetConfiguration> CollectVirtualNetworkConfig(string subscriptionId, string vnetResourceGroup, string vnetName, string vnetSubnetName, CancellationToken cancellationToken = default(CancellationToken))
         {
             var path = string.Format("subscriptions/{0}/providers/Microsoft.Web/collectVnetConfiguration", subscriptionId);
             var vnetParameters = new VnetParameters { VnetResourceGroup = vnetResourceGroup, VnetName = vnetName, VnetSubnetName = vnetSubnetName };
-            var result = await HttpPost<VnetConfiguration, VnetParameters>(path, vnetParameters, "", GeoMasterConstants.March2016Version, cancellationToken);
-            return result;
+            return HttpPost<VnetConfiguration, VnetParameters>(path, vnetParameters, "", GeoMasterConstants.March2016Version, cancellationToken);
         }
 
         /// <summary>
@@ -301,9 +300,9 @@ namespace Diagnostics.DataProviders
             return deployments;
         }
 
-        public async Task<List<IDictionary<string, dynamic>>> GetAppDeployments(string subscriptionId, string resourceGroupName, string name)
+        public Task<List<IDictionary<string, dynamic>>> GetAppDeployments(string subscriptionId, string resourceGroupName, string name)
         {
-            return await GetAppDeployments(subscriptionId, resourceGroupName, name, GeoMasterConstants.ProductionSlot);
+            return GetAppDeployments(subscriptionId, resourceGroupName, name, GeoMasterConstants.ProductionSlot);
         }
 
         /// <summary>
@@ -367,7 +366,7 @@ namespace Diagnostics.DataProviders
         /// }
         /// </code>
         /// </example>
-        public async Task<T> MakeHttpGetRequest<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string path = "")
+        public Task<T> MakeHttpGetRequest<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string path = "")
         {
             if (!string.IsNullOrWhiteSpace(path))
             {
@@ -382,13 +381,12 @@ namespace Diagnostics.DataProviders
                 path = $"{SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name)}/{path}";
             }
 
-            var geoMasterResponse = await HttpGet<T>(path);
-            return geoMasterResponse;
+            return HttpGet<T>(path);
         }
 
-        public async Task<T> MakeHttpGetRequest<T>(string subscriptionId, string resourceGroupName, string name, string path = "")
+        public Task<T> MakeHttpGetRequest<T>(string subscriptionId, string resourceGroupName, string name, string path = "")
         {
-            return await MakeHttpGetRequest<T>(subscriptionId, resourceGroupName, name, GeoMasterConstants.ProductionSlot, path);
+            return MakeHttpGetRequest<T>(subscriptionId, resourceGroupName, name, GeoMasterConstants.ProductionSlot, path);
         }
 
         /// <summary>
@@ -442,15 +440,14 @@ namespace Diagnostics.DataProviders
         /// </code>
         /// </example>
         /// <returns></returns>
-        public async Task<T> MakeHttpGetRequestWithFullPath<T>(string fullPath, string queryString = "", string apiVersion = GeoMasterConstants.August2016Version)
+        public Task<T> MakeHttpGetRequestWithFullPath<T>(string fullPath, string queryString = "", string apiVersion = GeoMasterConstants.August2016Version)
         {
             if (string.IsNullOrWhiteSpace(fullPath))
             {
-                throw new ArgumentNullException("fullPath");
+                throw new ArgumentNullException(nameof(fullPath));
             }
 
-            var geoMasterResponse = await HttpGet<T>(fullPath, queryString, apiVersion);
-            return geoMasterResponse;
+            return HttpGet<T>(fullPath, queryString, apiVersion);
         }
 
         /// <summary>
@@ -478,11 +475,10 @@ namespace Diagnostics.DataProviders
         /// </code>
         /// </example>
         /// <returns></returns>
-        public async Task<string> GetLinuxContainerLogs(string subscriptionId, string resourceGroupName, string name, string slotName)
+        public Task<string> GetLinuxContainerLogs(string subscriptionId, string resourceGroupName, string name, string slotName)
         {
             string path = $"{SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name, slotName)}/containerlogs";
-            var geoMasterResponse = await HttpPost<string, string>(path);
-            return geoMasterResponse;
+            return HttpPost<string, string>(path);
         }
 
         /// <summary>
@@ -513,16 +509,15 @@ namespace Diagnostics.DataProviders
         /// </code>
         /// </example>
         /// <returns></returns>
-        private async Task<T> InvokeSiteExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string extension, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
+        private Task<T> InvokeSiteExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string extension, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrWhiteSpace(extension))
             {
                 throw new ArgumentNullException(nameof(extension));
             }
 
-            string path = SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name, slotName) + SiteExtensionResource.Replace("{*extensionApiMethod}", extension);
-            var result = await HttpGet<T>(path, string.Empty, apiVersion, cancellationToken);
-            return result;
+            string path = SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name, slotName) + SiteExtensionResource.Replace("{*extensionApiMethod}", extension, StringComparison.CurrentCultureIgnoreCase);
+            return HttpGet<T>(path, string.Empty, apiVersion, cancellationToken);
         }
 
         /// <summary>
@@ -554,7 +549,7 @@ namespace Diagnostics.DataProviders
         /// </code>
         /// </example>
         /// <returns></returns>
-        public async Task<T> InvokeDaasExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string daasApiPath, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<T> InvokeDaasExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string daasApiPath, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrWhiteSpace(daasApiPath))
             {
@@ -569,72 +564,78 @@ namespace Diagnostics.DataProviders
             string extensionPath = $"daas/{daasApiPath}";
 
             string path = SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name, slotName) + SiteExtensionResource.Replace("{*extensionApiMethod}", extensionPath);
-            var result = await HttpGet<T>(path, string.Empty, apiVersion, cancellationToken);
-            return result;
+            return HttpGet<T>(path, string.Empty, apiVersion, cancellationToken);
         }
 
         #region HttpMethods
 
-        private async Task<R> HttpGet<R>(string path, string queryString = "", string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
+        private Task<R> HttpGet<R>(string path, string queryString = "", string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var query = SitePathUtility.CsmAnnotateQueryString(queryString, apiVersion);
-            var response = new HttpResponseMessage();
-
-            try
-            {
-                var uri = path + query;
-                response = await _geoMasterClient.Client.GetAsync(uri, cancellationToken);
-                response.EnsureSuccessStatusCode();
-            }
-            catch (TaskCanceledException)
-            {
-                if (cancellationToken != default(CancellationToken))
-                {
-                    throw new DataSourceCancelledException();
-                }
-                //if any task cancelled without provided cancellation token - we want capture exception in datasourcemanager
-                throw;
-            }
-
-            if (typeof(R) == typeof(string))
-            {
-                return (await response.Content.ReadAsStringAsync()).CastTo<R>();
-            }
-            string responseContent = await response.Content.ReadAsStringAsync();
-            R value = JsonConvert.DeserializeObject<R>(responseContent);
-            return value;
+            return PerformHttpRequest<R>(HttpMethod.Get, path, queryString, null, apiVersion, cancellationToken);
         }
 
-        private async Task<R> HttpPost<R, T>(string path, T content = default(T), string queryString = "", string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
+        private Task<R> HttpPost<R, T>(string path, T content = default(T), string queryString = "", string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var body = JsonConvert.SerializeObject(content);
+            return PerformHttpRequest<R>(HttpMethod.Post, path, queryString, body, apiVersion, cancellationToken);
+        }
+
+
+        private async Task<R> PerformHttpRequest<R>(HttpMethod method, string path, string queryString, string content, string apiVersion, CancellationToken cancellationToken)
         {
             var query = SitePathUtility.CsmAnnotateQueryString(queryString, apiVersion);
-            var response = new HttpResponseMessage();
+            HttpResponseMessage response = null;
 
             try
             {
-                var uri = path + query;
-                var body = JsonConvert.SerializeObject(content);
-                response = await _geoMasterClient.Client.PostAsync(uri, new StringContent(body, Encoding.UTF8, "application/json"), cancellationToken);
-                response.EnsureSuccessStatusCode();
-            }
-            catch (TaskCanceledException)
-            {
-                if (cancellationToken != default(CancellationToken))
+                using (var request = new HttpRequestMessage(method, path + query))
                 {
-                    throw new DataSourceCancelledException();
+                    try
+                    {
+                        if (method == HttpMethod.Post || method == HttpMethod.Put)
+                        {
+                            request.Content = new StringContent(content, Encoding.UTF8, "application/json");
+                        }
+
+                        var token = _geoMasterClient.AuthenticationToken;
+                        if (!string.IsNullOrWhiteSpace(token))
+                        {
+                            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                        }
+                        response = await _geoMasterClient.Client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                        response.EnsureSuccessStatusCode();
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        if (cancellationToken != default(CancellationToken))
+                        {
+                            throw new DataSourceCancelledException();
+                        }
+                        //if any task cancelled without provided cancellation token - we want capture exception in datasourcemanager
+                        throw;
+                    }
                 }
-                //if any task cancelled without provided cancellation token - we want capture exception in datasourcemanager
-                throw;
-            }
 
-            if (typeof(R) == typeof(string))
+                R value;
+
+                if (typeof(R) == typeof(string))
+                {
+                    value = (await response.Content.ReadAsStringAsync().ConfigureAwait(false)).CastTo<R>();
+                }
+                else
+                {
+                    string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    value = JsonConvert.DeserializeObject<R>(responseContent);
+                }
+                return value;
+            }
+            finally
             {
-                return (await response.Content.ReadAsStringAsync()).CastTo<R>();
+                if (response != null)
+                {
+                    response.Dispose();
+                }
             }
-
-            string responseContent = await response.Content.ReadAsStringAsync();
-            R value = JsonConvert.DeserializeObject<R>(responseContent);
-            return value;
         }
 
         public DataProviderMetadata GetMetadata()

--- a/src/Diagnostics.DataProviders/GeoMasterCertClient.cs
+++ b/src/Diagnostics.DataProviders/GeoMasterCertClient.cs
@@ -31,7 +31,6 @@ namespace Diagnostics.DataProviders
             };
 
             BaseUri = geoEndpoint.Uri;
-            _httpClient.BaseAddress = BaseUri;
         }
 
         public HttpClient Init(GeoMasterDataProviderConfiguration configuration)
@@ -54,7 +53,6 @@ namespace Diagnostics.DataProviders
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(HeaderConstants.JsonContentType));
             httpClient.DefaultRequestHeaders.Add(HeaderConstants.UserAgentHeaderName, "appservice-diagnostics");
             httpClient.Timeout = TimeSpan.FromSeconds(30);
-            httpClient.BaseAddress = BaseUri;
 
             return httpClient;
         }

--- a/src/Diagnostics.DataProviders/Interfaces/IGeoMasterClient.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IGeoMasterClient.cs
@@ -7,5 +7,6 @@ namespace Diagnostics.DataProviders
     {
         HttpClient Client { get; }
         Uri BaseUri { get; }
+        string AuthenticationToken { get; }
     }
 }

--- a/src/Diagnostics.DataProviders/TokenService/TokenServiceBase.cs
+++ b/src/Diagnostics.DataProviders/TokenService/TokenServiceBase.cs
@@ -99,6 +99,10 @@ namespace Diagnostics.DataProviders.TokenService
         {
             if (!tokenAcquiredAtleastOnce)
             {
+                while (acquireTokenTask == null)
+                {
+                    await Task.Delay(1000);
+                }
                 var authResult = await acquireTokenTask;
                 return GetAuthTokenFromAuthenticationResult(authResult);
             }

--- a/src/Diagnostics.DataProviders/TokenService/TokenServiceBase.cs
+++ b/src/Diagnostics.DataProviders/TokenService/TokenServiceBase.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Diagnostics.Logger;
+using Diagnostics.DataProviders.Utility;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Diagnostics.DataProviders.TokenService
@@ -15,7 +16,7 @@ namespace Diagnostics.DataProviders.TokenService
     public abstract class TokenServiceBase
     {
         private Task<AuthenticationResult> acquireTokenTask;
-        private readonly ManualResetEvent tokenAcquiredAtleastOnce = new ManualResetEvent(false);
+        private readonly AsyncManualResetEvent tokenAcquiredAtleastOnce = new AsyncManualResetEvent();
 
         /// <summary>
         /// Gets AAD issued auth token.
@@ -98,7 +99,7 @@ namespace Diagnostics.DataProviders.TokenService
         /// </summary>
         public async Task<string> GetAuthorizationTokenAsync()
         {
-            tokenAcquiredAtleastOnce.WaitOne();
+            await tokenAcquiredAtleastOnce.WaitAsync().ConfigureAwait(false);
             return AuthorizationToken;
         }
 

--- a/src/Diagnostics.DataProviders/Utility/AsyncMaualResetEvent.cs
+++ b/src/Diagnostics.DataProviders/Utility/AsyncMaualResetEvent.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Diagnostics.DataProviders.Utility
+{
+    // Quote from https://devblogs.microsoft.com/pfxteam/building-async-coordination-primitives-part-1-asyncmanualresetevent/
+    public sealed class AsyncManualResetEvent
+    {
+        private volatile TaskCompletionSource<bool> m_tcs = new TaskCompletionSource<bool>();
+        public Task WaitAsync() { return m_tcs.Task; }
+        public void Set() { m_tcs.TrySetResult(true); }
+
+        public void Reset()
+        {
+            while (true)
+            {
+                var tcs = m_tcs;
+                if (!tcs.Task.IsCompleted ||
+                    Interlocked.CompareExchange(ref m_tcs, new TaskCompletionSource<bool>(), tcs) == tcs)
+                    return;
+            }
+        }
+    }
+}

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Win32;
 using System;
+using System.Diagnostics;
 
 namespace Diagnostics.RuntimeHost
 {
@@ -22,6 +23,14 @@ namespace Diagnostics.RuntimeHost
         {
             Configuration = configuration;
             Environment = environment;
+
+            if (!Environment.IsProduction())
+            {
+                AppDomain.CurrentDomain.FirstChanceException += (sender, eventArgs) =>
+                {
+                    Debug.WriteLine(eventArgs.Exception.ToString());
+                };
+            }
         }
 
         public IConfiguration Configuration { get; }


### PR DESCRIPTION
This PR refactors GeoMasterDataProvider to remove frequent HttpClient constructions/destructions. It should reduce the number of socket open/close operations and lower the chance of SNAT port exhaustions. This PR also enables to log the full stack traces for first level exceptions.

There was an issue where lots of NullReferenceExceptions happening in the first 20 seconds when the project starts up. This was due to a race condition of the TokenServiceBase class initialization. This PR fixes it by waiting for a property to be populated.
