### PR TITLE
Remove authorization on the dependency check API namely because we ha…

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/ProcessHealthController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ProcessHealthController.cs
@@ -37,7 +37,6 @@ namespace Diagnostics.RuntimeHost.Controllers
             return Ok("Server is up and running.");
         }
 
-        [Authorize]
         [HttpGet("/dependencyCheck")]
         public async Task<IActionResult> DependencyCheck()
         {


### PR DESCRIPTION
…ve caching implemented for the API responses.