### PR TITLE
Create cxt.Resource.SubscriptionLocationPlacementId 

### DIFF
--- a/src/Diagnostics.DataProviders/AscClient.cs
+++ b/src/Diagnostics.DataProviders/AscClient.cs
@@ -238,7 +238,7 @@ namespace Diagnostics.DataProviders
         {
             if (!string.IsNullOrWhiteSpace(SubscriptionLocationPlacementId) && SubscriptionLocationPlacementId.Equals(DiagAscHeaderValue, StringComparison.CurrentCultureIgnoreCase))
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException("This subscription is not allowed for ASC calls");
             }
             var response = await SendAscRequestAsync(requestMessage, isBlobRequest, cancellationToken);
             string responseContent = await response.Content.ReadAsStringAsync();

--- a/src/Diagnostics.DataProviders/AscClient.cs
+++ b/src/Diagnostics.DataProviders/AscClient.cs
@@ -70,7 +70,11 @@ namespace Diagnostics.DataProviders
         /// </summary>
         private string apiVersion;
 
-        private readonly string MethodNotAllowed = "DataProvider method not allowed";
+        /// <summary>
+        /// Header value based on which we block ASC calls.
+        /// </summary>
+        private string DiagAscHeaderValue;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AscClient"/> class.
         /// <param name="config">Config for Asc Data Provider.</param>
@@ -91,6 +95,7 @@ namespace Diagnostics.DataProviders
             {
                 SubscriptionLocationPlacementId = string.Empty;
             }
+            DiagAscHeaderValue = config.DiagAscHeader;
         }
 
         private HttpClient httpClient
@@ -231,9 +236,9 @@ namespace Diagnostics.DataProviders
 
         private async Task<T> GetAscResponse<T>(HttpRequestMessage requestMessage, bool isBlobRequest, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (!string.IsNullOrWhiteSpace(SubscriptionLocationPlacementId) && SubscriptionLocationPlacementId.Equals("geos_2020-01-01", StringComparison.CurrentCultureIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(SubscriptionLocationPlacementId) && SubscriptionLocationPlacementId.Equals(DiagAscHeaderValue, StringComparison.CurrentCultureIgnoreCase))
             {
-                throw new HttpRequestException(MethodNotAllowed);
+                throw new InvalidOperationException();
             }
             var response = await SendAscRequestAsync(requestMessage, isBlobRequest, cancellationToken);
             string responseContent = await response.Content.ReadAsStringAsync();

--- a/src/Diagnostics.DataProviders/AscClient.cs
+++ b/src/Diagnostics.DataProviders/AscClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -9,6 +10,8 @@ using Diagnostics.DataProviders.DataProviderConfigurations;
 using Diagnostics.DataProviders.Interfaces;
 using Diagnostics.DataProviders.TokenService;
 using Diagnostics.Logger;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
 
 namespace Diagnostics.DataProviders
@@ -25,6 +28,11 @@ namespace Diagnostics.DataProviders
         {
             get { return AscClient.userAgent; }
         }
+
+        /// <summary>
+        /// Subscription Location PlacementId derived from incoming headers
+        /// </summary>
+        public string SubscriptionLocationPlacementId;
 
         private static string userAgent = string.Empty;
 
@@ -62,12 +70,13 @@ namespace Diagnostics.DataProviders
         /// </summary>
         private string apiVersion;
 
+        private readonly string MethodNotAllowed = "DataProvider method not allowed";
         /// <summary>
         /// Initializes a new instance of the <see cref="AscClient"/> class.
         /// <param name="config">Config for Asc Data Provider.</param>
         /// <param name="appLensRequestId">AppLens Request Id, used for logging.</param>
         /// </summary>
-        public AscClient(AscDataProviderConfiguration config, string appLensRequestId)
+        public AscClient(AscDataProviderConfiguration config, string appLensRequestId, IHeaderDictionary incomingRequestHeaders)
         {
             baseUri = config.BaseUri;
             apiUri = config.ApiUri;
@@ -75,6 +84,13 @@ namespace Diagnostics.DataProviders
             AscClient.userAgent = config.UserAgent;
             logger = DiagnosticsETWProvider.Instance;
             requestId = appLensRequestId;
+            if(incomingRequestHeaders.TryGetValue(HeaderConstants.SubscriptionLocationPlacementId, out StringValues subLocationPlacementId))
+            {
+                SubscriptionLocationPlacementId = subLocationPlacementId.FirstOrDefault();
+            } else
+            {
+                SubscriptionLocationPlacementId = string.Empty;
+            }
         }
 
         private HttpClient httpClient
@@ -89,7 +105,7 @@ namespace Diagnostics.DataProviders
         public async Task<T> MakeHttpPostRequest<T>(string jsonPostBody, string apiUri, string apiVersion, CancellationToken cancellationToken = default(CancellationToken))
         {
             try
-            {
+            {              
                 if (string.IsNullOrWhiteSpace(apiUri))
                 {
                     apiUri = this.apiUri;
@@ -215,6 +231,10 @@ namespace Diagnostics.DataProviders
 
         private async Task<T> GetAscResponse<T>(HttpRequestMessage requestMessage, bool isBlobRequest, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (!string.IsNullOrWhiteSpace(SubscriptionLocationPlacementId) && SubscriptionLocationPlacementId.Equals("geos_2020-01-01", StringComparison.CurrentCultureIgnoreCase))
+            {
+                throw new HttpRequestException(MethodNotAllowed);
+            }
             var response = await SendAscRequestAsync(requestMessage, isBlobRequest, cancellationToken);
             string responseContent = await response.Content.ReadAsStringAsync();
             if (response.IsSuccessStatusCode)

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/ASCDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/ASCDataProviderConfiguration.cs
@@ -51,6 +51,12 @@
         [ConfigurationName("AppKey")]
         public string AppKey { get; set; }
 
+        /// <summary>
+        /// Header value based on which we block calls to ASC
+        /// </summary>
+        [ConfigurationName("DiagAscHeader")]
+        public string DiagAscHeader { get; set; }
+
         public void PostInitialize()
         {
         }

--- a/src/Diagnostics.DataProviders/DataProviders.cs
+++ b/src/Diagnostics.DataProviders/DataProviders.cs
@@ -23,7 +23,7 @@ namespace Diagnostics.DataProviders
             GeoMaster = new GeoMasterLogDecorator(context, new GeoMasterDataProvider(_cache, context));
             AppInsights = new AppInsightsLogDecorator(context, new AppInsightsDataProvider(_cache, context.Configuration.AppInsightsConfiguration));
             ChangeAnalysis = new ChangeAnalysisLogDecorator(context, new ChangeAnalysisDataProvider(_cache, context.Configuration.ChangeAnalysisDataProviderConfiguration, context.RequestId, context.clientObjectId, context.clientPrincipalName, Kusto, context.receivedHeaders));
-            Asc = new AscLogDecorator(context, new AscDataProvider(_cache, context.Configuration.AscDataProviderConfiguration, context.RequestId));
+            Asc = new AscLogDecorator(context, new AscDataProvider(_cache, context.Configuration.AscDataProviderConfiguration, context.RequestId, context));
             Mdm = (MdmDataSource ds) =>
             {
                 switch (ds)

--- a/src/Diagnostics.DataProviders/DataProviders/AscDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/AscDataProvider.cs
@@ -17,18 +17,21 @@ namespace Diagnostics.DataProviders
 
         private string dataProviderRequestId;
 
+        private DataProviderContext CurrentRequestContext;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AscDataProvider"/> class.
         /// </summary>
         /// <param name="cache">Operation Data Cache instance.</param>
         /// <param name="configuration">Configuration for calling into Azure Support Center.</param>
         /// <param name="requestId">AppLens request id.</param>
-        public AscDataProvider(OperationDataCache cache, AscDataProviderConfiguration configuration, string requestId)
+        public AscDataProvider(OperationDataCache cache, AscDataProviderConfiguration configuration, string requestId, DataProviderContext context)
             : base(cache)
         {
             dataProviderConfiguration = configuration;
             dataProviderRequestId = requestId;
-            ascClient = new AscClient(configuration, dataProviderRequestId);
+            ascClient = new AscClient(configuration, dataProviderRequestId, context.receivedHeaders);
+            CurrentRequestContext = context;
         }
 
         /// <inheritdoc/>

--- a/src/Diagnostics.Logger/HeaderConstants.cs
+++ b/src/Diagnostics.Logger/HeaderConstants.cs
@@ -94,5 +94,10 @@ namespace Diagnostics.Logger
         /// Client Identity Provider header.
         /// </summary>
         public static readonly string ClientIdentityProviderHeader = "x-ms-client-identity-provider";
+
+        /// <summary>
+        /// Subscription Location Placement id.
+        /// </summary>
+        public static readonly string SubscriptionLocationPlacementId = "x-ms-subscription-location-placementid";
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/ApiManagementService.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/ApiManagementService.cs
@@ -56,11 +56,20 @@ namespace Diagnostics.ModelsAndUtils.Models
             }
         }
 
-        public ApiManagementService(string subscriptionId, string resourceGroup, string name) : base()
+        /// <summary>
+        /// Subscription Location Placement id
+        /// </summary>
+        public string SubscriptionLocationPlacementId
+        {
+            get; set;
+        }
+
+        public ApiManagementService(string subscriptionId, string resourceGroup, string name, string subLocationPlacementid = null) : base()
         {
             this.SubscriptionId = subscriptionId;
             this.ResourceGroup = resourceGroup;
             this.Name = name;
+            this.SubscriptionLocationPlacementId = subLocationPlacementid;
         }
 
         /// <summary>

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/App.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/App.cs
@@ -88,6 +88,11 @@ namespace Diagnostics.ModelsAndUtils.Models
             }
         }
 
+        public string SubscriptionLocationPlacementId
+        {
+            get; set;
+        }
+
         public App(string subscriptionId, string resourceGroup, string appName) : base()
         {
             this.SubscriptionId = subscriptionId;

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/AppServiceCertificate.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/AppServiceCertificate.cs
@@ -56,11 +56,20 @@ namespace Diagnostics.ModelsAndUtils.Models
             }
         }
 
-        public AppServiceCertificate(string subscriptionId, string resourceGroup, string name) : base()
+        /// <summary>
+        /// Subscription Location Placement id
+        /// </summary>
+        public string SubscriptionLocationPlacementId
+        {
+            get; set;
+        }
+
+        public AppServiceCertificate(string subscriptionId, string resourceGroup, string name, string subscriptionLocationPlacementId = null) : base()
         {
             this.SubscriptionId = subscriptionId;
             this.ResourceGroup = resourceGroup;
             this.Name = name;
+            SubscriptionLocationPlacementId = subscriptionLocationPlacementId;
         }
 
         /// <summary>

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/AppServiceDomain.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/AppServiceDomain.cs
@@ -56,11 +56,20 @@ namespace Diagnostics.ModelsAndUtils.Models
             }
         }
 
-        public AppServiceDomain(string subscriptionId, string resourceGroup, string name) : base()
+        /// <summary>
+        /// Subscription Location Placement id
+        /// </summary>
+        public string SubscriptionLocationPlacementId
+        {
+            get; set;
+        }
+
+        public AppServiceDomain(string subscriptionId, string resourceGroup, string name, string subscriptionLocationPlacementId = null) : base()
         {
             this.SubscriptionId = subscriptionId;
             this.ResourceGroup = resourceGroup;
             this.Name = name;
+            SubscriptionLocationPlacementId = subscriptionLocationPlacementId;
         }
 
         /// <summary>

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/ArmResource.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/ArmResource.cs
@@ -52,11 +52,20 @@ namespace Diagnostics.ModelsAndUtils.Models
             }
         }
 
-        public ArmResource(string subscriptionId, string resourceGroup, string provider, string resourceTypeName, string resourceName) : base(provider, resourceTypeName)
+        /// <summary>
+        /// Subscription Location Placement id
+        /// </summary>
+        public string SubscriptionLocationPlacementId
+        {
+            get; set;
+        }
+
+        public ArmResource(string subscriptionId, string resourceGroup, string provider, string resourceTypeName, string resourceName, string subscriptionLocationPlacementId = null) : base(provider, resourceTypeName)
         {
             this.SubscriptionId = subscriptionId;
             this.ResourceGroup = resourceGroup;
             this.Name = resourceName;
+            SubscriptionLocationPlacementId = subscriptionLocationPlacementId;
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/AzureKubernetesService.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/AzureKubernetesService.cs
@@ -54,6 +54,14 @@ namespace Diagnostics.ModelsAndUtils.Models
         }
 
         /// <summary>
+        /// Subscription Location Placement id
+        /// </summary>
+        public string SubscriptionLocationPlacementId
+        {
+            get; set;
+        }
+
+        /// <summary>
         /// Determines whether the Azure Kubernetes Service resource is applicable after filtering.
         /// </summary>
         /// <param name="filter">Resource Filter</param>
@@ -63,11 +71,12 @@ namespace Diagnostics.ModelsAndUtils.Models
             return filter is AzureKubernetesServiceFilter;
         }
 
-        public AzureKubernetesService(string subscriptionId, string resourceGroup, string resourceName) : base()
+        public AzureKubernetesService(string subscriptionId, string resourceGroup, string resourceName, string subLocationPlacementId = null) : base()
         {
             this.SubscriptionId = subscriptionId;
             this.ResourceGroup = resourceGroup;
             this.Name = resourceName;
+            SubscriptionLocationPlacementId = subLocationPlacementId;
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/HostingEnvironment.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/HostingEnvironment.cs
@@ -116,7 +116,6 @@ namespace Diagnostics.ModelsAndUtils.Models
             this.SubscriptionId = subscriptionId;
             this.ResourceGroup = resourceGroup;
             this.FriendlyName = name;
-            this.TenantIdList = new List<string>();
             SubscriptionLocationPlacementId = subLocationPlacementId;
         }
 

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/HostingEnvironment.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/HostingEnvironment.cs
@@ -108,12 +108,21 @@ namespace Diagnostics.ModelsAndUtils.Models
             }
         }
 
-        public HostingEnvironment(string subscriptionId, string resourceGroup, string name)
+        /// <summary>
+        /// Subscription Location Placement id
+        /// </summary>
+        public string SubscriptionLocationPlacementId
+        {
+            get; set;
+        }
+
+        public HostingEnvironment(string subscriptionId, string resourceGroup, string name, string subLocationPlacementId = null)
         {
             this.SubscriptionId = subscriptionId;
             this.ResourceGroup = resourceGroup;
             this.FriendlyName = name;
             this.TenantIdList = new List<string>();
+            SubscriptionLocationPlacementId = subLocationPlacementId;
         }
 
         public bool IsApplicable(IResourceFilter filter)

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/LogicApp.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/LogicApp.cs
@@ -53,11 +53,20 @@ namespace Diagnostics.ModelsAndUtils.Models
             }
         }
 
-        public LogicApp(string subscriptionId, string resourceGroup, string appName) : base()
+        /// <summary>
+        /// Subscription Location Placement id
+        /// </summary>
+        public string SubscriptionLocationPlacementId
+        {
+            get; set;
+        }
+
+        public LogicApp(string subscriptionId, string resourceGroup, string appName, string subscriptionLocationPlacementid = null) : base()
         {
             this.SubscriptionId = subscriptionId;
             this.ResourceGroup = resourceGroup;
             this.Name = appName;
+            SubscriptionLocationPlacementId = subscriptionLocationPlacementid;
         }
 
         /// <summary>

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -450,7 +450,12 @@ namespace Diagnostics.RuntimeHost.Controllers
 
         protected TResource GetResource(string subscriptionId, string resourceGroup, string name)
         {
-            return (TResource)Activator.CreateInstance(typeof(TResource), subscriptionId, resourceGroup, name);
+            var subLocationPlacementId = string.Empty;
+            if (Request.Headers.TryGetValue(HeaderConstants.SubscriptionLocationPlacementId, out StringValues subscriptionLocationPlacementId))
+            {
+                subLocationPlacementId = subscriptionLocationPlacementId.FirstOrDefault();
+            }
+            return (TResource)Activator.CreateInstance(typeof(TResource), subscriptionId, resourceGroup, name, subLocationPlacementId);
         }
 
         // Purposefully leaving this method in Base class. This method is shared between two resources right now - HostingEnvironment and WebApp
@@ -472,6 +477,12 @@ namespace Diagnostics.RuntimeHost.Controllers
                 SuspendedOn = stampPostBody.SuspendedOn,
                 Location = stampPostBody.Location
             };
+
+
+            if (Request.Headers.TryGetValue(HeaderConstants.SubscriptionLocationPlacementId, out StringValues subscriptionLocationPlacementId))
+            {
+                hostingEnv.SubscriptionLocationPlacementId = subscriptionLocationPlacementId.FirstOrDefault();
+            }
 
             switch (stampPostBody.Kind)
             {

--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SiteControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SiteControllerBase.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Diagnostics.DataProviders;
+using Diagnostics.Logger;
 using Diagnostics.ModelsAndUtils.Attributes;
 using Diagnostics.ModelsAndUtils.Models;
 using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Services;
 using Diagnostics.RuntimeHost.Utilities;
+using Microsoft.Extensions.Primitives;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -49,6 +51,10 @@ namespace Diagnostics.RuntimeHost.Controllers
                     break;
             }
 
+            if(Request.Headers.TryGetValue(HeaderConstants.SubscriptionLocationPlacementId, out StringValues subscriptionLocationPlacementId))
+            {
+                app.SubscriptionLocationPlacementId = subscriptionLocationPlacementId.FirstOrDefault();
+            }
             return app;
         }
 

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -81,7 +81,8 @@
     "AADAuthority": "https://login.microsoftonline.com/microsoft.onmicrosoft.com",
     "TokenResource": "https://microsoft.onmicrosoft.com/azurediagnostic",
     "ClientId": "",
-    "AppKey": ""
+    "AppKey": "",
+    "DiagAscHeader":  ""
   },
   "SearchAPI": {
     "SearchAPIEnabled": false,


### PR DESCRIPTION
- Based on incoming headers sent from the client (Portal for Diagnose and Solve), create cxt.Resource.SubscriptionLocationPlacementId which can be used in detectors. 
- Block calls to ASC based on subscription location placement id