### PR TITLE
Add GetLogFolderZip API to GeoMasterDataProvider

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -25,7 +25,7 @@ namespace Diagnostics.DataProviders
             var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(HeaderConstants.OctetStreamContentType));
-            httpClient.DefaultRequestHeaders.Add(HeaderConstants.UserAgentHeaderName, "appservice-diagnostics");
+            httpClient.DefaultRequestHeaders.Add(HeaderConstants.UserAgentHeaderName, HeaderConstants.UserAgentHeaderValue);
             httpClient.Timeout = TimeSpan.FromSeconds(30);
 
             return httpClient;
@@ -493,17 +493,16 @@ namespace Diagnostics.DataProviders
         }
 
         /// <summary>
-        /// Gets all the APP SETTINGS for the Web App that start with prefixes like WEBSITE_, FUNCTION_ etc, filtering out
-        /// the sensitive settings like connectionstrings, tokens, secrets, keys, content shares etc.
+        /// Downloads the zipped contents under app's /home/LogFiles directory as a byte array.
         /// </summary>
         /// <param name="subscriptionId">Subscription Id for the resource</param>
         /// <param name="resourceGroupName">The resource group that the resource is part of </param>
         /// <param name="name">Name of the resource</param>
         /// <param name="slotName">slot name (if querying for a slot, defaults to production slot)</param>
-        /// <returns>A dictionary of AppSetting Keys and values</returns>
+        /// <returns>A byte array of zipped contents under /home/LogFiles</returns>
         /// <example>
         /// <code>
-        /// This sample shows how to call the <see cref="GetAppSettings"/> method in a detector
+        /// This sample shows how to call the <see cref="GetLogFolderZip"/> method in a detector
         /// public async static Task<![CDATA[<Response>]]> Run(DataProviders dp, OperationContext<![CDATA[<App>]]> cxt, Response res)
         /// {
         ///     var subId = cxt.Resource.SubscriptionId;
@@ -512,6 +511,29 @@ namespace Diagnostics.DataProviders
         ///     var slot = cxt.Resource.Slot;
         ///
         ///     byte[] zip = await dp.GeoMaster.GetLogFilesZip(subId, rg, name, slot);
+        /// 
+        ///     using (MemoryStream ms = new MemoryStream(zipBytes))
+        ///     {
+        ///         using (ZipArchive ar = new ZipArchive(ms))
+        ///         {
+        ///             foreach(var e in ar.Entries)
+        ///             {
+        ///                 // Find Linux log files
+        ///                 var m = Regex.Match(e.Name, @"^\d{4}_\d\d_\d\d_RD[0-9a-fA-F]+.*.log");
+        ///                 if (m.Success)
+        ///                 {
+        ///                     using (var fs = e.Open())
+        ///                     {
+        ///                         using (var sr = new StreamReader(fs))
+        ///                         {
+        ///                             var body = sr.ReadToEnd();
+        ///                             // Do what you want with the log file
+        ///                         }
+        ///                     }
+        ///                 }
+        ///             }
+        ///         }
+        ///     }
         /// }
         /// </code>
         /// </example>

--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -510,29 +510,36 @@ namespace Diagnostics.DataProviders
         ///     var name = cxt.Resource.Name;
         ///     var slot = cxt.Resource.Slot;
         ///
-        ///     byte[] zip = await dp.GeoMaster.GetLogFilesZip(subId, rg, name, slot);
-        /// 
-        ///     using (MemoryStream ms = new MemoryStream(zipBytes))
+        ///     try
         ///     {
-        ///         using (ZipArchive ar = new ZipArchive(ms))
+        ///         byte[] zip = await dp.GeoMaster.GetLogFilesZip(subId, rg, name, slot);
+        /// 
+        ///         using (MemoryStream ms = new MemoryStream(zipBytes))
         ///         {
-        ///             foreach(var e in ar.Entries)
+        ///             using (ZipArchive ar = new ZipArchive(ms))
         ///             {
-        ///                 // Find Linux log files
-        ///                 var m = Regex.Match(e.Name, @"^\d{4}_\d\d_\d\d_RD[0-9a-fA-F]+.*.log");
-        ///                 if (m.Success)
+        ///                 foreach(var e in ar.Entries)
         ///                 {
-        ///                     using (var fs = e.Open())
+        ///                     // Find Linux log files
+        ///                     var m = Regex.Match(e.Name, @"^\d{4}_\d\d_\d\d_RD[0-9a-fA-F]+.*.log");
+        ///                     if (m.Success)
         ///                     {
-        ///                         using (var sr = new StreamReader(fs))
+        ///                         using (var fs = e.Open())
         ///                         {
-        ///                             var body = sr.ReadToEnd();
-        ///                             // Do what you want with the log file
+        ///                             using (var sr = new StreamReader(fs))
+        ///                             {
+        ///                                 var body = sr.ReadToEnd();
+        ///                                 // Do what you want with the log file
+        ///                             }
         ///                         }
         ///                     }
         ///                 }
         ///             }
         ///         }
+        ///     }
+        ///     catch(Exception)
+        ///     {
+        ///         // Error handling
         ///     }
         /// }
         /// </code>

--- a/src/Diagnostics.DataProviders/GeoMasterCertClient.cs
+++ b/src/Diagnostics.DataProviders/GeoMasterCertClient.cs
@@ -51,7 +51,7 @@ namespace Diagnostics.DataProviders
             var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(HeaderConstants.JsonContentType));
-            httpClient.DefaultRequestHeaders.Add(HeaderConstants.UserAgentHeaderName, "appservice-diagnostics");
+            httpClient.DefaultRequestHeaders.Add(HeaderConstants.UserAgentHeaderName, HeaderConstants.UserAgentHeaderValue);
             httpClient.Timeout = TimeSpan.FromSeconds(30);
 
             return httpClient;

--- a/src/Diagnostics.DataProviders/GeoMasterLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/GeoMasterLogDecorator.cs
@@ -61,6 +61,11 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(DataProvider.GetLinuxContainerLogs(subscriptionId, resourceGroupName, name, slotName));
         }
 
+        public Task<byte[]> GetLogFolderZip(string subscriptionId, string resourceGroupName, string name, string slotName)
+        {
+            return MakeDependencyCall(DataProvider.GetLogFolderZip(subscriptionId, resourceGroupName, name, slotName));
+        }
+
         public Task<T> InvokeDaasExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string daasApiPath, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
         {
             return MakeDependencyCall(DataProvider.InvokeDaasExtension<T>(subscriptionId, resourceGroupName, name, slotName, daasApiPath, apiVersion, cancellationToken));

--- a/src/Diagnostics.DataProviders/Interfaces/IGeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IGeoMasterDataProvider.cs
@@ -31,6 +31,8 @@ namespace Diagnostics.DataProviders
 
         Task<string> GetLinuxContainerLogs(string subscriptionId, string resourceGroupName, string name, string slotName);
 
+        Task<byte[]> GetLogFolderZip(string subscriptionId, string resourceGroupName, string name, string slotName);
+
         Task<T> InvokeDaasExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string daasApiPath, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Diagnostics.DataProviders/KustoClient.cs
+++ b/src/Diagnostics.DataProviders/KustoClient.cs
@@ -69,7 +69,7 @@ namespace Diagnostics.DataProviders
             var request = new HttpRequestMessage(HttpMethod.Post, KustoApiQueryEndpoint.Replace("{cluster}", cluster));            
             request.Headers.Add("Authorization", authorizationToken);
             request.Headers.Add(HeaderConstants.ClientRequestIdHeader, kustoClientId ?? Guid.NewGuid().ToString());
-            request.Headers.UserAgent.ParseAdd("appservice-diagnostics");
+            request.Headers.UserAgent.ParseAdd(HeaderConstants.UserAgentHeaderValue);
             var requestPayload = new
             {
                 db = database,

--- a/src/Diagnostics.Logger/HeaderConstants.cs
+++ b/src/Diagnostics.Logger/HeaderConstants.cs
@@ -99,5 +99,10 @@ namespace Diagnostics.Logger
         /// Client Identity Provider header.
         /// </summary>
         public static readonly string ClientIdentityProviderHeader = "x-ms-client-identity-provider";
+
+        /// <summary>
+        /// User Agent value for App Service Diagnostics.
+        /// </summary>
+        public static readonly string UserAgentHeaderValue = "appservice-diagnostics";
     }
 }

--- a/src/Diagnostics.Logger/HeaderConstants.cs
+++ b/src/Diagnostics.Logger/HeaderConstants.cs
@@ -76,6 +76,11 @@ namespace Diagnostics.Logger
         public static readonly string JsonContentType = "application/json";
 
         /// <summary>
+        /// Binary Content type header.
+        /// </summary>
+        public static readonly string OctetStreamContentType = "application/octet-stream";
+
+        /// <summary>
         /// Client Issuer header.
         /// </summary>
         public static readonly string ClientIssuerHeader = "x-ms-client-issuer";


### PR DESCRIPTION
This PR adds a new method named GetLogFolderZip to the GeoMasterDataProvider. This new method allows detectors to download the entire contents under app's /home/LogFiles as a zipped binary image. Detectors can unzip and read log files from it. Typical use cases include php log analysis, dotnet log analysis, getting logs older than 10 days, etc.