### PR TITLE
ASC bridge with support topic mapping for all partner products

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/ApiManagement/ApiManagementController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ApiManagement/ApiManagementController.cs
@@ -6,6 +6,8 @@ using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Newtonsoft.Json;
+using Microsoft.CSharp.RuntimeBinder;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -50,9 +52,18 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.Insights)]
-        public async Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string serviceName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string serviceName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string supportTopic = null, string startTime = null, string endTime = null, string timeGrain = null)
         {
-            return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, serviceName), pesId, supportTopicId, startTime, endTime, timeGrain);
+            string postBodyString;
+            try
+            {
+                postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
+            }
+            catch (RuntimeBinderException)
+            {
+                postBodyString = "";
+            }
+            return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, serviceName), pesId, supportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }
 
         /// <summary>

--- a/src/Diagnostics.RuntimeHost/Controllers/AppServiceCertificate/AppServiceCertificateController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/AppServiceCertificate/AppServiceCertificateController.cs
@@ -6,6 +6,8 @@ using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Newtonsoft.Json;
+using Microsoft.CSharp.RuntimeBinder;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -50,9 +52,18 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.Insights)]
-        public async Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string certificateName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string certificateName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string supportTopic = null, string startTime = null, string endTime = null, string timeGrain = null)
         {
-            return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, certificateName), pesId, supportTopicId, startTime, endTime, timeGrain);
+            string postBodyString;
+            try
+            {
+                postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
+            }
+            catch (RuntimeBinderException)
+            {
+                postBodyString = "";
+            }
+            return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, certificateName), pesId, supportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }
 
         /// <summary>

--- a/src/Diagnostics.RuntimeHost/Controllers/AppServiceDomain/AppServiceDomainController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/AppServiceDomain/AppServiceDomainController.cs
@@ -6,6 +6,8 @@ using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Newtonsoft.Json;
+using Microsoft.CSharp.RuntimeBinder;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -50,9 +52,18 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.Insights)]
-        public async Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string domainName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string domainName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string supportTopic = null, string startTime = null, string endTime = null, string timeGrain = null)
         {
-            return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, domainName), pesId, supportTopicId, startTime, endTime, timeGrain);
+            string postBodyString;
+            try
+            {
+                postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
+            }
+            catch (RuntimeBinderException)
+            {
+                postBodyString = "";
+            }
+            return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, domainName), pesId, supportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }
 
         /// <summary>

--- a/src/Diagnostics.RuntimeHost/Controllers/ArmResource/ArmResourceController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ArmResource/ArmResourceController.cs
@@ -7,6 +7,8 @@ using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Newtonsoft.Json;
+using Microsoft.CSharp.RuntimeBinder;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -54,9 +56,18 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.Insights)]
-        public Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string provider, string resourceTypeName, string resourceName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string startTime = null, string endTime = null, string timeGrain = null)
+        public Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string provider, string resourceTypeName, string resourceName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string supportTopic = null, string startTime = null, string endTime = null, string timeGrain = null)
         {
-            return base.GetInsights(new ArmResource(subscriptionId, resourceGroupName, provider, resourceTypeName, resourceName, GetLocation()), pesId, supportTopicId, startTime, endTime, timeGrain);
+            string postBodyString;
+            try
+            {
+                postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
+            }
+            catch (RuntimeBinderException)
+            {
+                postBodyString = "";
+            }
+            return base.GetInsights(new ArmResource(subscriptionId, resourceGroupName, provider, resourceTypeName, resourceName, GetLocation()), pesId, supportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }
 
         /// <summary>

--- a/src/Diagnostics.RuntimeHost/Controllers/AzureKubernetesService/AzureKubernetesServiceController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/AzureKubernetesService/AzureKubernetesServiceController.cs
@@ -6,6 +6,9 @@ using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Newtonsoft.Json;
+using Microsoft.CSharp.RuntimeBinder;
+
 namespace Diagnostics.RuntimeHost.Controllers
 {
     [Authorize]
@@ -49,9 +52,18 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.Insights)]
-        public async Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string clusterName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string clusterName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string supportTopic = null, string startTime = null, string endTime = null, string timeGrain = null)
         {
-            return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, clusterName), pesId, supportTopicId, startTime, endTime, timeGrain);
+            string postBodyString;
+            try
+            {
+                postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
+            }
+            catch (RuntimeBinderException)
+            {
+                postBodyString = "";
+            }
+            return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, clusterName), pesId, supportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }
 
         /// <summary>

--- a/src/Diagnostics.RuntimeHost/Controllers/LogicApp/LogicAppController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/LogicApp/LogicAppController.cs
@@ -6,6 +6,8 @@ using Diagnostics.RuntimeHost.Models;
 using Diagnostics.RuntimeHost.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Newtonsoft.Json;
+using Microsoft.CSharp.RuntimeBinder;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -50,9 +52,18 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.Insights)]
-        public async Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string logicAppName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> GetInsights(string subscriptionId, string resourceGroupName, string logicAppName, [FromBody] dynamic postBody, string pesId, string supportTopicId = null, string supportTopic = null, string startTime = null, string endTime = null, string timeGrain = null)
         {
-            return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, logicAppName), pesId, supportTopicId, startTime, endTime, timeGrain);
+            string postBodyString;
+            try
+            {
+                postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
+            }
+            catch (RuntimeBinderException)
+            {
+                postBodyString = "";
+            }
+            return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, logicAppName), pesId, supportTopicId, startTime, endTime, timeGrain, postBodyString);
         }
 
         /// <summary>

--- a/src/Diagnostics.RuntimeHost/Services/SupportTopicService/SupportTopicService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SupportTopicService/SupportTopicService.cs
@@ -44,7 +44,7 @@ namespace Diagnostics.RuntimeHost.Services
             string query = $@"cluster('azsupport').database('AzureSupportability').ActiveSupportTopicTree
                             | where Timestamp > ago(3d)
                             | summarize by ProductId, SupportTopicId = SupportTopicL3Id, ProductName, SupportTopicL2Name, SupportTopicL3Name
-                            | where SupportTopicId != '' //and SupportTopicL2Name != '' //and SupportTopicL3Name != ''
+                            | where SupportTopicId != ''
                             | extend SupportTopicPath = strcat(ProductName, '\\', SupportTopicL2Name,'\\', SupportTopicL3Name)
                             | project ProductId, SupportTopicId, SupportTopicPath";
             return query;

--- a/src/Diagnostics.RuntimeHost/Services/SupportTopicService/SupportTopicService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SupportTopicService/SupportTopicService.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using Diagnostics.DataProviders;
+using Diagnostics.DataProviders.DataProviderConfigurations;
+using Newtonsoft.Json;
+
+namespace Diagnostics.RuntimeHost.Services
+{
+    public interface ISupportTopicService
+    {
+        Task<SupportTopicModel> GetSupportTopicFromString(string supportTopicString, DataProviderContext dataProviderContext);
+    }
+
+    public class SupportTopicModel
+    {
+        public string SupportTopicId { get; set; }
+        public string ProductId { get; set; }
+        public string SupportTopicPath { get; set; }
+
+        public SupportTopicModel(DataRow row)
+        {
+            SupportTopicId = row["SupportTopicId"].ToString();
+            ProductId = row["ProductId"].ToString();
+            SupportTopicPath = row["SupportTopicPath"].ToString();
+        }
+    }
+
+    public class SupportTopicService : ISupportTopicService
+    {
+        private Dictionary<string, SupportTopicModel> _supportTopicCache;
+        
+        public SupportTopicService()
+        {
+            _supportTopicCache = new Dictionary<string, SupportTopicModel>();
+        }
+
+        private string GetSupportTopicKustoQuery() {
+            string query = $@"cluster('azsupport').database('AzureSupportability').ActiveSupportTopicTree
+                            | where Timestamp > ago(3d)
+                            | summarize by ProductId, SupportTopicId = SupportTopicL3Id, ProductName, SupportTopicL2Name, SupportTopicL3Name
+                            | where SupportTopicId != '' //and SupportTopicL2Name != '' //and SupportTopicL3Name != ''
+                            | extend SupportTopicPath = strcat(ProductName, '\\', SupportTopicL2Name,'\\', SupportTopicL3Name)
+                            | project ProductId, SupportTopicId, SupportTopicPath";
+            return query;
+        }
+
+        private async Task PopulateSupportTopicCache(DataProviderContext dataProviderContext) {
+            var dp = new DataProviders.DataProviders(dataProviderContext);
+            DataTable supportTopicMappingTable = new DataTable();
+            Guid requestIdGuid = Guid.NewGuid();
+            supportTopicMappingTable = await dp.Kusto.ExecuteClusterQuery(GetSupportTopicKustoQuery(), requestIdGuid.ToString(), operationName: "PopulateSupportTopicCache");
+            foreach(DataRow row in supportTopicMappingTable.Rows)
+            {
+                _supportTopicCache[row["SupportTopicPath"].ToString()] = new SupportTopicModel(row);
+            }
+        }
+
+        public async Task<SupportTopicModel> GetSupportTopicFromString(string supportTopicString, DataProviderContext dataProviderContext)
+        {
+            SupportTopicModel result = null;
+            if (!_supportTopicCache.TryGetValue(supportTopicString, out result))
+            {
+                await PopulateSupportTopicCache(dataProviderContext);
+                _supportTopicCache.TryGetValue(supportTopicString, out result);
+            }
+            return result;
+        }
+    }
+}

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -125,6 +125,7 @@ namespace Diagnostics.RuntimeHost
             services.AddSingleton<IInvokerCacheService, InvokerCacheService>();
             services.AddSingleton<IGistCacheService, GistCacheService>();
             services.AddSingleton<ISiteService, SiteService>();
+            services.AddSingleton<ISupportTopicService, SupportTopicService>();
             services.AddScoped(typeof(IRuntimeContext<>), typeof(RuntimeContext<>));
             services.AddSingleton<IStampService>((serviceProvider) =>
             {


### PR DESCRIPTION
Modification to the GetInsights method of the controller of every resource type to accept a dynamic post body (where it isn't accepting already) and a supportTopic parameter which is the support topic path.

Pass the post body and supportTopicPath parameter to the base controller i.e. DiagnosticsControllerBase.

This controller takes care of converting the supportTopicPath into a product Id and Support topic Id which is further used in the existing flow of the api.

A support topic service created to carry out the conversion using a support topic path to id mapping obtained from kusto query.