### PR TITLE
Model read write improvements

### DIFF
--- a/src/Diagnostics.AIProjects/SearchAPI/SearchModule/StorageAccountHelper.py
+++ b/src/Diagnostics.AIProjects/SearchAPI/SearchModule/StorageAccountHelper.py
@@ -25,7 +25,7 @@ class StorageAccountHelper:
 			for productId in productIds:
 				modelOnDisk = None
 				try:
-					modelOnDisk = open(os.path.join(os.getcwd(), app.config["TRAINED_MODELS_PATH"], productId, "trainingId.txt")).read()
+					modelOnDisk = open(os.path.join(os.getcwd(), app.config["TRAINED_MODELS_PATH"], productId, "trainingId.txt")).read().strip()
 				except:
 					pass
 				loadedModelId = None
@@ -51,7 +51,7 @@ class StorageAccountHelper:
 							if modelOnDisk != loadedModelId:
 								try:
 									self.loggerInstance.logInsights("modelReloadTask: Models are changed for {0}. Reloading the latest model.".format(productId))
-									loadModel(productId)
+									loadModel(productId, None, forced=True)
 								except Exception as e:
 									self.loggerInstance.logHandledException("modelReloadTask", "Failed to reload the latest model: {0}".format(str(e)))
 						else:

--- a/src/Diagnostics.AIProjects/SearchAPI/SearchModule/TextSearchModule.py
+++ b/src/Diagnostics.AIProjects/SearchAPI/SearchModule/TextSearchModule.py
@@ -12,7 +12,7 @@ class TextSearchModel():
     def __init__(self, modelpackagepath):
         self.trainingId = None
         try:
-            self.trainingId = open(absPath(os.path.join(modelpackagepath, "trainingId.txt"))).read()
+            self.trainingId = open(absPath(os.path.join(modelpackagepath, "trainingId.txt"))).read().strip()
         except:
             pass
         modelInfo = ModelInfo(json.loads(open(absPath(os.path.join(modelpackagepath, "ModelInfo.json"))).read()))
@@ -28,13 +28,13 @@ class TextSearchModel():
     def queryUtterances(self, query=None, existing_utterances=[]):
         return self.model.queryUtterances(query, existing_utterances)
 
-def loadModel(productId, model=None):
+def loadModel(productId, model=None, forced=False):
     prelogMessage = loadModelMessage.format(productId)
     if model:
         loggerInstance.logInsights(f"{prelogMessage}From provided pre-loaded model.")
         loaded_models[productId] = model
         return
-    if productId in loaded_models:
+    if (productId in loaded_models) and (not forced):
         loggerInstance.logInsights(f"{prelogMessage}Model is already loaded in app")
         return
     modelpackagepath = os.path.join("SearchModule", productId)


### PR DESCRIPTION
We are trying to avoid any unnecessary writes to the worker file server for refreshing models. This will save trouble when multiple instances are trying to refresh the model and get permission denied error.