### PR TITLE
Save search terms from getting wiped out

### DIFF
--- a/src/Diagnostics.RuntimeHost/Models/Package.cs
+++ b/src/Diagnostics.RuntimeHost/Models/Package.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Diagnostics.RuntimeHost.Utilities;
@@ -76,15 +77,26 @@ namespace Diagnostics.RuntimeHost.Models
             var metadataFilePath = $"{Id.ToLower()}/metadata.json";
             var configPath = $"{Id.ToLower()}/package.json";
             Metadata = Metadata ?? string.Empty;
-
-            return new List<CommitContent>
+            bool includeMetadata = false;
+            try
             {
-                new CommitContent(csxFilePath, CodeString),
-                new CommitContent(configPath, PackageConfig),
-                new CommitContent(dllFilePath, DllBytes, EncodingType.Base64),
-                new CommitContent(pdbFilePath, PdbBytes, EncodingType.Base64),
-                new CommitContent(metadataFilePath, Metadata)
-            };
+                var metadata = JsonConvert.DeserializeObject<dynamic>(Metadata);
+                if (metadata != null && (metadata["utterances"] != null) && (metadata["utterances"].Count > 0))
+                {
+                    includeMetadata = true;
+                }
+            }
+            catch (Exception ex){
+            }
+            List<CommitContent> commits = new List<CommitContent>();
+            commits.Add(new CommitContent(csxFilePath, CodeString));
+            commits.Add(new CommitContent(configPath, PackageConfig));
+            commits.Add(new CommitContent(dllFilePath, DllBytes, EncodingType.Base64));
+            commits.Add(new CommitContent(pdbFilePath, PdbBytes, EncodingType.Base64));
+            if (includeMetadata)
+            commits.Add(new CommitContent(metadataFilePath, Metadata));
+
+            return commits;
         }
 
         /// <summary>


### PR DESCRIPTION
I tracked nearly 35 commits in detectors repo where all search terms were getting wiped out entirely due to publishing from local development environments pointing to staging backend or local detector development using VS Code (where addition of search terms is not facilitated).
So we handle this in the ultimate backend where the publishing takes place, we only include metadata in commit if it has some search terms. Null or empty array will be skipped from getting committed. 