### PR TITLE
National Cloud Updates

### DIFF
--- a/azure-nationalcloud-pipelines.yml
+++ b/azure-nationalcloud-pipelines.yml
@@ -1,0 +1,38 @@
+# ASP.NET Core (.NET Framework)
+# Build and test ASP.NET Core projects targeting the full .NET Framework.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+trigger:
+- nationalcloud
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'build'
+    projects: '$(solution)'
+    configuration: '$(buildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'test'
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: publish
+    publishWebProjects: True
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'
+    zipAfterPublish: True
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    artifactName: backend-drop1

--- a/src/Diagnostics.CompilerHost/Startup.cs
+++ b/src/Diagnostics.CompilerHost/Startup.cs
@@ -44,16 +44,14 @@ namespace Diagnostics.CompilerHost
             var builtConfig = builder.Build();
 
             string keyVaultConfig = Helpers.GetKeyvaultforEnvironment(hostingEnvironment.EnvironmentName);
-            var tokenProvider = new AzureServiceTokenProvider();
+            var tokenProvider = new AzureServiceTokenProvider(azureAdInstance: builtConfig["Secrets:AzureAdInstance"]);
             var keyVaultClient = new KeyVaultClient(
                 new KeyVaultClient.AuthenticationCallback(
                     tokenProvider.KeyVaultTokenCallback
                 )
             );
 
-            builder.AddAzureKeyVault($"https://{builtConfig[keyVaultConfig]}.vault.azure.net/",
-                                         keyVaultClient,
-                                         new DefaultKeyVaultSecretManager());
+            builder.AddAzureKeyVault(builtConfig[keyVaultConfig], keyVaultClient, new DefaultKeyVaultSecretManager());
 
             Configuration = builder.Build();
         }

--- a/src/Diagnostics.DataProviders/ConfigurationFactory.cs
+++ b/src/Diagnostics.DataProviders/ConfigurationFactory.cs
@@ -32,7 +32,7 @@ namespace Diagnostics.DataProviders
 
             var builtConfig = builder.Build();
 
-            var tokenProvider = new AzureServiceTokenProvider();
+            var tokenProvider = new AzureServiceTokenProvider(azureAdInstance: builtConfig["Secrets:AzureAdInstance"]);
             var keyVaultClient = new KeyVaultClient(
                 new KeyVaultClient.AuthenticationCallback(
                     tokenProvider.KeyVaultTokenCallback
@@ -40,9 +40,7 @@ namespace Diagnostics.DataProviders
             );
 
             string keyVaultConfig = Helpers.GetKeyvaultforEnvironment(env.EnvironmentName);
-            builder.AddAzureKeyVault($"https://{builtConfig[keyVaultConfig]}.vault.azure.net/",
-                                         keyVaultClient,
-                                         new DefaultKeyVaultSecretManager());
+            builder.AddAzureKeyVault(builtConfig[keyVaultConfig], keyVaultClient, new DefaultKeyVaultSecretManager());
 
             _configuration = builder.Build();
         }

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/ASCDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/ASCDataProviderConfiguration.cs
@@ -52,6 +52,11 @@
         public string AppKey { get; set; }
 
         /// <summary>
+        ///  Enabled
+        /// </summary>
+        [ConfigurationName("Enabled")]
+        public bool Enabled { get; set; }
+
         /// Header value based on which we block calls to ASC
         /// </summary>
         [ConfigurationName("DiagAscHeader")]

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/ChangeAnalysisDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/ChangeAnalysisDataProviderConfiguration.cs
@@ -39,6 +39,12 @@
         [ConfigurationName("Apiversion")]
         public string Apiversion { get; set; }
 
+        /// <summary>
+        /// Enabled
+        /// </summary>
+        [ConfigurationName("Enabled")]
+        public bool Enabled { get; set; }
+
         public void PostInitialize()
         {
         }

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
@@ -44,13 +44,9 @@ namespace Diagnostics.DataProviders
         /// </summary>
         public string AADAuthority { get; set; }
 
-        /// <summary>
-        /// Gets resourceId for WAWSObserver AAD app.
-        /// </summary>
-        public string WawsObserverResourceId
-        {
-            get { return "d1abfd91-e19c-426e-802f-a6c55421a5ef"; }
-        }
+
+        [ConfigurationName("AADResource")]
+        public string AADResource { get; set; }
 
         /// <summary>
         /// Gets uri for SupportObserverResourceAAD app.

--- a/src/Diagnostics.DataProviders/DataProviders/DiagnosticDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/DiagnosticDataProvider.cs
@@ -1,23 +1,39 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Diagnostics.ModelsAndUtils.Models;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Diagnostics.DataProviders
 {
-    public class DiagnosticDataProvider
+    public class DiagnosticDataProvider : IDiagnosticDataProvider, IHealthCheck
     {
         private OperationDataCache _cache;
+        private IDataProviderConfiguration _configuration;
 
         public DiagnosticDataProvider(OperationDataCache cache)
         {
             _cache = cache;
         }
 
+        public DiagnosticDataProvider(OperationDataCache cache, IDataProviderConfiguration configuration)
+        {
+            _cache = cache;
+            _configuration = configuration;
+        }
+
+        public DataProviderMetadata Metadata { get; set; }
+
+        public IDataProviderConfiguration DataProviderConfiguration => _configuration;
+
         protected Task<T> GetOrAddFromCache<T>(string key, Func<string, CacheMember> addFunction)
         {
             return Convert.ChangeType(_cache.GetOrAdd(key, addFunction), typeof(Task<T>)) as Task<T>;
         }
 
-        public DataProviderMetadata Metadata { get; set; }
+        public virtual Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            return null;
+        }
     }
 }

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -41,7 +41,7 @@ namespace Diagnostics.DataProviders
             return await ExecuteQuery(query, DataProviderConstants.FakeStampForAnalyticsCluster, requestId, operationName);
         }
 
-        public async Task<DataTable> ExecuteClusterQuery(string query, string cluster, string databaseName, string operationName, string requestId = null)
+        public async Task<DataTable> ExecuteClusterQuery(string query, string cluster, string databaseName, string requestId, string operationName)
         {
             await AddQueryInformationToMetadata(query, cluster, operationName);
             return await _kustoClient.ExecuteQueryAsync(query, cluster, databaseName, requestId, operationName);
@@ -108,7 +108,7 @@ namespace Diagnostics.DataProviders
             try
             {
                 var cluster = _configuration.RegionSpecificClusterNameCollection.Values.First();
-                response = await ExecuteClusterQuery(_configuration.HeartBeatQuery, cluster, _configuration.DBName, "");
+                response = await ExecuteClusterQuery(_configuration.HeartBeatQuery, cluster, _configuration.DBName, null, null);
             }
             catch (Exception ex)
             {

--- a/src/Diagnostics.DataProviders/Diagnostics.DataProviders.csproj
+++ b/src/Diagnostics.DataProviders/Diagnostics.DataProviders.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.2" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
   </ItemGroup>

--- a/src/Diagnostics.DataProviders/Interfaces/IDiagnosticDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IDiagnosticDataProvider.cs
@@ -2,6 +2,6 @@
 {
     public interface IDiagnosticDataProvider
     {
-        // TODO
+        IDataProviderConfiguration DataProviderConfiguration { get; }
     }
 }

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -7,6 +7,8 @@ namespace Diagnostics.DataProviders
     {
         Task<DataTable> ExecuteClusterQuery(string query, string requestId = null, string operationName = null);
 
+        Task<DataTable> ExecuteClusterQuery(string query, string cluster, string databaseName, string requestId = null, string operationName = null);
+
         Task<DataTable> ExecuteQuery(string query, string stampName, string requestId = null, string operationName = null);
 
         Task<KustoQuery> GetKustoQuery(string query, string stampName);

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -7,7 +7,7 @@ namespace Diagnostics.DataProviders
     {
         Task<DataTable> ExecuteClusterQuery(string query, string requestId = null, string operationName = null);
 
-        Task<DataTable> ExecuteClusterQuery(string query, string cluster, string databaseName, string requestId = null, string operationName = null);
+        Task<DataTable> ExecuteClusterQuery(string query, string cluster, string databaseName, string requestId, string operationName);
 
         Task<DataTable> ExecuteQuery(string query, string stampName, string requestId = null, string operationName = null);
 

--- a/src/Diagnostics.DataProviders/KustoLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/KustoLogDecorator.cs
@@ -22,7 +22,7 @@ namespace Diagnostics.DataProviders
 			return ExecuteQuery(query, DataProviderConstants.FakeStampForAnalyticsCluster, requestId, operationName);
 		}
 
-		public Task<DataTable> ExecuteClusterQuery(string query, string cluster, string databaseName, string requestId = null, string operationName = null)
+		public Task<DataTable> ExecuteClusterQuery(string query, string cluster, string databaseName, string requestId, string operationName)
 		{
 			return ExecuteClusterQuery(query, cluster, databaseName, requestId, operationName);
 		}

--- a/src/Diagnostics.DataProviders/KustoLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/KustoLogDecorator.cs
@@ -7,7 +7,7 @@ namespace Diagnostics.DataProviders
 	{
 		public IKustoDataProvider DataProvider;
 
-		public KustoLogDecorator(DataProviderContext context, IKustoDataProvider dataProvider) : base(context, dataProvider.GetMetadata())
+		public KustoLogDecorator(DataProviderContext context, IKustoDataProvider dataProvider) : base((DiagnosticDataProvider)dataProvider, context, dataProvider.GetMetadata())
 		{
 			DataProvider = dataProvider;
 		}
@@ -20,6 +20,11 @@ namespace Diagnostics.DataProviders
 		public Task<DataTable> ExecuteClusterQuery(string query, string requestId = null, string operationName = null)
 		{
 			return ExecuteQuery(query, DataProviderConstants.FakeStampForAnalyticsCluster, requestId, operationName);
+		}
+
+		public Task<DataTable> ExecuteClusterQuery(string query, string cluster, string databaseName, string requestId = null, string operationName = null)
+		{
+			return ExecuteClusterQuery(query, cluster, databaseName, requestId, operationName);
 		}
 
 		public Task<KustoQuery> GetKustoQuery(string query, string stampName)

--- a/src/Diagnostics.DataProviders/LogDecoratorBase.cs
+++ b/src/Diagnostics.DataProviders/LogDecoratorBase.cs
@@ -7,11 +7,20 @@ using Diagnostics.ModelsAndUtils.Models;
 
 namespace Diagnostics.DataProviders
 {
-    internal abstract class LogDecoratorBase : IMetadataProvider
+    public abstract class LogDecoratorBase : IMetadataProvider
     {
+        public DiagnosticDataProvider DataProvider { get; private set; }
         protected string _requestId;
         private DataProviderMetadata _metadataProvider;
         private CancellationToken _dataSourceCancellationToken;
+
+        protected LogDecoratorBase(DiagnosticDataProvider dataProvider, DataProviderContext context, DataProviderMetadata metaData)
+        {
+            DataProvider = dataProvider;
+            _metadataProvider = metaData;
+            _requestId = context.RequestId;
+            _dataSourceCancellationToken = context.DataSourcesCancellationToken;
+        }
 
         protected LogDecoratorBase(DataProviderContext context, DataProviderMetadata metaData)
         {

--- a/src/Diagnostics.RuntimeHost/Controllers/ProcessHealthController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ProcessHealthController.cs
@@ -5,6 +5,8 @@ using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using Diagnostics.DataProviders;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -33,6 +35,13 @@ namespace Diagnostics.RuntimeHost.Controllers
             await Task.WhenAll(allChecks);
 
             return Ok("Server is up and running.");
+        }
+
+        [HttpGet("/dependencyCheck")]
+        public async Task<IEnumerable<HealthCheckResult>> DependencyCheck()
+        {
+            var dataProviders = new DataProviders.DataProviders((DataProviderContext)HttpContext.Items[HostConstants.DataProviderContextKey]);
+            return await _healthCheckService.RunDependencyCheck(dataProviders);
         }
     }
 }

--- a/src/Diagnostics.RuntimeHost/Diagnostics.RuntimeHost.csproj
+++ b/src/Diagnostics.RuntimeHost/Diagnostics.RuntimeHost.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="2.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.5.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.5.0" />
     <PackageReference Include="Octokit" Version="0.31.0" />

--- a/src/Diagnostics.RuntimeHost/Extensions/ApplicationLoggingExtensions.cs
+++ b/src/Diagnostics.RuntimeHost/Extensions/ApplicationLoggingExtensions.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.Logging.AzureAppServices;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ApplicationLoggingExtensions
+    {
+        /// <summary>
+        /// Write application logs to the file system. App Services will honors the settings in the 
+        /// App Service logs section of the App Service page of the Azure portal. When Application Logging (Filesystem) setting is updated, the changes take effect immediately without 
+        /// requiring a restart or redeployment of the app
+        /// </summary>
+        /// <param name="services">The Microsoft.Extensions.DependencyInjection.IServiceCollection to add services to.</param>
+        /// <returns>The Microsoft.Extensions.DependencyInjection.IServiceCollection so that additional calls can be chained.</returns>
+        public static IServiceCollection AddAppServiceApplicationLogging(this IServiceCollection services)
+        {
+            const int maxLogSizeInBytes = 50 * 1024;
+            services.Configure<AzureFileLoggerOptions>(options =>
+            {
+                options.FileName = "diagnostics-";
+                options.FileSizeLimit = maxLogSizeInBytes;
+                options.RetainedFileCountLimit = 10;
+            });
+            return services;
+        }
+    }
+}

--- a/src/Diagnostics.RuntimeHost/Middleware/DiagnosticsRequestMiddleware.cs
+++ b/src/Diagnostics.RuntimeHost/Middleware/DiagnosticsRequestMiddleware.cs
@@ -13,16 +13,21 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 using static Diagnostics.Logger.HeaderConstants;
 using Diagnostics.RuntimeHost.Models.Exceptions;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Octokit;
 
 namespace Diagnostics.RuntimeHost.Middleware
 {
     public class DiagnosticsRequestMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly ILogger<DiagnosticsRequestMiddleware> _logger;
 
-        public DiagnosticsRequestMiddleware(RequestDelegate next)
+        public DiagnosticsRequestMiddleware(RequestDelegate next, ILogger<DiagnosticsRequestMiddleware> logger)
         {
             _next = next;
+            _logger = logger;
         }
 
         public async Task Invoke(HttpContext httpContext)
@@ -52,6 +57,7 @@ namespace Diagnostics.RuntimeHost.Middleware
             {
                 exception = ex;
                 statusCode = (int)HttpStatusCode.InternalServerError;
+                throw;
             }
             finally
             {
@@ -146,6 +152,8 @@ namespace Diagnostics.RuntimeHost.Middleware
 
         private void LogException(HttpContext context, Exception ex)
         {
+            _logger.LogError(ex, $"Failed to process request for {context.Request.Path.Value}", null);
+
             try
             {
                 var logger = (ApiMetricsLogger)context.Items[HostConstants.ApiLoggerKey] ?? new ApiMetricsLogger(context);

--- a/src/Diagnostics.RuntimeHost/Program.cs
+++ b/src/Diagnostics.RuntimeHost/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.Configuration.AzureKeyVault;
+using Microsoft.Extensions.Logging;
 using Diagnostics.DataProviders;
 using System;
 using Microsoft.CodeAnalysis;
@@ -41,16 +42,23 @@ namespace Diagnostics.RuntimeHost
             return WebHost.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((context, config) =>
                 {
-                    var (keyVaultConfig, keyVaultClient) = GetKeyVaultSettings(context, config);
+                    var (keyVaultUri, keyVaultClient) = GetKeyVaultSettings(context, config);
 
                     config
                         .AddAzureKeyVault(
-                            $"https://{keyVaultConfig}.vault.azure.net/",
+                            keyVaultUri,
                             keyVaultClient,
                             new DefaultKeyVaultSecretManager())
                         .AddEnvironmentVariables()
                         .AddCommandLine(args)
                         .Build();
+                })
+                .ConfigureLogging(loggingBuilder =>
+                {
+                    //Send log output to text file application logs
+                    loggingBuilder.AddAzureWebAppDiagnostics();
+                    //Send log output to the Windows Event Log
+                    loggingBuilder.AddEventLog();
                 })
                 .UseStartup<Startup>()
                 .Build();
@@ -58,15 +66,13 @@ namespace Diagnostics.RuntimeHost
 
         private static Tuple<string, KeyVaultClient> GetKeyVaultSettings(WebHostBuilderContext context, IConfigurationBuilder config)
         {
-            var azureServiceTokenProvider = new AzureServiceTokenProvider();
+            var builtConfig = config.Build();
+            var azureServiceTokenProvider = new AzureServiceTokenProvider(azureAdInstance: builtConfig["Secrets:AzureAdInstance"]);
             var keyVaultClient = new KeyVaultClient(
                 new KeyVaultClient.AuthenticationCallback(
                     azureServiceTokenProvider.KeyVaultTokenCallback));
 
             string keyVaultConfig = Helpers.GetKeyvaultforEnvironment(context.HostingEnvironment.EnvironmentName);
-
-            var builtConfig = config.Build();
-
             return new Tuple<string, KeyVaultClient>(builtConfig[keyVaultConfig], keyVaultClient);
         }
     }

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -1,8 +1,9 @@
 {
   "Secrets": {
-    "DevKeyVaultName": "appservicediagnostics",
-    "StagingKeyVaultName": "AppServiceDiagnosticsKV",
-    "ProdKeyVaultName": "AppServiceDiagnosticsKV"
+    "DevKeyVaultName": "https://appservicediagnostics.vault.azure.net/",
+    "StagingKeyVaultName": "https://AppServiceDiagnosticsKV.vault.azure.net/",
+    "ProdKeyVaultName": "https://AppServiceDiagnosticsKV.vault.azure.net/",
+    "AzureAdInstance": "https://login.microsoftonline.com/"
   },
   "Logging": {
     "IncludeScopes": false,
@@ -22,7 +23,8 @@
     "ClientId": "",
     "AppKey": "",
     "AADAuthority": "",
-    "AADResource": ""
+    "AADResource": "",
+    "Enabled": true
   },
   "SourceWatcher": {
     "WatcherType": "1",
@@ -58,7 +60,8 @@
     "ClientId": "",
     "AppKey": "",
     "Endpoint": "https://wawsobserver-prod.azurewebsites.net",
-    "ObserverLocalHostEnabled": false
+    "ObserverLocalHostEnabled": false,
+    "AADResource": "d1abfd91-e19c-426e-802f-a6c55421a5ef"
   },
   "GeoMaster": {
     "GeoCertThumbprint": "",
@@ -71,7 +74,8 @@
   "Mdm": {
     "MdmShoeboxEndpoint": "",
     "MdmRegistrationCertThumbprint": "",
-    "MdmShoeboxAccount": ""
+    "MdmShoeboxAccount": "",
+    "Enabled": true
   },
   "ChangeAnalysis": {
     "ClientId": "",
@@ -79,7 +83,8 @@
     "AADAuthority": "https://login.microsoftonline.com/microsoft.onmicrosoft.com",
     "AADResource": "",
     "Endpoint": "https://changeanalysis-dataplane-dev.azurewebsites.net/providers/microsoft.changeanalysis/",
-    "Apiversion": "2019-04-01-preview"
+    "Apiversion": "2019-04-01-preview",
+    "Enabled": true
   },
   "AzureSupportCenter": {
     "BaseUri": "https://api.diagnostics.msftcloudes.com",
@@ -90,6 +95,7 @@
     "TokenResource": "https://microsoft.onmicrosoft.com/azurediagnostic",
     "ClientId": "",
     "AppKey": "",
+    "Enabled": true,
     "DiagAscHeader":  ""
   },
   "SearchAPI": {
@@ -104,7 +110,8 @@
   "SecuritySettings": {
     "AADAuthority": "",
     "ClientId": "",
-    "AllowedAppIds": ""
+    "AllowedAppIds": "",
+    "ShowIdentityModelErrors": false
   },
   "CloudDomain": "PublicAzure",
   "HealthCheckSettings": {


### PR DESCRIPTION
- Remove static KeyVault URL and make it configurable so that it can be configured for different clouds
- By default `AzureServiceTokenProvider` uses public AAD authority, instead make the authority configurable and pass it into the class's constructor
- Log unhanded exceptions to app service application logs and windows event logs
- Create configurable feature flags for each data provider and compilerhost
- Add dependency checker API
- Create overload of ExecuteClusterQuery which takes cluster and database as parameters. This will stop kusto queries from proxying through our clusters
- Remove static text for AAD resource for Observer and create configurable AAD resource.