### PR TITLE
Removing start up of more than one source watcher to avoid race condi…

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubScriptWorkerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Workers/GithubScriptWorkerBase.cs
@@ -140,7 +140,8 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Workers
                 }
                 else if(fileExtension.Equals("dll", StringComparison.OrdinalIgnoreCase))
                 {
-                    assemblyPath = downloadFilePath;
+                    //Getting most recent downloaded dll file for the corresponding Github entry.
+                    assemblyPath = GetMostRecentFileByExtension(artifactsDestination, ".dll").FullName;
                 }
             }
 

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -189,7 +189,7 @@ namespace Diagnostics.RuntimeHost
             {
                 services.AddSingleton<ISearchService, SearchServiceDisabled>();
             }
-            servicesProvider.GetService<ISourceWatcherService>();
+            
 
             services.AddLogging(loggingConfig =>
             {


### PR DESCRIPTION
We can see from logs that there are 2 GithubWatchers running which is leading to race conditions in terms of downloading and IO operations