### PR TITLE
Adding DataSources Tab info for AI and MDM

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/DataProviderMetadataQuery.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/DataProviderMetadataQuery.cs
@@ -1,0 +1,9 @@
+﻿namespace Diagnostics.ModelsAndUtils.Models
+{
+    public class DataProviderMetadataQuery
+    {
+        public string Text;
+        public string Url;
+        public string OperationName;
+    }
+}


### PR DESCRIPTION
With this PR, we are adding DataSource information for MDM provider and Application insights to Data Sources tab.

- For MDM, only a link to JARVIS portal with the right dashboard and timestamp will be provided (Unfortunately, for MDM, I cannot test my logic end to end because we dont have a private setup for MDM so there is a chance we have the URL which is slightly incorrect and might need another PR to get perfect) 
- For AppInsights, only the QueryText makes sense because we dont have the URL for customer's AI resource's Analytics blade. We are just pointing to documentation for Analytics for now.

After this gets deployed, slight changes would be required to the UI code because currently every link is coming as **Run In Kusto Web Explorer**

