### PR TITLE
Set weak consistency for queries runing against Antares kusto clusters.

### DIFF
--- a/src/Diagnostics.DataProviders/KustoClient.cs
+++ b/src/Diagnostics.DataProviders/KustoClient.cs
@@ -70,6 +70,11 @@ namespace Diagnostics.DataProviders
             request.Headers.Add("Authorization", authorizationToken);
             request.Headers.Add(HeaderConstants.ClientRequestIdHeader, kustoClientId ?? Guid.NewGuid().ToString());
             request.Headers.UserAgent.ParseAdd("appservice-diagnostics");
+            string queryConsistency = "strongconsistency";
+            if (cluster.StartsWith("waws", StringComparison.OrdinalIgnoreCase))
+            {
+                queryConsistency = "weakconsistency";
+            }
             var requestPayload = new
             {
                 db = database,
@@ -79,7 +84,8 @@ namespace Diagnostics.DataProviders
                     ClientRequestId = kustoClientId,
                     Options = new
                     {
-                        servertimeout = new TimeSpan(0, 1, 0)
+                        servertimeout = new TimeSpan(0, 1, 0),
+                        queryconsistency = queryConsistency
                     }
                 }
             };


### PR DESCRIPTION
More info on weak consistency
https://kusto.azurewebsites.net/docs/concepts/queryconsistency.html?q=queryconsistency 

This change will help alleviate some pressure from the admin nodes making the cluster more responsive. The queries however "might" have stale data for up to 5 minutes only from the time of ingestion. Will not add to query latency.