### PR TITLE
Fixing DataSources issue for MDM

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders.cs
+++ b/src/Diagnostics.DataProviders/DataProviders.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Diagnostics.DataProviders.DataProviderConfigurations;
 using Diagnostics.DataProviders.Interfaces;
-
+using Diagnostics.ModelsAndUtils.Models;
 
 namespace Diagnostics.DataProviders
 {
@@ -18,27 +20,85 @@ namespace Diagnostics.DataProviders
         public Func<MdmDataSource, IMdmDataProvider> Mdm;
         public Func<GenericMdmDataProviderConfiguration, IMdmDataProvider> MdmGeneric;
 
+        private readonly Dictionary<object, IMetadataProvider> _dataProvidersCache = new Dictionary<object, IMetadataProvider>();
+
         public DataProviders(DataProviderContext context)
         {
-            Kusto = new KustoLogDecorator(context, new KustoDataProvider(_cache, context.Configuration.KustoConfiguration, context.RequestId, context.KustoHeartBeatService));
-            Observer = new ObserverLogDecorator(context, SupportObserverDataProviderFactory.GetDataProvider(_cache, context.Configuration, context));
-            GeoMaster = new GeoMasterLogDecorator(context, new GeoMasterDataProvider(_cache, context));
-            AppInsights = new AppInsightsLogDecorator(context, new AppInsightsDataProvider(_cache, context.Configuration.AppInsightsConfiguration));
-            ChangeAnalysis = new ChangeAnalysisLogDecorator(context, new ChangeAnalysisDataProvider(_cache, context.Configuration.ChangeAnalysisDataProviderConfiguration, context.RequestId, context.clientObjectId, context.clientPrincipalName, Kusto, context.receivedHeaders));
-            Asc = new AscLogDecorator(context, new AscDataProvider(_cache, context.Configuration.AscDataProviderConfiguration, context.RequestId, context));
-            Mdm = (MdmDataSource ds) =>
+
+            Kusto = FromMemoryCache("Kusto", context) as IKustoDataProvider;
+            Observer = FromMemoryCache("Observer", context) as ISupportObserverDataProvider;
+            GeoMaster = FromMemoryCache("GeoMaster", context) as IGeoMasterDataProvider;
+            AppInsights = FromMemoryCache("AppInsights", context) as IAppInsightsDataProvider;
+            ChangeAnalysis = FromMemoryCache("ChangeAnalysis", context) as IChangeAnalysisDataProvider;
+            Asc = FromMemoryCache("Asc", context) as IAscDataProvider;
+            Mdm = (MdmDataSource ds) => FromMemoryCache(ds, context) as IMdmDataProvider;
+            MdmGeneric = (GenericMdmDataProviderConfiguration config) => FromMemoryCache(config, context) as IMdmDataProvider;
+        }
+
+        private IMetadataProvider FromMemoryCache(object key, DataProviderContext context)
+        {
+            if (_dataProvidersCache.ContainsKey(key))
             {
-                switch (ds)
+                return _dataProvidersCache[key] as IMetadataProvider;
+            }
+            else
+            {
+                IMetadataProvider dataProviderObject = null;
+                if (key is string keyString)
                 {
-                    case MdmDataSource.Antares:
-                        return new MdmLogDecorator(context, new MdmDataProvider(_cache, context.Configuration.AntaresMdmConfiguration, context.RequestId));
-                    case MdmDataSource.Networking:
-                        return new MdmLogDecorator(context, new MdmDataProvider(_cache, context.Configuration.NetworkingMdmConfiguration, context.RequestId));
-                    default:
-                        throw new NotSupportedException($"{ds} is not supported.");
+                    switch (keyString)
+                    {
+                        case "Kusto":
+                            dataProviderObject = new KustoLogDecorator(context, new KustoDataProvider(_cache, context.Configuration.KustoConfiguration, context.RequestId, context.KustoHeartBeatService));
+                            break;
+                        case "Observer":
+                            dataProviderObject = new ObserverLogDecorator(context, SupportObserverDataProviderFactory.GetDataProvider(_cache, context.Configuration, context));
+                            break;
+                        case "GeoMaster":
+                            dataProviderObject = new GeoMasterLogDecorator(context, new GeoMasterDataProvider(_cache, context));
+                            break;
+                        case "AppInsights":
+                            dataProviderObject = new AppInsightsLogDecorator(context, new AppInsightsDataProvider(_cache, context.Configuration.AppInsightsConfiguration));
+                            break;
+                        case "ChangeAnalysis":
+                            dataProviderObject = new ChangeAnalysisLogDecorator(context, new ChangeAnalysisDataProvider(_cache, context.Configuration.ChangeAnalysisDataProviderConfiguration, context.RequestId, context.clientObjectId, context.clientPrincipalName, Kusto, context.receivedHeaders));
+                            break;
+                        case "Asc":
+                            dataProviderObject = new AscLogDecorator(context, new AscDataProvider(_cache, context.Configuration.AscDataProviderConfiguration, context.RequestId, context));
+                            break;
+                        default:
+                            break;
+                    }
                 }
-            };
-            MdmGeneric = (GenericMdmDataProviderConfiguration config) => new MdmLogDecorator(context, new MdmDataProvider(_cache, new GenericMdmDataProviderConfigurationWrapper(config), context.RequestId, context.receivedHeaders));
+                else if (key is MdmDataSource ds)
+                {
+                    switch (ds)
+                    {
+                        case MdmDataSource.Antares:
+                            dataProviderObject = new MdmLogDecorator(context, new MdmDataProvider(_cache, context.Configuration.AntaresMdmConfiguration, context.RequestId));
+                            break;
+                        case MdmDataSource.Networking:
+                            dataProviderObject = new MdmLogDecorator(context, new MdmDataProvider(_cache, context.Configuration.NetworkingMdmConfiguration, context.RequestId));
+                            break;
+                        default:
+                            throw new NotSupportedException($"{ds} is not supported.");
+                    }
+                }
+                else if (key is GenericMdmDataProviderConfiguration config)
+                {
+                    dataProviderObject = new MdmLogDecorator(context, new MdmDataProvider(_cache, new GenericMdmDataProviderConfigurationWrapper(config), context.RequestId, context.receivedHeaders));
+                }
+
+                _dataProvidersCache.Add(key, dataProviderObject);
+                return dataProviderObject;
+            }
+        }
+
+        public List<DataProviderMetadata> GetMetadata()
+        {
+
+            return _dataProvidersCache.Values.Where(d => d != null && d.GetMetadata() != null)
+                .Select(d => d.GetMetadata()).ToList();
         }
     }
 }

--- a/src/Diagnostics.DataProviders/DataProviders.cs
+++ b/src/Diagnostics.DataProviders/DataProviders.cs
@@ -20,84 +20,54 @@ namespace Diagnostics.DataProviders
         public Func<MdmDataSource, IMdmDataProvider> Mdm;
         public Func<GenericMdmDataProviderConfiguration, IMdmDataProvider> MdmGeneric;
 
-        private readonly Dictionary<object, IMetadataProvider> _dataProvidersCache = new Dictionary<object, IMetadataProvider>();
+        private readonly List<LogDecoratorBase> _dataProviderList = new List<LogDecoratorBase>();
 
         public DataProviders(DataProviderContext context)
         {
 
-            Kusto = FromMemoryCache("Kusto", context) as IKustoDataProvider;
-            Observer = FromMemoryCache("Observer", context) as ISupportObserverDataProvider;
-            GeoMaster = FromMemoryCache("GeoMaster", context) as IGeoMasterDataProvider;
-            AppInsights = FromMemoryCache("AppInsights", context) as IAppInsightsDataProvider;
-            ChangeAnalysis = FromMemoryCache("ChangeAnalysis", context) as IChangeAnalysisDataProvider;
-            Asc = FromMemoryCache("Asc", context) as IAscDataProvider;
-            Mdm = (MdmDataSource ds) => FromMemoryCache(ds, context) as IMdmDataProvider;
-            MdmGeneric = (GenericMdmDataProviderConfiguration config) => FromMemoryCache(config, context) as IMdmDataProvider;
+            Kusto = GetOrAddDataProvider(new KustoLogDecorator(context, new KustoDataProvider(_cache,
+                     context.Configuration.KustoConfiguration,
+                     context.RequestId,
+                     context.KustoHeartBeatService)));
+
+            Observer = GetOrAddDataProvider(new ObserverLogDecorator(context, SupportObserverDataProviderFactory.GetDataProvider(_cache, context.Configuration, context)));
+
+            GeoMaster = GetOrAddDataProvider(new GeoMasterLogDecorator(context, new GeoMasterDataProvider(_cache, context)));
+
+            AppInsights = GetOrAddDataProvider(new AppInsightsLogDecorator(context, new AppInsightsDataProvider(_cache, context.Configuration.AppInsightsConfiguration)));
+
+            ChangeAnalysis = GetOrAddDataProvider(new ChangeAnalysisLogDecorator(context, new ChangeAnalysisDataProvider(_cache, context.Configuration.ChangeAnalysisDataProviderConfiguration, context.RequestId, context.clientObjectId, context.clientPrincipalName, Kusto, context.receivedHeaders)));
+
+            Asc = GetOrAddDataProvider(new AscLogDecorator(context, new AscDataProvider(_cache, context.Configuration.AscDataProviderConfiguration, context.RequestId, context)));
+
+            Mdm = (MdmDataSource ds) =>
+            {
+                switch (ds)
+                {
+                    case MdmDataSource.Antares:
+                        return GetOrAddDataProvider(new MdmLogDecorator(context, new MdmDataProvider(_cache, context.Configuration.AntaresMdmConfiguration, context.RequestId)));
+                    case MdmDataSource.Networking:
+                        return GetOrAddDataProvider(new MdmLogDecorator(context, new MdmDataProvider(_cache, context.Configuration.NetworkingMdmConfiguration, context.RequestId)));
+                    default:
+                        throw new NotSupportedException($"{ds} is not supported.");
+                }
+            };
+
+            MdmGeneric = (GenericMdmDataProviderConfiguration config) =>
+            {
+                return GetOrAddDataProvider(new MdmLogDecorator(context, new MdmDataProvider(_cache, new GenericMdmDataProviderConfigurationWrapper(config), context.RequestId, context.receivedHeaders)));
+            };
         }
 
-        private IMetadataProvider FromMemoryCache(object key, DataProviderContext context)
+        private T GetOrAddDataProvider<T>(T dataProvider) where T : LogDecoratorBase
         {
-            if (_dataProvidersCache.ContainsKey(key))
-            {
-                return _dataProvidersCache[key] as IMetadataProvider;
-            }
-            else
-            {
-                IMetadataProvider dataProviderObject = null;
-                if (key is string keyString)
-                {
-                    switch (keyString)
-                    {
-                        case "Kusto":
-                            dataProviderObject = new KustoLogDecorator(context, new KustoDataProvider(_cache, context.Configuration.KustoConfiguration, context.RequestId, context.KustoHeartBeatService));
-                            break;
-                        case "Observer":
-                            dataProviderObject = new ObserverLogDecorator(context, SupportObserverDataProviderFactory.GetDataProvider(_cache, context.Configuration, context));
-                            break;
-                        case "GeoMaster":
-                            dataProviderObject = new GeoMasterLogDecorator(context, new GeoMasterDataProvider(_cache, context));
-                            break;
-                        case "AppInsights":
-                            dataProviderObject = new AppInsightsLogDecorator(context, new AppInsightsDataProvider(_cache, context.Configuration.AppInsightsConfiguration));
-                            break;
-                        case "ChangeAnalysis":
-                            dataProviderObject = new ChangeAnalysisLogDecorator(context, new ChangeAnalysisDataProvider(_cache, context.Configuration.ChangeAnalysisDataProviderConfiguration, context.RequestId, context.clientObjectId, context.clientPrincipalName, Kusto, context.receivedHeaders));
-                            break;
-                        case "Asc":
-                            dataProviderObject = new AscLogDecorator(context, new AscDataProvider(_cache, context.Configuration.AscDataProviderConfiguration, context.RequestId, context));
-                            break;
-                        default:
-                            break;
-                    }
-                }
-                else if (key is MdmDataSource ds)
-                {
-                    switch (ds)
-                    {
-                        case MdmDataSource.Antares:
-                            dataProviderObject = new MdmLogDecorator(context, new MdmDataProvider(_cache, context.Configuration.AntaresMdmConfiguration, context.RequestId));
-                            break;
-                        case MdmDataSource.Networking:
-                            dataProviderObject = new MdmLogDecorator(context, new MdmDataProvider(_cache, context.Configuration.NetworkingMdmConfiguration, context.RequestId));
-                            break;
-                        default:
-                            throw new NotSupportedException($"{ds} is not supported.");
-                    }
-                }
-                else if (key is GenericMdmDataProviderConfiguration config)
-                {
-                    dataProviderObject = new MdmLogDecorator(context, new MdmDataProvider(_cache, new GenericMdmDataProviderConfigurationWrapper(config), context.RequestId, context.receivedHeaders));
-                }
-
-                _dataProvidersCache.Add(key, dataProviderObject);
-                return dataProviderObject;
-            }
+            _dataProviderList.Add(dataProvider);
+            return dataProvider;
         }
 
         public List<DataProviderMetadata> GetMetadata()
         {
-
-            return _dataProvidersCache.Values.Where(d => d != null && d.GetMetadata() != null)
+            return _dataProviderList.Where(d => d != null && d.GetMetadata() != null)
                 .Select(d => d.GetMetadata()).ToList();
         }
     }

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -748,6 +748,15 @@ namespace Diagnostics.RuntimeHost.Controllers
                 var response = (Response)await invoker.Invoke(new object[] { dataProviders, context.OperationContext, res });
                 response.UpdateDetectorStatusFromInsights();
 
+                //
+                // update the dataProvidersMetdata after detector execution to update data source
+                // information for parameterized data sources like MDM
+                //
+                if (context.ClientIsInternal)
+                {
+                    dataProvidersMetadata = GetDataProvidersMetadata(dataProviders);
+                }
+
                 return new Tuple<Response, List<DataProviderMetadata>>(response, dataProvidersMetadata);
             }
             catch (Exception ex)
@@ -860,64 +869,7 @@ namespace Diagnostics.RuntimeHost.Controllers
 
         private List<DataProviderMetadata> GetDataProvidersMetadata(DataProviders.DataProviders dataProviders)
         {
-            var dataprovidersMetadata = new List<DataProviderMetadata>();
-            foreach (var dataProvider in dataProviders.GetType().GetFields())
-            {
-                if (dataProvider.FieldType.IsInterface)
-                {
-                    if (dataProvider.GetValue(dataProviders) is IMetadataProvider metadataProvider)
-                    {
-                        var metadata = metadataProvider.GetMetadata();
-                        if (metadata != null)
-                        {
-                            dataprovidersMetadata.Add(metadata);
-                        }
-                    }
-                }
-                else if (dataProvider.FieldType.UnderlyingSystemType.Name.StartsWith("Func`2", StringComparison.OrdinalIgnoreCase))
-                {
-
-                    if (dataProvider.GetValue(dataProviders) is MulticastDelegate m)
-                    {
-                        if (m.Method.ReturnType.IsInterface &&
-                            m.Method.ReturnType.GetInterfaces().Count() > 0
-                            && m.Method.ReturnType.GetInterfaces().Contains(typeof(IMetadataProvider)))
-                        {
-                            var methodParameters = m.Method.GetParameters();
-                            if (methodParameters.Count() == 1)
-                            {
-                                var firstParameter = methodParameters.FirstOrDefault();
-                                if (firstParameter.ParameterType.BaseType == typeof(Enum))
-                                {
-                                    var enumArray = Enum.GetValues(firstParameter.ParameterType);
-
-                                    foreach (var e in enumArray)
-                                    {
-                                        //
-                                        // run this logic in a try..catch as we don't want this part 
-                                        // to break the detector execution 
-                                        //
-                                        try
-                                        {
-                                            var output = m.Method.Invoke(m.Target, new object[] { e }) as IMetadataProvider;
-                                            var metadata = output.GetMetadata();
-                                            if (metadata != null)
-                                            {
-                                                dataprovidersMetadata.Add(metadata);
-                                            }
-                                        }
-                                        catch (Exception)
-                                        {
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            return dataprovidersMetadata;
+            return dataProviders.GetMetadata();
         }
 
         private bool VerifyEntity(EntityInvoker invoker, ref QueryResponse<DiagnosticApiResponse> queryRes, string publishingDetectorId)


### PR DESCRIPTION
With this change,
1. We are creating an object cache in DataProviders for each data provider. Using this cache we can then populate DataProviderMetadata
2. We got rid of all reflection code which was dirty
3. Added an additional call to `GetDataProvidersMetadata(dataProviders);` in `GetDetectorInternal` to update the DataProviderMetadata for all the parameterized DataProviders (like MDM and MDMGeneric)