### PR TITLE
Handle exception and fix logging issue

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubKustoConfigurationWorker.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubKustoConfigurationWorker.cs
@@ -65,7 +65,7 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
                 foreach (var githubFile in githubEntries)
                 {
                     string downloadFilePath = Path.Combine(artifactsDestination.FullName, githubFile.Name.ToLower());
-                    LogMessage($"Begin downloading File : {githubFile.Name.ToLower()} and saving it as : {downloadFilePath}");
+                    LogMessage($"Begin downloading File : {githubFile.Name.ToLower()} and saving it as : {downloadFilePath}", Name);
                     await _githubClient.DownloadFile(githubFile.Download_url, downloadFilePath);
 
                     _cacheService.TryRemoveValue(artifactsDestination.Name, out List<Dictionary<string, string>> throwAway);

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubScriptWorkerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubScriptWorkerBase.cs
@@ -53,13 +53,13 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
 
                 if (string.IsNullOrWhiteSpace(cacheId) || !GetCacheService().TryGetValue(cacheId, out EntityInvoker invoker) || invoker.EntityMetadata.Sha != subDirSha)
                 {
-                    LogMessage($"Folder : {subDir.FullName} missing in invoker cache.");
+                    LogMessage($"Folder : {subDir.FullName} missing in invoker cache.", Name);
 
                     // Check if delete marker file exists.
                     var deleteMarkerFile = new FileInfo(Path.Combine(subDir.FullName, _deleteMarkerName));
                     if (deleteMarkerFile.Exists)
                     {
-                        LogMessage("Folder marked for deletion. Skipping cache update");
+                        LogMessage("Folder marked for deletion. Skipping cache update", Name);
                         return;
                     }
 
@@ -68,7 +68,7 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
                     var metadataFile = Path.Combine(subDir.FullName, "metadata.json");
                     if (mostRecentAssembly == default(FileInfo) || csxScriptFile == default(FileInfo))
                     {
-                        LogWarning("No Assembly file (.dll) or Csx File found (.csx). Skipping cache update");
+                        LogWarning("No Assembly file (.dll) or Csx File found (.csx). Skipping cache update", Name);
                         return;
                     }
 
@@ -85,26 +85,26 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
                         metadata = await FileHelper.GetFileContentAsync(metadataFile);
                     }
 
-                    LogMessage($"Loading assembly : {mostRecentAssembly.FullName}");
+                    LogMessage($"Loading assembly : {mostRecentAssembly.FullName}", Name);
                     var asm = Assembly.LoadFrom(mostRecentAssembly.FullName);
                     invoker = new EntityInvoker(new EntityMetadata(scriptText, GetEntityType(), metadata, subDirSha));
                     invoker.InitializeEntryPoint(asm);
 
                     if (invoker.EntryPointDefinitionAttribute != null)
                     {
-                        LogMessage($"Updating cache with new invoker with id : {invoker.EntryPointDefinitionAttribute.Id}");
+                        LogMessage($"Updating cache with new invoker with id : {invoker.EntryPointDefinitionAttribute.Id}", Name);
                         GetCacheService().AddOrUpdate(invoker.EntryPointDefinitionAttribute.Id, invoker);
                         await FileHelper.WriteToFileAsync(subDir.FullName, _cacheIdFileName, invoker.EntryPointDefinitionAttribute.Id);
                     }
                     else
                     {
-                        LogWarning("Missing Entry Point Definition attribute. skipping cache update");
+                        LogWarning("Missing Entry Point Definition attribute. skipping cache update", Name);
                     }
                 }
             }
             catch (Exception ex)
             {
-                LogException(ex.Message, ex);
+                LogException(ex.Message, ex, Name);
             }
         }
 
@@ -145,7 +145,7 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
                     downloadFilePath = Path.Combine(artifactsDestination.FullName, $"{assemblyName}.{fileExtension.ToLower()}");
                 }
 
-                LogMessage($"Begin downloading File : {githubFile.Name.ToLower()} and saving it as : {downloadFilePath}");
+                LogMessage($"Begin downloading File : {githubFile.Name.ToLower()} and saving it as : {downloadFilePath}", Name);
                 await _githubClient.DownloadFile(githubFile.Download_url, downloadFilePath);
             }
 
@@ -176,38 +176,48 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
         /// <returns>Task for downloading and updating cache.</returns>
         public override async Task CreateOrUpdateCacheAsync(DirectoryInfo destDir, string sha, string scriptText, string assemblyPath, string metadata)
         {
-            if (_loadOnlyPublicDetectors && !regexPublicDetectors.Match(scriptText).Success)
+            try
             {
-                return;
-            }
+                if (_loadOnlyPublicDetectors && !regexPublicDetectors.Match(scriptText).Success)
+                {
+                    return;
+                }
 
-            LogMessage($"Loading assembly : {assemblyPath}");
-            var asm = Assembly.LoadFrom(assemblyPath);
+                LogMessage($"Loading assembly : {assemblyPath}", Name);
+                var asm = Assembly.LoadFrom(assemblyPath);
 
-            var newInvoker = new EntityInvoker(new EntityMetadata(scriptText, GetEntityType(), metadata, sha));
-            newInvoker.InitializeEntryPoint(asm);
+                var newInvoker = new EntityInvoker(new EntityMetadata(scriptText, GetEntityType(), metadata, sha));
+                newInvoker.InitializeEntryPoint(asm);
 
-            var cacheIdFilePath = Path.Combine(destDir.FullName, _cacheIdFileName);
+                var cacheIdFilePath = Path.Combine(destDir.FullName, _cacheIdFileName);
 
-            // Remove the Old Invoker from Cache
-            var lastCacheId = await FileHelper.GetFileContentAsync(cacheIdFilePath);
-            if (!string.IsNullOrWhiteSpace(lastCacheId) && GetCacheService().TryRemoveValue(lastCacheId, out EntityInvoker oldInvoker))
+                // Remove the Old Invoker from Cache
+                var lastCacheId = await FileHelper.GetFileContentAsync(cacheIdFilePath);
+                if (!string.IsNullOrWhiteSpace(lastCacheId) && GetCacheService().TryRemoveValue(lastCacheId, out EntityInvoker oldInvoker))
+                {
+                    LogMessage($"Removing old invoker with id : {oldInvoker.EntryPointDefinitionAttribute.Id} from Cache", Name);
+                    oldInvoker.Dispose();
+                }
+
+                // Add new invoker to Cache and update Cache Id File
+                if (newInvoker.EntryPointDefinitionAttribute != null)
+                {
+                    LogMessage($"Updating cache with  new invoker with id : {newInvoker.EntryPointDefinitionAttribute.Id}", Name);
+                    GetCacheService().AddOrUpdate(newInvoker.EntryPointDefinitionAttribute.Id, newInvoker);
+                    await FileHelper.WriteToFileAsync(cacheIdFilePath, newInvoker.EntryPointDefinitionAttribute.Id);
+                }
+                else
+                {
+                    LogWarning("Missing Entry Point Definition attribute. skipping cache update", Name);
+                }
+            } catch (Exception ex)
             {
-                LogMessage($"Removing old invoker with id : {oldInvoker.EntryPointDefinitionAttribute.Id} from Cache");
-                oldInvoker.Dispose();
+                if(!ex.ToString().Contains("process cannot access the file"))
+                {
+                    throw;
+                }
             }
-
-            // Add new invoker to Cache and update Cache Id File
-            if (newInvoker.EntryPointDefinitionAttribute != null)
-            {
-                LogMessage($"Updating cache with  new invoker with id : {newInvoker.EntryPointDefinitionAttribute.Id}");
-                GetCacheService().AddOrUpdate(newInvoker.EntryPointDefinitionAttribute.Id, newInvoker);
-                await FileHelper.WriteToFileAsync(cacheIdFilePath, newInvoker.EntryPointDefinitionAttribute.Id);
-            }
-            else
-            {
-                LogWarning("Missing Entry Point Definition attribute. skipping cache update");
-            }
+            
         }
     }
 }

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubWorkerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubWorkerBase.cs
@@ -34,20 +34,20 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
             return workerId;
         }
 
-        protected static void LogMessage(string message)
+        protected static void LogMessage(string message, string worker = "GithubWatcher")
         {
-            DiagnosticsETWProvider.Instance.LogSourceWatcherMessage("GithubWatcher", message);
+            DiagnosticsETWProvider.Instance.LogSourceWatcherMessage(worker, message);
         }
 
-        protected static void LogWarning(string message)
+        protected static void LogWarning(string message, string worker = "GithubWatcher")
         {
-            DiagnosticsETWProvider.Instance.LogSourceWatcherWarning("GithubWatcher", message);
+            DiagnosticsETWProvider.Instance.LogSourceWatcherWarning(worker, message);
         }
 
-        protected static void LogException(string message, Exception ex)
+        protected static void LogException(string message, Exception ex, string worker = "GithubWatcher")
         {
-            var exception = new SourceWatcherException("Github", message, ex);
-            DiagnosticsETWProvider.Instance.LogSourceWatcherException("GithubWatcher", message, exception.GetType().ToString(), exception.ToString());
+            var exception = new SourceWatcherException(worker, message, ex);
+            DiagnosticsETWProvider.Instance.LogSourceWatcherException(worker, message, exception.GetType().ToString(), exception.ToString());
         }
 
         protected static FileInfo GetMostRecentFileByExtension(DirectoryInfo dir, string extension)


### PR DESCRIPTION
- Include GithubWorker name in the log (GithubGistWorker, GithubDetectorWorker, GithubKustoConfigurationWorker) to distinguish between logs. Right now all these logs coming from different workers have same name "GithubWatcher"

- Skip exception "process cannot access file" 