### PR TITLE
Set weak consistency for queries running against Antares Kusto clusters.

### DIFF
--- a/src/Diagnostics.DataProviders/KustoSDKClient.cs
+++ b/src/Diagnostics.DataProviders/KustoSDKClient.cs
@@ -75,7 +75,10 @@ namespace Diagnostics.DataProviders
             var kustoClientId = $"Diagnostics.{operationName ?? "Query"};{_requestId}##{0}_{Guid.NewGuid().ToString()}";
             clientRequestProperties.ClientRequestId = kustoClientId;
             clientRequestProperties.SetOption("servertimeout", new TimeSpan(0,0,timeoutSeconds));
-
+            if(cluster.StartsWith("waws",StringComparison.OrdinalIgnoreCase))
+            {
+                clientRequestProperties.SetOption(ClientRequestProperties.OptionQueryConsistency, ClientRequestProperties.OptionQueryConsistency_Weak);
+            }
             try
             {
                 timeTakenStopWatch.Start();


### PR DESCRIPTION
More info on weak consistency 
https://kusto.azurewebsites.net/docs/concepts/queryconsistency.html?q=queryconsistency 

This change will help alleviate some pressure from the admin nodes making the cluster more responsive. The queries however "might" have stale data for up to 5 minutes only from the time of ingestion. Will not add to query latency.