### PR TITLE
Fix GeoMaster.MakeHttpGetRequest ignores slotName

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -382,11 +382,11 @@ namespace Diagnostics.DataProviders
             }
             if (string.IsNullOrWhiteSpace(path))
             {
-                path = $"{SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name)}";
+                path = $"{SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name, slotName)}";
             }
             else
             {
-                path = $"{SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name)}/{path}";
+                path = $"{SitePathUtility.GetSitePath(subscriptionId, resourceGroupName, name, slotName)}/{path}";
             }
 
             return HttpGet<T>(path);


### PR DESCRIPTION
There was a customer report that one detector showing an incorrect result. We found that the GeoMasterDataProvider.MakeHttpGetRequest() doesn't honor the specified slot name. This PR fixes the issue.
