### PR TITLE
Checking for Func instead of Interface

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/AppInsightsDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/AppInsightsDataProvider.cs
@@ -24,6 +24,10 @@ namespace Diagnostics.DataProviders
         {
             _configuration = configuration;
             _appInsightsClient = new AppInsightsClient(_configuration);
+            Metadata = new DataProviderMetadata
+            {
+                ProviderName = "AppInsights"
+            };
         }
 
         public Task<bool> SetAppInsightsKey(string appId, string apiKey)
@@ -110,10 +114,10 @@ namespace Diagnostics.DataProviders
 
         public async Task<DataTable> ExecuteAppInsightsQuery(string query)
         {
-            return await ExecuteAppInsightsQuery(query, "AppInsightsQuery");
+            return await ExecuteAppInsightsQuery(query, "");
         }
 
-        private void AddQueryInformationToMetadata(string query, string operationName = "AppInsightsQuery")
+        private void AddQueryInformationToMetadata(string query, string operationName = "")
         {
             bool queryExists = Metadata.PropertyBag.Any(x => x.Key == "Query" &&
                                                             x.Value.GetType() == typeof(DataProviderMetadataQuery) &&

--- a/src/Diagnostics.DataProviders/DataProviders/MdmDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/MdmDataProvider.cs
@@ -274,7 +274,7 @@ namespace Diagnostics.DataProviders
 
                 if (dashboard == "WAWS Shoebox/Web Apps/Per Resource")
                 {
-                    AddRemainingParametersForWebApps(queryParameters, resourceId);
+                    AddRemainingParametersForWebApps(queryParameters, resourceId, seriesResolutionInMinutes);
                 }
 
             }
@@ -297,7 +297,7 @@ namespace Diagnostics.DataProviders
             }
         }
 
-        private void AddRemainingParametersForWebApps(List<MdmQueryParameters> queryParameters, string resourceId)
+        private void AddRemainingParametersForWebApps(List<MdmQueryParameters> queryParameters, string resourceId, int seriesResolutionInMinutes)
         {
             var hostArray = resourceId.Split(".");
             if (hostArray.Length < 3)
@@ -318,6 +318,13 @@ namespace Diagnostics.DataProviders
                 replacement = hostArray[0]
             };
             queryParameters.Add(paramAppName);
+
+            var paramTimeResolution = new MdmQueryParameters
+            {
+                query = $"//*[id='timeResolution']",
+                replacement = seriesResolutionInMinutes.ToString()
+            };
+            queryParameters.Add(paramTimeResolution);
         }
 
         private double GetDateTimeInEpochMilliseconds(DateTime dateTimeUtc)

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -865,14 +865,53 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 if (dataProvider.FieldType.IsInterface)
                 {
-                    var metadataProvider = dataProvider.GetValue(dataProviders) as IMetadataProvider;
-                    if (metadataProvider != null)
+                    if (dataProvider.GetValue(dataProviders) is IMetadataProvider metadataProvider)
                     {
                         var metadata = metadataProvider.GetMetadata();
                         if (metadata != null)
                         {
                             dataprovidersMetadata.Add(metadata);
                         }
+                    }
+                }
+                else if (dataProvider.FieldType.UnderlyingSystemType.Name.StartsWith("Func`2", StringComparison.OrdinalIgnoreCase))
+                {
+                    //
+                    // run this logic in a try..catch as we don't want this part 
+                    // to break the detector execution 
+                    //
+                    try
+                    {
+                        if (dataProvider.GetValue(dataProviders) is MulticastDelegate m)
+                        {
+                            if (m.Method.ReturnType.IsInterface &&
+                                m.Method.ReturnType.GetInterfaces().Count() > 0
+                                && m.Method.ReturnType.GetInterfaces().Contains(typeof(IMetadataProvider)))
+                            {
+                                var methodParameters = m.Method.GetParameters();
+                                if (methodParameters.Count() == 1)
+                                {
+                                    var firstParameter = methodParameters.FirstOrDefault();
+                                    if (firstParameter.ParameterType.BaseType == typeof(Enum))
+                                    {
+                                        var enumArray = Enum.GetValues(firstParameter.ParameterType);
+
+                                        foreach (var e in enumArray)
+                                        {
+                                            var output = m.Method.Invoke(m.Target, new object[] { e }) as IMetadataProvider;
+                                            var metdata = output.GetMetadata();
+                                            if (metdata != null && metdata.PropertyBag.Count > 0)
+                                            {
+                                                dataprovidersMetadata.Add(metdata);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception)
+                    {
                     }
                 }
             }

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -868,7 +868,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                     if (dataProvider.GetValue(dataProviders) is IMetadataProvider metadataProvider)
                     {
                         var metadata = metadataProvider.GetMetadata();
-                        if (metadata != null && metadata.PropertyBag.Count > 0)
+                        if (metadata != null)
                         {
                             dataprovidersMetadata.Add(metadata);
                         }
@@ -876,42 +876,43 @@ namespace Diagnostics.RuntimeHost.Controllers
                 }
                 else if (dataProvider.FieldType.UnderlyingSystemType.Name.StartsWith("Func`2", StringComparison.OrdinalIgnoreCase))
                 {
-                    //
-                    // run this logic in a try..catch as we don't want this part 
-                    // to break the detector execution 
-                    //
-                    try
-                    {
-                        if (dataProvider.GetValue(dataProviders) is MulticastDelegate m)
-                        {
-                            if (m.Method.ReturnType.IsInterface &&
-                                m.Method.ReturnType.GetInterfaces().Count() > 0
-                                && m.Method.ReturnType.GetInterfaces().Contains(typeof(IMetadataProvider)))
-                            {
-                                var methodParameters = m.Method.GetParameters();
-                                if (methodParameters.Count() == 1)
-                                {
-                                    var firstParameter = methodParameters.FirstOrDefault();
-                                    if (firstParameter.ParameterType.BaseType == typeof(Enum))
-                                    {
-                                        var enumArray = Enum.GetValues(firstParameter.ParameterType);
 
-                                        foreach (var e in enumArray)
+                    if (dataProvider.GetValue(dataProviders) is MulticastDelegate m)
+                    {
+                        if (m.Method.ReturnType.IsInterface &&
+                            m.Method.ReturnType.GetInterfaces().Count() > 0
+                            && m.Method.ReturnType.GetInterfaces().Contains(typeof(IMetadataProvider)))
+                        {
+                            var methodParameters = m.Method.GetParameters();
+                            if (methodParameters.Count() == 1)
+                            {
+                                var firstParameter = methodParameters.FirstOrDefault();
+                                if (firstParameter.ParameterType.BaseType == typeof(Enum))
+                                {
+                                    var enumArray = Enum.GetValues(firstParameter.ParameterType);
+
+                                    foreach (var e in enumArray)
+                                    {
+                                        //
+                                        // run this logic in a try..catch as we don't want this part 
+                                        // to break the detector execution 
+                                        //
+                                        try
                                         {
                                             var output = m.Method.Invoke(m.Target, new object[] { e }) as IMetadataProvider;
                                             var metadata = output.GetMetadata();
-                                            if (metadata != null && metadata.PropertyBag.Count > 0)
+                                            if (metadata != null)
                                             {
                                                 dataprovidersMetadata.Add(metadata);
                                             }
+                                        }
+                                        catch (Exception)
+                                        {
                                         }
                                     }
                                 }
                             }
                         }
-                    }
-                    catch (Exception)
-                    {
                     }
                 }
             }

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -868,7 +868,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                     if (dataProvider.GetValue(dataProviders) is IMetadataProvider metadataProvider)
                     {
                         var metadata = metadataProvider.GetMetadata();
-                        if (metadata != null)
+                        if (metadata != null && metadata.PropertyBag.Count > 0)
                         {
                             dataprovidersMetadata.Add(metadata);
                         }
@@ -899,10 +899,10 @@ namespace Diagnostics.RuntimeHost.Controllers
                                         foreach (var e in enumArray)
                                         {
                                             var output = m.Method.Invoke(m.Target, new object[] { e }) as IMetadataProvider;
-                                            var metdata = output.GetMetadata();
-                                            if (metdata != null && metdata.PropertyBag.Count > 0)
+                                            var metadata = output.GetMetadata();
+                                            if (metadata != null && metadata.PropertyBag.Count > 0)
                                             {
-                                                dataprovidersMetadata.Add(metdata);
+                                                dataprovidersMetadata.Add(metadata);
                                             }
                                         }
                                     }


### PR DESCRIPTION
Since MDM is a field of type `Func<MdmDataSource, IMdmDataProvider>` in DataProviders class, our default logic of casting the field to Interface is not working and we are not getting the dataProvider metadata. 

This change only handles for fields which are of type` Func<Enum, Interface>` so the below logic will not work for `Func<GenericMdmDataProviderConfiguration, IMdmDataProvider>`