### PR TITLE
Adding InitializeAppInsightsKey to read key from Tags

### DIFF
--- a/src/Diagnostics.DataProviders/AppInsightsLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/AppInsightsLogDecorator.cs
@@ -19,9 +19,9 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(DataProvider.ExecuteAppInsightsQuery(query));
         }
 
-        public Task<bool> InitializeAppInsightsKey(OperationContext<IResource> cxt)
+        public Task<bool> SetAppInsightsKey(OperationContext<IResource> cxt)
         {
-            return MakeDependencyCall(DataProvider.InitializeAppInsightsKey(cxt));
+            return MakeDependencyCall(DataProvider.SetAppInsightsKey(cxt));
         }
 
         public Task<bool> SetAppInsightsKey(string appId, string apiKey)

--- a/src/Diagnostics.DataProviders/AppInsightsLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/AppInsightsLogDecorator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Data;
 using System.Threading.Tasks;
 using Diagnostics.DataProviders.Interfaces;
+using Diagnostics.ModelsAndUtils.Models;
 
 namespace Diagnostics.DataProviders
 {
@@ -16,6 +17,11 @@ namespace Diagnostics.DataProviders
         public Task<DataTable> ExecuteAppInsightsQuery(string query)
         {
             return MakeDependencyCall(DataProvider.ExecuteAppInsightsQuery(query));
+        }
+
+        public Task<bool> InitializeAppInsightsKey(OperationContext<IResource> cxt)
+        {
+            return MakeDependencyCall(DataProvider.InitializeAppInsightsKey(cxt));
         }
 
         public Task<bool> SetAppInsightsKey(string appId, string apiKey)

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/AppInsightsDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/AppInsightsDataProviderConfiguration.cs
@@ -3,6 +3,9 @@
     [DataSourceConfiguration("AppInsights")]
     public class AppInsightsDataProviderConfiguration : IDataProviderConfiguration
     {
+        [ConfigurationName("EncryptionKey")]
+        public string EncryptionKey { get; set; }
+
         public void PostInitialize()
         {
         }

--- a/src/Diagnostics.DataProviders/DataProviders/AppInsightsDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/AppInsightsDataProvider.cs
@@ -32,7 +32,7 @@ namespace Diagnostics.DataProviders
             return Task.FromResult(true);
         }
 
-        public async Task<bool> InitializeAppInsightsKey(OperationContext<IResource> cxt)
+        public async Task<bool> SetAppInsightsKey(OperationContext<IResource> cxt)
         {
             bool keyFound = false;
             if (cxt.Resource is App app)
@@ -46,7 +46,7 @@ namespace Diagnostics.DataProviders
             return keyFound;
         }
 
-        public string DecryptString(string encryptedString)
+        private string DecryptString(string encryptedString)
         {
             byte[] iv = new byte[16];
             byte[] buffer = Convert.FromBase64String(encryptedString);

--- a/src/Diagnostics.DataProviders/DataProviders/AppInsightsDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/AppInsightsDataProvider.cs
@@ -1,13 +1,22 @@
-﻿using System.Data;
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Diagnostics.DataProviders.DataProviderConfigurations;
 using Diagnostics.DataProviders.Interfaces;
 using Diagnostics.ModelsAndUtils.Models;
+using Newtonsoft.Json;
 
 namespace Diagnostics.DataProviders
 {
     public class AppInsightsDataProvider : DiagnosticDataProvider, IDiagnosticDataProvider, IAppInsightsDataProvider
     {
+        const string AppInsightsTagName = "hidden-related:diagnostics/applicationInsightsSettings";
         private readonly IAppInsightsClient _appInsightsClient;
         private AppInsightsDataProviderConfiguration _configuration;
 
@@ -23,6 +32,76 @@ namespace Diagnostics.DataProviders
             return Task.FromResult(true);
         }
 
+        public async Task<bool> InitializeAppInsightsKey(OperationContext<IResource> cxt)
+        {
+            bool keyFound = false;
+            if (cxt.Resource is App app)
+            {
+                var tag = GetAppIdAndKeyFromAppSettingsTags(app.Tags);
+                if (tag != null)
+                {
+                    keyFound = await SetAppInsightsKey(tag.AppId, DecryptString(tag.ApiKey));
+                }
+            }
+            return keyFound;
+        }
+
+        public string DecryptString(string encryptedString)
+        {
+            byte[] iv = new byte[16];
+            byte[] buffer = Convert.FromBase64String(encryptedString);
+
+            using (Aes aes = Aes.Create())
+            {
+                aes.Key = Encoding.UTF8.GetBytes(_configuration.EncryptionKey);
+                aes.IV = iv;
+                ICryptoTransform decryptor = aes.CreateDecryptor(aes.Key, aes.IV);
+
+                using (MemoryStream memoryStream = new MemoryStream(buffer))
+                {
+                    using (CryptoStream cryptoStream = new CryptoStream((Stream)memoryStream, decryptor, CryptoStreamMode.Read))
+                    {
+                        using (StreamReader streamReader = new StreamReader((Stream)cryptoStream))
+                        {
+                            return streamReader.ReadToEnd();
+                        }
+                    }
+                }
+            }
+        }
+
+        private AppInsightsTag GetAppIdAndKeyFromAppSettingsTags(string tagsXml)
+        {
+            AppInsightsTag tag = null;
+            var tagValue = GetTagValue(tagsXml, AppInsightsTagName);
+            if (!string.IsNullOrWhiteSpace(tagValue))
+            {
+                tag = JsonConvert.DeserializeObject<AppInsightsTag>(tagValue);
+            }
+            return tag;
+        }
+
+        private string GetTagValue(string tagsXml, string key)
+        {
+            string tagValue = string.Empty;
+            var xDocument = XDocument.Parse(tagsXml);
+            XNamespace nsSys = "http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+            IEnumerable<XElement> tag = from el in xDocument.Elements(nsSys + "ArrayOfKeyValueOfstringstring").Elements()
+                                        where (string)el.Element(nsSys + "Key") == key
+                                        select el;
+
+            if (tag != null && tag.Count() > 0)
+            {
+                var valueElement = tag.FirstOrDefault().Element(nsSys + "Value");
+                if (valueElement != null)
+                {
+                    tagValue = valueElement.Value;
+                }
+
+            }
+            return tagValue;
+        }
+
         public async Task<DataTable> ExecuteAppInsightsQuery(string query)
         {
             return await _appInsightsClient.ExecuteQueryAsync(query);
@@ -33,4 +112,5 @@ namespace Diagnostics.DataProviders
             return null;
         }
     }
+
 }

--- a/src/Diagnostics.DataProviders/DataProviders/AppInsightsTag.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/AppInsightsTag.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Diagnostics.ModelsAndUtils.Models
+﻿namespace Diagnostics.DataProviders
 {
     public class AppInsightsTag
     {

--- a/src/Diagnostics.DataProviders/Interfaces/IAppInsightsDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IAppInsightsDataProvider.cs
@@ -10,6 +10,6 @@ namespace Diagnostics.DataProviders.Interfaces
 
         Task<bool> SetAppInsightsKey(string appId, string apiKey);
 
-        Task<bool> InitializeAppInsightsKey(OperationContext<IResource> cxt);
+        Task<bool> SetAppInsightsKey(OperationContext<IResource> cxt);
     }
 }

--- a/src/Diagnostics.DataProviders/Interfaces/IAppInsightsDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IAppInsightsDataProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using System.Threading.Tasks;
+using Diagnostics.ModelsAndUtils.Models;
 
 namespace Diagnostics.DataProviders.Interfaces
 {
@@ -8,5 +9,7 @@ namespace Diagnostics.DataProviders.Interfaces
         Task<DataTable> ExecuteAppInsightsQuery(string query);
 
         Task<bool> SetAppInsightsKey(string appId, string apiKey);
+
+        Task<bool> InitializeAppInsightsKey(OperationContext<IResource> cxt);
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Attributes/ResourceFilter/AppFilter.cs
+++ b/src/Diagnostics.ModelsAndUtils/Attributes/ResourceFilter/AppFilter.cs
@@ -32,5 +32,10 @@
             this.StackType = StackType.All;
             this.StampType = StampType.All;
         }
+
+        /// <summary>
+        /// ARM tags set on the resource
+        /// </summary>
+        public string Tags;
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/AppInsights/AppInsightsTag.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/AppInsights/AppInsightsTag.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Diagnostics.ModelsAndUtils.Models
+{
+    public class AppInsightsTag
+    {
+        public string AppId { get; set; }
+        public string ApiKey { get; set; }
+    }
+}

--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SiteControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SiteControllerBase.cs
@@ -34,8 +34,9 @@ namespace Diagnostics.RuntimeHost.Controllers
                 Stamp = await GetHostingEnvironment(postBody.Stamp.Subscription, postBody.Stamp.ResourceGroup, postBody.Stamp != null ? postBody.Stamp.Name : string.Empty, postBody.Stamp, startTime, endTime, postBody.Kind),
                 AppType = GetApplicationType(postBody.Kind),
                 PlatformType = (!string.IsNullOrWhiteSpace(postBody.Kind) && postBody.Kind.ToLower().Contains("linux")) ? PlatformType.Linux : PlatformType.Windows,
-                StackType =  StackType.All //await this._siteService.GetApplicationStack(subscriptionId, resourceGroup, appName, (DataProviderContext)HttpContext.Items[HostConstants.DataProviderContextKey])
+                StackType =  StackType.All, //await this._siteService.GetApplicationStack(subscriptionId, resourceGroup, appName, (DataProviderContext)HttpContext.Items[HostConstants.DataProviderContextKey])
                 // Not Fetching Stack Information anymore for kusto optimizations. Instead, detectors should look to leverage a gist created for the same.
+                Tags = postBody.Tags
             };
 
             switch (app.Stamp.HostingEnvironmentType)

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -59,6 +59,7 @@
     "Token": ""
   },
   "AppInsights": {
+    "EncryptionKey": ""
   },
   "Mdm": {
     "MdmShoeboxEndpoint": "",


### PR DESCRIPTION
Detector code will do something like this...

```
    var isKeyConfigured = await dp.AppInsights.InitializeAppInsightsKey(cxt);
    if (isKeyConfigured)
    {
        res.AddMarkdownView("Yes, key is configured");
        var appInsightsData = await dp.AppInsights.ExecuteAppInsightsQuery("requests | where timestamp > ago(1d) | take 5 | project name, url");
        res.Dataset.Add(new DiagnosticData()
        {
            Table = appInsightsData,
            RenderingProperties = new TableRendering()
        });
    }
```