### PR TITLE
Fix nullref exceptino in MdmClientFactory.GetMdmClient() (#475)

### DIFF
--- a/src/Diagnostics.DataProviders/MdmClient/MdmClientFactory.cs
+++ b/src/Diagnostics.DataProviders/MdmClient/MdmClientFactory.cs
@@ -1,4 +1,5 @@
-﻿using Diagnostics.DataProviders.DataProviderConfigurations;
+﻿using System;
+using Diagnostics.DataProviders.DataProviderConfigurations;
 using Diagnostics.DataProviders.Interfaces;
 
 namespace Diagnostics.DataProviders
@@ -10,7 +11,7 @@ namespace Diagnostics.DataProviders
     {
         internal static IMdmClient GetMdmClient(IMdmDataProviderConfiguration config, string requestId)
         {
-            if (config.MonitoringAccount.StartsWith("Mock"))
+            if (config.MonitoringAccount != null && config.MonitoringAccount.StartsWith("Mock", StringComparison.OrdinalIgnoreCase))
             {
                 return new MockMdmClient();
             }


### PR DESCRIPTION
Cherry-pick: 0672e2705d485365e4bf99b0218a74d3438c57f3

Co-authored-by: Michimune Kohno <mikono@microsoft.com>