### PR TITLE
Changes to enable ListDetectors call completely

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/CacheService/DiagEntityTableCacheService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/CacheService/DiagEntityTableCacheService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Diagnostics.ModelsAndUtils.Models.Storage;
 using Diagnostics.RuntimeHost.Models;
 using System.Linq;
+using Diagnostics.Logger;
 
 namespace Diagnostics.RuntimeHost.Services.CacheService
 {
@@ -30,6 +31,7 @@ namespace Diagnostics.RuntimeHost.Services.CacheService
             do
             {
                 await Task.Delay(cacheExpirationTimeInSecs * 1000);
+                DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(DiagEntityTableCacheService), "Polling Azure Storage for refreshing cache");
                 var detectorResult = await storageService.GetEntitiesByPartitionkey("Detector");
                 if (detectorResult != null)
                 {


### PR DESCRIPTION
- With this change we can enable ListDetectors call in prod. If detector gets published, the cache service will poll storage every 60secs and keep the cache upto date