### PR TITLE
Enable ETW events for runtime logs

### DIFF
--- a/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
+++ b/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
@@ -596,5 +596,113 @@ namespace Diagnostics.Logger
         }
 
         #endregion Internal AI API Events (ID Range : 4000 - 4199)
+
+        #region Runtime Events (ID Range: 5000 - 5199)
+
+        /// <summary>
+        /// Log runtime host message (Error/Critical).
+        /// </summary>
+        /// <param name="RequestId">Request id.</param>
+        /// <param name="Source">The source.</param>
+        /// <param name="SubscriptionId">Subscription id.</param>
+        /// <param name="ResourceGroup">Resource group.</param>
+        /// <param name="Resource">The resource.</param>
+        /// <param name="ExceptionType">Exception type.</param>
+        /// <param name="ExceptionDetails">Exception details.</param>
+        /// <param name="Message">The message.</param>
+        [Event(5000, Level = EventLevel.Error, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeMessage)]
+        public void LogRuntimeLogError(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string ExceptionType, string ExceptionDetails, string Message)
+        {
+            WriteDiagnosticsEvent(
+                5000,
+                RequestId,
+                Source,
+                SubscriptionId,
+                ResourceGroup,
+                Resource,
+                ExceptionType,
+                ExceptionDetails,
+                Message);
+        }
+
+        /// <summary>
+        /// Log runtime host message (Warning).
+        /// </summary>
+        /// <param name="RequestId">Request id.</param>
+        /// <param name="Source">The source.</param>
+        /// <param name="SubscriptionId">Subscription id.</param>
+        /// <param name="ResourceGroup">Resource group.</param>
+        /// <param name="Resource">The resource.</param>
+        /// <param name="ExceptionType">Exception type.</param>
+        /// <param name="ExceptionDetails">Exception details.</param>
+        /// <param name="Message">The message.</param>
+        [Event(5001, Level = EventLevel.Warning, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeMessage)]
+        public void LogRuntimeLogWarning(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string ExceptionType, string ExceptionDetails, string Message)
+        {
+            WriteDiagnosticsEvent(
+                5001,
+                RequestId,
+                Source,
+                SubscriptionId,
+                ResourceGroup,
+                Resource,
+                ExceptionType,
+                ExceptionDetails,
+                Message);
+        }
+
+        /// <summary>
+        /// Log runtime host message (Information).
+        /// </summary>
+        /// <param name="RequestId">Request id.</param>
+        /// <param name="Source">The source.</param>
+        /// <param name="SubscriptionId">Subscription id.</param>
+        /// <param name="ResourceGroup">Resource group.</param>
+        /// <param name="Resource">The resource.</param>
+        /// <param name="ExceptionType">Exception type.</param>
+        /// <param name="ExceptionDetails">Exception details.</param>
+        /// <param name="Message">The message.</param>
+        [Event(5002, Level = EventLevel.Informational, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeMessage)]
+        public void LogRuntimeLogInformation(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string ExceptionType, string ExceptionDetails, string Message)
+        {
+            WriteDiagnosticsEvent(
+                5002,
+                RequestId,
+                Source,
+                SubscriptionId,
+                ResourceGroup,
+                Resource,
+                ExceptionType,
+                ExceptionDetails,
+                Message);
+        }
+
+        /// <summary>
+        /// Log runtime host message (Trace/Debug).
+        /// </summary>
+        /// <param name="RequestId">Request id.</param>
+        /// <param name="Source">The source.</param>
+        /// <param name="SubscriptionId">Subscription id.</param>
+        /// <param name="ResourceGroup">Resource group.</param>
+        /// <param name="Resource">The resource.</param>
+        /// <param name="ExceptionType">Exception type.</param>
+        /// <param name="ExceptionDetails">Exception details.</param>
+        /// <param name="Message">The message.</param>
+        [Event(5003, Level = EventLevel.Warning, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeMessage)]
+        public void LogRuntimeLogTrace(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string ExceptionType, string ExceptionDetails, string Message)
+        {
+            WriteDiagnosticsEvent(
+                5003,
+                RequestId,
+                Source,
+                SubscriptionId,
+                ResourceGroup,
+                Resource,
+                ExceptionType,
+                ExceptionDetails,
+                Message);
+        }
+
+        #endregion
     }
 }

--- a/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
+++ b/src/Diagnostics.Logger/ETWProvider/DiagnosticsETWProvider.cs
@@ -688,7 +688,7 @@ namespace Diagnostics.Logger
         /// <param name="ExceptionType">Exception type.</param>
         /// <param name="ExceptionDetails">Exception details.</param>
         /// <param name="Message">The message.</param>
-        [Event(5003, Level = EventLevel.Warning, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeMessage)]
+        [Event(5003, Level = EventLevel.Verbose, Channel = EventChannel.Admin, Message = ETWMessageTemplates.LogRuntimeMessage)]
         public void LogRuntimeLogTrace(string RequestId, string Source, string SubscriptionId, string ResourceGroup, string Resource, string ExceptionType, string ExceptionDetails, string Message)
         {
             WriteDiagnosticsEvent(

--- a/src/Diagnostics.Logger/ETWProvider/ETWMessageTemplates.cs
+++ b/src/Diagnostics.Logger/ETWProvider/ETWMessageTemplates.cs
@@ -34,6 +34,7 @@ namespace Diagnostics.Logger
         public const string LogRuntimeHostHandledException = "Runtime Host Handled Exception : {3}";
         public const string LogRuntimeHostDetectorAscInsight = "ASC Insight Detail for Detector";
         public const string LogRuntimeHostSupportTopicAscInsight = "ASC Insight Detail for Detector";
+        public const string LogRuntimeMessage = "Runtime Log from Detector";
 
         #endregion Runtime Host Event Message Templates
 

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -79,7 +79,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                 return BadRequest(errorMessage);
             }
 
-            RuntimeContext<TResource> cxt = PrepareContext(resource, startTimeUtc, endTimeUtc, Form: form);
+            RuntimeContext<TResource> cxt = PrepareContext(resource, startTimeUtc, endTimeUtc, Form: form, detectorId: detectorId);
             var detectorResponse = await GetDetectorInternal(detectorId, cxt);
             return detectorResponse == null ? (IActionResult)NotFound() : Ok(DiagnosticApiResponse.FromCsxResponse(detectorResponse.Item1, detectorResponse.Item2));
         }
@@ -165,7 +165,7 @@ namespace Diagnostics.RuntimeHost.Controllers
 
             await _sourceWatcherService.Watcher.WaitForFirstCompletion();
 
-            var runtimeContext = PrepareContext(resource, startTimeUtc, endTimeUtc, Form: Form);
+            var runtimeContext = PrepareContext(resource, startTimeUtc, endTimeUtc, Form: Form, detectorId: detectorId);
 
             var dataProviders = new DataProviders.DataProviders((DataProviderContext)HttpContext.Items[HostConstants.DataProviderContextKey]);
 
@@ -322,12 +322,13 @@ namespace Diagnostics.RuntimeHost.Controllers
                         {
                             runtimeContext.OperationContext.Logger.LogInformation(invocationResponse.ToString());
                         }
-                        runtimeContext.OperationContext.Logger.LogError(FlattenIfAggregatedException(ex).ToString());
+                        var baseException = FlattenIfAggregatedException(ex);
+                        runtimeContext.OperationContext.Logger.LogError(baseException, "Runtime exception has occurred");
                         queryRes.RuntimeLogOutput = _loggerProvider.GetAndClear(runtimeContext.OperationContext.RequestId);
                         if (isInternalCall)
                         {
                             queryRes.RuntimeSucceeded = false;
-                            queryRes.InvocationOutput = CreateQueryExceptionResponse(ex, invoker.EntryPointDefinitionAttribute, isInternalCall, GetDataProvidersMetadata(dataProviders));
+                            queryRes.InvocationOutput = CreateQueryExceptionResponse(baseException, invoker.EntryPointDefinitionAttribute, isInternalCall, GetDataProvidersMetadata(dataProviders));
                         }
                         else
                         {
@@ -358,7 +359,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                 Metadata = RemovePIIFromDefinition(detectorDefinition, isInternal),
                 IsInternalCall = isInternal
             };
-            response.AddMarkdownView($"<pre><code>Exception message:<strong> {ex.Message}</strong><br>Stack trace: {ex.StackTrace}</code></pre>", "Detector Runtime Exception");
+            response.AddMarkdownView($"<pre><code>Exception message:<strong> {ex.GetType().FullName}: {ex.Message}</strong><br>Stack trace: {ex.StackTrace}</code></pre>", "Detector Runtime Exception");
             return DiagnosticApiResponse.FromCsxResponse(response, dataProvidersMetadata);
         }
 
@@ -560,7 +561,7 @@ namespace Diagnostics.RuntimeHost.Controllers
             return systemContext;
         }
 
-        private RuntimeContext<TResource> PrepareContext(TResource resource, DateTime startTime, DateTime endTime, bool forceInternal = false, SupportTopic supportTopic = null, Form Form = null)
+        private RuntimeContext<TResource> PrepareContext(TResource resource, DateTime startTime, DateTime endTime, bool forceInternal = false, SupportTopic supportTopic = null, Form Form = null, string detectorId = null)
         {
             this.Request.Headers.TryGetValue(HeaderConstants.RequestIdHeaderName, out StringValues requestIds);
             this.Request.Headers.TryGetValue(HeaderConstants.InternalClientHeader, out StringValues internalCallHeader);
@@ -593,6 +594,11 @@ namespace Diagnostics.RuntimeHost.Controllers
                 logger: _loggerProvider.CreateLogger(requestId)
             );
 
+            if (operationContext.Logger is RuntimeLogger runtimeLogger)
+            {
+                runtimeLogger.Resource = resource;
+                runtimeLogger.DetectorId = detectorId;
+            }
             _runtimeContext.ClientIsInternal = isInternalClient || forceInternal;
             _runtimeContext.OperationContext = operationContext;
             var queryParamCollection = Request.Query;


### PR DESCRIPTION
This PR adds ETW events ranging 5000 to 5003 for runtime event logs.

It also simplifies the runtime exception stack trace shown as a runtime exception insight