### PR TITLE
Fix runtime error when compiling a gist

### DIFF
--- a/src/Diagnostics.Scripts/EntityInvoker.cs
+++ b/src/Diagnostics.Scripts/EntityInvoker.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Diagnostics.ModelsAndUtils.Attributes;
+using Diagnostics.ModelsAndUtils.Models;
 using Diagnostics.Scripts.CompilationService;
 using Diagnostics.Scripts.CompilationService.Gist;
 using Diagnostics.Scripts.CompilationService.Interfaces;
@@ -173,6 +174,12 @@ namespace Diagnostics.Scripts
             if (!IsCompilationSuccessful)
             {
                 throw new ScriptCompilationException(CompilationOutput);
+            }
+
+            if (EntityMetadata.Type == EntityType.Gist)
+            {
+                // This is a gist. We cannot invoke it. Let's return an empty response object.
+                return new Response();
             }
 
             var methodInfo = memberInfo as MethodInfo;


### PR DESCRIPTION
When compiling a gist, there is a runtime error showing up, like "Runtime exception has occurred: undefined: undefined undefined." This issue happens because the runtime host tries to invoke the entry point of the compiling .csx file and apparently the gist doesn't have any entry point.

This PR fixes the error by checking if the compiling file is a gist and then it skips to invoke the class.