### PR TITLE
Remove event log provider for public azure

### DIFF
--- a/src/Diagnostics.CompilerHost/Startup.cs
+++ b/src/Diagnostics.CompilerHost/Startup.cs
@@ -122,7 +122,6 @@ namespace Diagnostics.CompilerHost
                 loggingConfig.ClearProviders();
                 loggingConfig.AddConfiguration(Configuration.GetSection("Logging"));
                 loggingConfig.AddDebug();
-                loggingConfig.AddEventSourceLogger();
                 loggingConfig.AddAzureWebAppDiagnostics();
 
                 if (Environment.IsDevelopment())

--- a/src/Diagnostics.CompilerHost/Startup.cs
+++ b/src/Diagnostics.CompilerHost/Startup.cs
@@ -122,6 +122,7 @@ namespace Diagnostics.CompilerHost
                 loggingConfig.ClearProviders();
                 loggingConfig.AddConfiguration(Configuration.GetSection("Logging"));
                 loggingConfig.AddDebug();
+                loggingConfig.AddEventSourceLogger();
                 loggingConfig.AddAzureWebAppDiagnostics();
 
                 if (Environment.IsDevelopment())

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -194,10 +194,13 @@ namespace Diagnostics.RuntimeHost
                 loggingConfig.ClearProviders();
                 loggingConfig.AddConfiguration(Configuration.GetSection("Logging"));
                 loggingConfig.AddDebug();
-                loggingConfig.AddEventSourceLogger();
-                loggingConfig.AddEventLog();
-                loggingConfig.AddAzureWebAppDiagnostics();
 
+                if (string.Compare(Configuration.GetValue<string>("CloudDomain"), DataProviderConstants.AzureCloud, true) == 0)
+                {
+                    loggingConfig.AddEventLog();
+                    loggingConfig.AddAzureWebAppDiagnostics();
+                }
+             
                 if (Environment.IsDevelopment())
                 {
                     loggingConfig.AddConsole();

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -194,7 +194,8 @@ namespace Diagnostics.RuntimeHost
                 loggingConfig.ClearProviders();
                 loggingConfig.AddConfiguration(Configuration.GetSection("Logging"));
                 loggingConfig.AddDebug();
-                
+                loggingConfig.AddEventSourceLogger();
+
                 if (string.Compare(Configuration.GetValue<string>("CloudDomain"), DataProviderConstants.AzureCloud, true) == 0 || string.Compare(Configuration.GetValue<string>("CloudDomain"), DataProviderConstants.AzureCloudAlternativeName, true) == 0)
                 {
                     loggingConfig.AddEventLog();

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -194,8 +194,8 @@ namespace Diagnostics.RuntimeHost
                 loggingConfig.ClearProviders();
                 loggingConfig.AddConfiguration(Configuration.GetSection("Logging"));
                 loggingConfig.AddDebug();
-
-                if (string.Compare(Configuration.GetValue<string>("CloudDomain"), DataProviderConstants.AzureCloud, true) == 0)
+                
+                if (string.Compare(Configuration.GetValue<string>("CloudDomain"), DataProviderConstants.AzureCloud, true) == 0 || string.Compare(Configuration.GetValue<string>("CloudDomain"), DataProviderConstants.AzureCloudAlternativeName, true) == 0)
                 {
                     loggingConfig.AddEventLog();
                     loggingConfig.AddAzureWebAppDiagnostics();


### PR DESCRIPTION
We got some logging file locked exceptions because it's a shared resource. Remove this for public azure