### PR TITLE
Fix bug package.json stored as empty

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/CompilationCache.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/CompilationCache.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Reflection;
+
+namespace Diagnostics.ModelsAndUtils.Models
+{
+    public class CompilationCache
+    {
+        public Assembly AssemblyCache;
+
+        public CompilerResponse CompilerResponseCache;
+    }
+}

--- a/src/Diagnostics.RuntimeHost/Services/CacheService/AssemblyCacheService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/CacheService/AssemblyCacheService.cs
@@ -34,7 +34,8 @@ namespace Diagnostics.RuntimeHost.Services.CacheService
         }
 
         /// <summary>
-        /// Adds a given <paramref name="assemblyName"/> to the cache. If a limit of <see cref="MaxQueueSize"/> is reached, oldest assembly is removed
+        /// For a given <paramref name="assemblyName"/>, adds the <paramref name="assemblyDll"/> and <paramref name="compilerResponse"/> to the cache.
+        /// If a limit of <see cref="MaxQueueSize"/> is reached, oldest assembly is removed
         /// </summary>
         /// <param name="assemblyName">Full Qualified name of the DLL to cache</param>
         /// <param name="assemblyDll">DLL to add to cache</param>
@@ -54,7 +55,7 @@ namespace Diagnostics.RuntimeHost.Services.CacheService
         }
 
         /// <summary>
-        /// Checks if a <paramref name="assemblyName"/> is loaded in cache and returns <paramref name="loadedAssembly"/>
+        /// Checks if a <paramref name="assemblyName"/> is loaded in cache 
         /// </summary>
         public bool IsAssemblyLoaded(string assemblyName)
         {
@@ -65,6 +66,10 @@ namespace Diagnostics.RuntimeHost.Services.CacheService
             return CompilationCache.TryGetValue(assemblyName, out CompilationCache compilationCache);
         }
 
+        /// <summary>
+        /// For the given <paramref name="assemblyName"/> fetches the cached compiler response
+        /// </summary>
+        /// <param name="assemblyName"></param>
         public CompilerResponse GetCachedCompilerResponse(string assemblyName)
         {
             if(CompilationCache.TryGetValue(assemblyName, out CompilationCache cacheItem))
@@ -74,6 +79,10 @@ namespace Diagnostics.RuntimeHost.Services.CacheService
             return new CompilerResponse();
         }
 
+        /// <summary>
+        /// For the given <paramref name="assemblyName"/> fetches the cached assembly 
+        /// </summary>
+        /// <param name="assemblyName"></param>
         public Assembly GetCachedAssembly(string assemblyName)
         {
             if(CompilationCache.TryGetValue(assemblyName, out CompilationCache cacheItem))

--- a/src/Diagnostics.RuntimeHost/Services/CacheService/Interfaces/IAssemblyCacheService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/CacheService/Interfaces/IAssemblyCacheService.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using Diagnostics.ModelsAndUtils.Models;
+using System.Reflection;
 
 namespace Diagnostics.RuntimeHost.Services.CacheService.Interfaces
 {
@@ -12,11 +13,15 @@ namespace Diagnostics.RuntimeHost.Services.CacheService.Interfaces
         /// </summary>
         /// <param name="assemblyName">Full Qualified name of the DLL to cache</param>
         /// <param name="assemblyDll">DLL to add to cache</param>
-        void AddAssemblyToCache(string assemblyName, Assembly assemblyDll);
+        void AddAssemblyToCache(string assemblyName, Assembly assemblyDll, CompilerResponse compilerResponse);
 
         /// <summary>
         /// Checks if a <paramref name="assemblyName"/> is loaded in cache and returns <paramref name="loadedAssembly"/>
         /// </summary>
-        bool IsAssemblyLoaded(string assemblyName, out Assembly loadedAssembly);
+        bool IsAssemblyLoaded(string assemblyName);
+
+
+        CompilerResponse GetCachedCompilerResponse(string assemblyName);
+        Assembly GetCachedAssembly(string assemblyName);
     }
 }

--- a/src/Diagnostics.RuntimeHost/Services/CacheService/Interfaces/IAssemblyCacheService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/CacheService/Interfaces/IAssemblyCacheService.cs
@@ -9,19 +9,29 @@ namespace Diagnostics.RuntimeHost.Services.CacheService.Interfaces
     public interface IAssemblyCacheService
     {
         /// <summary>
-        /// Adds a given <paramref name="assemblyName"/> to the cache. If a limit of <see cref="MaxQueueSize"/> is reached, oldest assembly is removed
+        /// For a given <paramref name="assemblyName"/>, adds the <paramref name="assemblyDll"/> and <paramref name="compilerResponse"/> to the cache.
+        /// If a limit of <see cref="MaxQueueSize"/> is reached, oldest assembly is removed
         /// </summary>
         /// <param name="assemblyName">Full Qualified name of the DLL to cache</param>
         /// <param name="assemblyDll">DLL to add to cache</param>
         void AddAssemblyToCache(string assemblyName, Assembly assemblyDll, CompilerResponse compilerResponse);
 
         /// <summary>
-        /// Checks if a <paramref name="assemblyName"/> is loaded in cache and returns <paramref name="loadedAssembly"/>
+        /// Checks if a <paramref name="assemblyName"/> is loaded in cache
         /// </summary>
         bool IsAssemblyLoaded(string assemblyName);
 
+        /// <summary>
+        /// For the given <paramref name="assemblyName"/> fetches the cached compiler response
+        /// </summary>
+        /// <param name="assemblyName"></param>
 
         CompilerResponse GetCachedCompilerResponse(string assemblyName);
+
+        /// <summary>
+        /// For the given <paramref name="assemblyName"/> fetches the cached assembly 
+        /// </summary>
+        /// <param name="assemblyName"></param>
         Assembly GetCachedAssembly(string assemblyName);
     }
 }

--- a/tests/Diagnostics.Tests.Integration.RuntimeHost/TestData.json
+++ b/tests/Diagnostics.Tests.Integration.RuntimeHost/TestData.json
@@ -3,6 +3,6 @@
     [ "/subscriptions/ef90e930-9d7f-4a60-8a99-748e0eea69de/resourceGroups/detector-development/providers/Microsoft.Web/sites/buggybakery/detectors", 5 ]
   ],
   "GetDetector": [
-    [ "/subscriptions/ef90e930-9d7f-4a60-8a99-748e0eea69de/resourceGroups/detector-development/providers/Microsoft.Web/sites/buggybakery/detectors/httpservererrors", 4 ]
+    [ "/subscriptions/ef90e930-9d7f-4a60-8a99-748e0eea69de/resourceGroups/detector-development/providers/Microsoft.Web/sites/buggybakery/detectors/httpservererrors", 1 ]
   ]
 }


### PR DESCRIPTION
Fix bug where package.json was stored with empty data. Around 20-25 detectors were in this state.
- **Cause:** When detector code was compiled without any changes, empty CompilerResponse object was sent back to AppLens UI and when detector got published, package.json did not have any data
- **Fix:** Added CompilerResponse to the cache so that if detector code was compiled without any changes, backend will send the cached compiler response instead of empty object so package.json gets populated with necessary data