### PR TITLE
Fixed ListDetectors bug and perf optimization for Storage

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/ArmResource.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/ArmResource.cs
@@ -1,4 +1,5 @@
-﻿using Diagnostics.ModelsAndUtils.Attributes;
+﻿using System;
+using Diagnostics.ModelsAndUtils.Attributes;
 using Diagnostics.ModelsAndUtils.Models.Storage;
 using Diagnostics.ModelsAndUtils.ScriptUtilities;
 
@@ -86,7 +87,7 @@ namespace Diagnostics.ModelsAndUtils.Models
             {
                 return false;
             }
-            return diagEntity.ResourceProvider == this.Provider && diagEntity.ResourceType == this.ResourceTypeName;
+            return diagEntity.ResourceProvider.Equals(this.Provider, StringComparison.CurrentCultureIgnoreCase) && diagEntity.ResourceType.Equals(this.ResourceTypeName, StringComparison.CurrentCultureIgnoreCase);
         }
     }
 }

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -69,7 +69,11 @@ namespace Diagnostics.RuntimeHost.Controllers
             this._kustoMappingCacheService = (IKustoMappingsCacheService)services.GetService(typeof(IKustoMappingsCacheService));
             this._loggerProvider = (IRuntimeLoggerProvider)services.GetService(typeof(IRuntimeLoggerProvider));
             tableCacheService = (IDiagEntityTableCacheService)services.GetService(typeof(IDiagEntityTableCacheService));
-            storageWatcher = ((StorageWatcher)services.GetService(typeof(ISourceWatcher)));
+            var sourcewatchertype = _sourceWatcherService.Watcher.GetType();
+            if (sourcewatchertype != typeof(StorageWatcher))
+            {
+                storageWatcher = ((StorageWatcher)services.GetService(typeof(ISourceWatcher)));
+            }
             this._internalApiHelper = new InternalAPIHelper();
             _runtimeContext = runtimeContext;
         }
@@ -714,6 +718,10 @@ namespace Diagnostics.RuntimeHost.Controllers
             if (tableCacheService.IsStorageAsSourceEnabled())
             {
                 var allDetectorsFromStorage = await tableCacheService.GetEntityListByType<TResource>(context);
+                if(allDetectorsFromStorage.Count == 0)
+                {
+                    DiagnosticsETWProvider.Instance.LogRuntimeHostMessage($"No detectors were returned from table cache service for {context.OperationContext.Resource.ResourceUri}");
+                }
                 if (searchResults != null)
                 {
                     // Return those detectors that have positive search score and present in searchResult.

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
@@ -174,7 +174,7 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Watchers
         private async Task StartBlobDownload(bool startup = false)
         {
             var detectorsList = await storageService.GetEntitiesByPartitionkey("Detector");
-            var gists = await storageService.GetEntitiesByPartitionkey("Gist");
+            var gists = !LoadOnlyPublicDetectors ? await storageService.GetEntitiesByPartitionkey("Gist") : new List<DiagEntity>();
             var entitiesToLoad = new List<DiagEntity>();
             var filteredDetectors = LoadOnlyPublicDetectors ? detectorsList.Where(row => !row.IsInternal).ToList() : detectorsList;
             if(!startup)

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
@@ -226,7 +226,7 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Watchers
 
                     if (_invokerDictionary.TryGetValue(entityType, out ICache<string, EntityInvoker> cache) && newInvoker.EntryPointDefinitionAttribute != null)
                     {
-                        DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageWatcher), $"Updating cache with new invoker with id : {newInvoker.EntryPointDefinitionAttribute.Id}");
+                        DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageWatcher), $"Updating cache with new invoker with id : {newInvoker.EntryPointDefinitionAttribute.Id} {entity.PartitionKey}");
                         cache.AddOrUpdate(newInvoker.EntryPointDefinitionAttribute.Id, newInvoker);
                     }
                     else
@@ -275,6 +275,7 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Watchers
                     var kustoMappingsStringContent = config.KustoClusterMapping;
                     var kustoMappings = (List<Dictionary<string, string>>)JsonConvert.DeserializeObject(kustoMappingsStringContent, typeof(List<Dictionary<string, string>>));
                     var resourceProvider = config.RowKey;
+                    DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageWatcher), $"Adding {resourceProvider} to kustoMapping cache");
                     kustoMappingsCacheService.AddOrUpdate(resourceProvider, kustoMappings);              
                 }
             } 

--- a/src/Diagnostics.RuntimeHost/Services/StorageService/StorageService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/StorageService/StorageService.cs
@@ -100,7 +100,7 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
                     }
                 } while (tableContinuationToken != null);
                 timeTakenStopWatch.Stop();
-                DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageService), $"GetEntities by Partition key {partitionKey} took {timeTakenStopWatch.ElapsedMilliseconds}");
+                DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageService), $"GetEntities by Partition key {partitionKey} took {timeTakenStopWatch.ElapsedMilliseconds}, Total rows = {detectorsResult.Count}");
                 return detectorsResult.Where(result => !result.IsDisabled).ToList();
             }
             catch (Exception ex)
@@ -269,7 +269,7 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
                     }
                 } while (tableContinuationToken != null);
                 timeTakenStopWatch.Stop();
-                DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageService), $"GetConfiguration by Partition key {partitionkey} took {timeTakenStopWatch.ElapsedMilliseconds}");
+                DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageService), $"GetConfiguration by Partition key {partitionkey} took {timeTakenStopWatch.ElapsedMilliseconds}, Total rows = {diagConfigurationsResult.Count}");
                 return diagConfigurationsResult.Where(row => !row.IsDisabled).ToList();
             } catch (Exception ex)
             {


### PR DESCRIPTION
- Fixed bug where ListDetectors returned empty list when called from Azure Portal. This was caused due to lowercase in the routing when request came from Azure Portal. Changed the comparison to ignore case and added log statements if there is 0 detectors returned in ListDetectors API call 
- For public endpoints, do not download Gists (.dll and .csx files) because its not required and it will save us time and network calls. This is only needed in euap endpoints because of publishing flow. For other endpoints, download only detector dll 
- Log statement improvements