### PR TITLE
Rekha/passcxt childdetectors

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/OperationContext.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/OperationContext.cs
@@ -1,6 +1,7 @@
 ﻿using Diagnostics.ModelsAndUtils.Attributes;
 using Diagnostics.ModelsAndUtils.Models.ResponseExtensions;
 using Diagnostics.ModelsAndUtils.Utilities;
+using System.Collections.Generic;
 
 namespace Diagnostics.ModelsAndUtils.Models
 {
@@ -57,6 +58,8 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// </summary>
         public string CloudDomain { get; private set; }
 
+        public Dictionary<string, string> QueryParams { get; set; }
+
         public static implicit operator OperationContext(OperationContext<TResource> context)
         {
             return new OperationContext(context.Resource, context.StartTime, context.EndTime, context.IsInternalCall,
@@ -74,6 +77,7 @@ namespace Diagnostics.ModelsAndUtils.Models
             SupportTopic = supportTopic;
             Form = form;
             CloudDomain = cloudDomain;
+            QueryParams = new Dictionary<string, string>();
         }
     }
 

--- a/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
@@ -28,6 +28,8 @@ namespace Diagnostics.ModelsAndUtils.Models
 
         public string MessageIfCritical { get; set; }
 
+        public string AdditionalParams { get; set; }
+
         public DetectorCollectionRendering() : base(RenderingType.Detector)
         {
         }

--- a/src/Diagnostics.ModelsAndUtils/Models/ResponseExtensions/DetectorCollection.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/ResponseExtensions/DetectorCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Diagnostics.ModelsAndUtils.Models.ResponseExtensions
 {
@@ -19,13 +20,14 @@ namespace Diagnostics.ModelsAndUtils.Models.ResponseExtensions
             return diagnosticData;
         }
 
-        public static DiagnosticData AddDetector(this Response response, string detectorId)
+        public static DiagnosticData AddDetector(this Response response, string detectorId, IDictionary<string, string> additionalParams = null )
         {
             var diagnosticData = new DiagnosticData()
             {
                 RenderingProperties = new DetectorCollectionRendering()
                 {
-                    DetectorIds = new string[] { detectorId }
+                    DetectorIds = new string[] { detectorId },
+                    AdditionalParams = additionalParams != null ? JsonConvert.SerializeObject(additionalParams) : string.Empty,
                 }
             };
 

--- a/src/Diagnostics.ModelsAndUtils/Models/ResponseExtensions/DetectorCollection.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/ResponseExtensions/DetectorCollection.cs
@@ -5,13 +5,14 @@ namespace Diagnostics.ModelsAndUtils.Models.ResponseExtensions
 {
     public static class ResponseDetectorViewExtensions
     {
-        public static DiagnosticData AddDetectorCollection(this Response response, List<string> detectorIds)
+        public static DiagnosticData AddDetectorCollection(this Response response, List<string> detectorIds, IDictionary<string, string> additionalParams = null)
         {
             var diagnosticData = new DiagnosticData()
             {
                 RenderingProperties = new DetectorCollectionRendering()
                 {
-                    DetectorIds = detectorIds
+                    DetectorIds = detectorIds,
+                    AdditionalParams = additionalParams != null ? JsonConvert.SerializeObject(additionalParams) : string.Empty,
                 }
             };
 

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -566,6 +566,11 @@ namespace Diagnostics.RuntimeHost.Controllers
 
             _runtimeContext.ClientIsInternal = isInternalClient || forceInternal;
             _runtimeContext.OperationContext = operationContext;
+            var queryParamCollection = Request.Query;
+            foreach(var pair in queryParamCollection)
+            {
+                _runtimeContext.OperationContext.QueryParams.Add(pair.Key, pair.Value);
+            }
 
             return (RuntimeContext<TResource>)_runtimeContext;
         }


### PR DESCRIPTION
This gives detector authors ability to pass any key value pairs to child detectors from parent detector. 
Example code for passing key-value pairs:
```
  var additionalParams = new Dictionary<string, string>();
            additionalParams.Add("Input", "ABCD");
            res.AddDetector("detectorqp", additionalParams ); 
```

```
  var children = new List<string>();
    children.Add("http4xx");
    children.Add("detectorqp");
    var additionalParams = new Dictionary<string, string>();
    additionalParams.Add("Input","abcd");
    res.AddDetectorCollection(children, additionalParams);
```

Example code in child detector to access these key-value pairs:

```
 if(cxt.QueryParams != null) {
       var keys = cxt.QueryParams.Keys;
       string markdown = "";
       foreach(string key in keys) {
           markdown += $"{key} = {cxt.QueryParams[key]} \n\n";
       }
       res.AddMarkdownView(markdown, "Detector Query Params received");
   }
```

![image](https://user-images.githubusercontent.com/46545195/72103304-c86d7800-32dd-11ea-899d-49d23198f92f.png)
