### PR TITLE
Fix gist load using storage watcher

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/GithubClient/GithubClient.cs
+++ b/src/Diagnostics.RuntimeHost/Services/GithubClient/GithubClient.cs
@@ -42,6 +42,8 @@ namespace Diagnostics.RuntimeHost.Services
         Task<HttpResponseMessage> GetTreeBySha(string sha, string etag = "");
 
         string GetContentUrl(string path);
+
+        Task<string> GetFileContent(string filepath);
     }
 
     public class GithubClient : IGithubClient
@@ -218,6 +220,21 @@ namespace Diagnostics.RuntimeHost.Services
         {
             return $"https://api.github.com/repos/{_userName}/{_repoName}/contents/{path}?ref={_branch}";
         }
+        
+        public async Task<string> GetFileContent(string filepath)
+        {
+            var downloadUrl = $"https://raw.githubusercontent.com/{_userName}/{_repoName}/{_branch}/{filepath}";
+            var response = await _httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, downloadUrl));
+            if(response.IsSuccessStatusCode)
+            {
+                var responsestring = await response.Content.ReadAsStringAsync();
+                return responsestring;
+            } else
+            {
+                return string.Empty;
+            }
+        }
+
         private void LoadConfigurations()
         {
             _userName = _config[$"SourceWatcher:Github:{RegistryConstants.GithubUserNameKey}"];

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
@@ -181,7 +181,13 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Watchers
                     {
                         entityType = EntityType.Detector;
                     }
-                    EntityMetadata metaData = new EntityMetadata(string.Empty, entityType);
+
+                    var script = string.Empty;
+                    if(entity.PartitionKey.Equals("Gist"))
+                    {
+                        script = await gitHubClient.GetFileContent($"{entity.RowKey.ToLower()}/{entity.RowKey.ToLower()}.csx");
+                    }
+                    EntityMetadata metaData = new EntityMetadata(script, entityType);
                     var newInvoker = new EntityInvoker(metaData);
                     newInvoker.InitializeEntryPoint(temp);
 


### PR DESCRIPTION
Fixing a bug where referencing a gist in detector code wasn't working in Storage SourceWatcher.

When Gist cache is updated, get the script content from Github. 