### PR TITLE
Clearer Logic For Pulling Stamp Name From AdminSites

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -217,8 +217,8 @@ namespace Diagnostics.DataProviders
             var stampNameObjects = objects.Where(x => x.ContainsKey("StampName") && !string.IsNullOrWhiteSpace(x["StampName"].ToString()));
             if (stampNameObjects.Any())
                 return stampNameObjects.First()["StampName"].ToString();
-
-            throw new Exception($"Admin Sites response did not contain stamp name for site {siteName}");
+            
+            throw new Exception($"Admin Sites response did not contain stamp name for site {siteName}. Admin Sites response: {siteObjects}");
         }
 
         public override async Task<dynamic> GetHostNames(string stampName, string siteName)


### PR DESCRIPTION
- Added clear exception messages if stamp name is not found on adminsites
- Previous logic allowed "StampName" to be present but still returned empty "InternalStampName"; logic now prefers InternalStampName before falling back to StampName