### PR TITLE
Move downloading Github files to GithubWatcher

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/GitHubWatcher.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/GitHubWatcher.cs
@@ -71,9 +71,9 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher
             #region Initialize Github Worker
 
             // TODO: Register the github worker with destination path.
-            var gistWorker = new GithubGistWorker(gistCache, _loadOnlyPublicDetectors, _githubClient);
-            var detectorWorker = new GithubDetectorWorker(invokerCache, _loadOnlyPublicDetectors, _githubClient);
-            var kustoMappingsWorker = new GithubKustoConfigurationWorker(kustoMappingsCache, _githubClient);
+            var gistWorker = new GithubGistWorker(gistCache, _loadOnlyPublicDetectors);
+            var detectorWorker = new GithubDetectorWorker(invokerCache, _loadOnlyPublicDetectors);
+            var kustoMappingsWorker = new GithubKustoConfigurationWorker(kustoMappingsCache);
 
             GithubWorkers = new Dictionary<string, IGithubWorker>
             {

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubDetectorWorker.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubDetectorWorker.cs
@@ -23,7 +23,7 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
         /// Initializes a new instance of the <see cref="GithubDetectorWorker"/> class.
         /// </summary>
         /// <param name="invokerCache">Invoker cache.</param>
-        public GithubDetectorWorker(IInvokerCacheService invokerCache, bool loadOnlyPublicDetectors, IGithubClient githubClient) : base(loadOnlyPublicDetectors, githubClient)
+        public GithubDetectorWorker(IInvokerCacheService invokerCache, bool loadOnlyPublicDetectors) : base(loadOnlyPublicDetectors)
         {
             InvokerCache = invokerCache;
         }

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubGistWorker.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubGistWorker.cs
@@ -28,7 +28,7 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
         /// Initializes a new instance of the <see cref="GithubGistWorker"/> class.
         /// </summary>
         /// <param name="gistCache">Gist cache service.</param>
-        public GithubGistWorker(IGistCacheService gistCache, bool loadOnlyPublicDetectors, IGithubClient githubClient) : base(loadOnlyPublicDetectors, githubClient)
+        public GithubGistWorker(IGistCacheService gistCache, bool loadOnlyPublicDetectors) : base(loadOnlyPublicDetectors)
         {
             GistCache = gistCache;
         }

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubKustoConfigurationWorker.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubKustoConfigurationWorker.cs
@@ -63,11 +63,7 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
             if (IsWorkerApplicable(githubEntries))
             {
                 foreach (var githubFile in githubEntries)
-                {
-                    string downloadFilePath = Path.Combine(artifactsDestination.FullName, githubFile.Name.ToLower());
-                    LogMessage($"Begin downloading File : {githubFile.Name.ToLower()} and saving it as : {downloadFilePath}", this.Name);
-                    await _githubClient.DownloadFile(githubFile.Download_url, downloadFilePath);
-
+                {                  
                     _cacheService.TryRemoveValue(artifactsDestination.Name, out List<Dictionary<string, string>> throwAway);
 
                     var kustoMappingsStringContent = await FileHelper.GetFileContentAsync(artifactsDestination.FullName, githubFile.Name);

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubKustoConfigurationWorker.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubKustoConfigurationWorker.cs
@@ -18,13 +18,11 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
     public class GithubKustoConfigurationWorker : GithubWorkerBase
     {
         public override string Name { get { return "KustoConfigurationWorker"; } }
-        private IGithubClient _githubClient;
         private IKustoMappingsCacheService _cacheService;
         private const string _kustoClusterFileName = "kustoClusterMappings";
 
-        public GithubKustoConfigurationWorker(IKustoMappingsCacheService cacheService, IGithubClient githubClient)
+        public GithubKustoConfigurationWorker(IKustoMappingsCacheService cacheService)
         {
-            _githubClient = githubClient;
             _cacheService = cacheService;
         }
 

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubScriptWorkerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubScriptWorkerBase.cs
@@ -110,12 +110,13 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
 
         public override async Task CreateOrUpdateCacheAsync(IEnumerable<GithubEntry> githubEntries, DirectoryInfo artifactsDestination, string lastModifiedMarker)
         {
-            var assemblyName = Guid.NewGuid().ToString();
+            var assemblyPath = string.Empty;
             var csxFilePath = string.Empty;
             var confFilePath = string.Empty;
             var metadataFilePath = string.Empty;
             var expectedFiles = new string[] { "csx", "package.json", "metadata.json" };
 
+            // Check if worker applicable for any of the downloaded files.
             if (!githubEntries.Any(x => expectedFiles.Any(y => x.Name.Contains(y, StringComparison.CurrentCultureIgnoreCase))))
             {
                 return;
@@ -141,16 +142,11 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
                 }
                 else
                 {
-                    // Use Guids for Assembly and PDB Names to ensure uniqueness.
-                    downloadFilePath = Path.Combine(artifactsDestination.FullName, $"{assemblyName}.{fileExtension.ToLower()}");
+                    assemblyPath = downloadFilePath;
                 }
-
-                LogMessage($"Begin downloading File : {githubFile.Name.ToLower()} and saving it as : {downloadFilePath}", this.Name);
-                await _githubClient.DownloadFile(githubFile.Download_url, downloadFilePath);
             }
 
             var scriptText = await FileHelper.GetFileContentAsync(csxFilePath);
-            var assemblyPath = Path.Combine(artifactsDestination.FullName, $"{assemblyName}.dll");
 
             var configFile = await FileHelper.GetFileContentAsync(confFilePath);
             var config = JsonConvert.DeserializeObject<PackageConfig>(configFile);

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubScriptWorkerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubScriptWorkerBase.cs
@@ -20,13 +20,11 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
     public abstract class GithubScriptWorkerBase : GithubWorkerBase
     {
         private readonly bool _loadOnlyPublicDetectors;
-        private IGithubClient _githubClient;
         private static Regex regexPublicDetectors = new Regex(@"InternalOnly\s*=\s*false", RegexOptions.IgnoreCase);
 
-        public GithubScriptWorkerBase(bool loadOnlyPublicDetectors, IGithubClient githubClient)
+        public GithubScriptWorkerBase(bool loadOnlyPublicDetectors)
         {
             _loadOnlyPublicDetectors = loadOnlyPublicDetectors;
-            _githubClient = githubClient;
         }
 
         protected abstract ICache<string, EntityInvoker> GetCacheService();


### PR DESCRIPTION
Having github client download files in base class can potentially cause race conditions between Gist and Detector SourceWatcher. Moved the github client download operation to GithubWatcher and specific SourceWatchers - Gist, Detector, Kusto will only read from file system and update their caches. 