### PR TITLE
Using geo redundancy to achieve high availability

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/StorageService/StorageService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/StorageService/StorageService.cs
@@ -43,6 +43,7 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
         private bool isStorageEnabled;
         private CloudTable cloudTable;
         private string detectorRuntimeConfigTable;
+        private bool isSecondaryAccount = false;
 
         public StorageService(IConfiguration configuration, IHostingEnvironment hostingEnvironment)
         {
@@ -57,11 +58,15 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
             {
                 var accountname = configuration["SourceWatcher:DiagStorageAccount"];
                 var key = configuration["SourceWatcher:DiagStorageKey"];
-                var storageAccount = new CloudStorageAccount(new StorageCredentials(accountname, key), accountname, "core.windows.net", true);
+                var storageAccount = new CloudStorageAccount(new StorageCredentials(accountname, key), accountname, "core.windows.net", true);        
                 tableClient = storageAccount.CreateCloudTableClient();
                 containerClient = storageAccount.CreateCloudBlobClient().GetContainerReference(container);
-            }
-         
+                if(accountname.Contains("-secondary", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    isSecondaryAccount = true;
+                    DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageService),$"Connected to secondary storage account {accountname}");
+                }
+            }            
             if (!bool.TryParse((configuration[$"SourceWatcher:{RegistryConstants.LoadOnlyPublicDetectorsKey}"]), out loadOnlyPublicDetectors))
             {
                 loadOnlyPublicDetectors = false;
@@ -79,7 +84,10 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
             try
             {
                 CloudTable table = tableClient.GetTableReference(tableName);
-                await table.CreateIfNotExistsAsync();
+                if(!isSecondaryAccount)
+                {
+                    await table.CreateIfNotExistsAsync();
+                }
                 var timeTakenStopWatch = new Stopwatch();             
                 partitionKey = partitionKey == null ? "Detector" : partitionKey;
                 var filterPartitionKey = TableQuery.GenerateFilterCondition(PartitionKey, QueryComparisons.Equal, partitionKey);
@@ -121,7 +129,7 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
             {
                 // Create a table client for interacting with the table service 
                 CloudTable table = tableClient.GetTableReference(tableName);
-                await table.CreateIfNotExistsAsync();
+                await table.CreateIfNotExistsAsync();             
                 if (detectorEntity == null || detectorEntity.PartitionKey == null || detectorEntity.RowKey == null)
                 {
                     throw new ArgumentNullException(nameof(detectorEntity));
@@ -177,7 +185,10 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
             try
             {
                 var timeTakenStopWatch = new Stopwatch();
-                await containerClient.CreateIfNotExistsAsync();
+                if(!isSecondaryAccount)
+                {
+                    await containerClient.CreateIfNotExistsAsync();
+                }
                 timeTakenStopWatch.Start();
                 var cloudBlob = containerClient.GetBlockBlobReference(name);
                 using (MemoryStream ms = new MemoryStream())
@@ -248,7 +259,10 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
             try
             {
                 CloudTable cloudTable = tableClient.GetTableReference(detectorRuntimeConfigTable);
-                await cloudTable.CreateIfNotExistsAsync();
+                if(!isSecondaryAccount)
+                {
+                    await cloudTable.CreateIfNotExistsAsync();
+                }
                 var timeTakenStopWatch = new Stopwatch();
                 var partitionkey = "KustoClusterMapping";
                 var filterPartitionKey = TableQuery.GenerateFilterCondition(PartitionKey, QueryComparisons.Equal, partitionkey);

--- a/src/Diagnostics.RuntimeHost/Services/StorageService/StorageService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/StorageService/StorageService.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using Diagnostics.RuntimeHost.Services.SourceWatcher;
 using Diagnostics.RuntimeHost.Models;
+using System.Net;
 
 namespace Diagnostics.RuntimeHost.Services.StorageService
 {
@@ -58,7 +59,12 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
             {
                 var accountname = configuration["SourceWatcher:DiagStorageAccount"];
                 var key = configuration["SourceWatcher:DiagStorageKey"];
-                var storageAccount = new CloudStorageAccount(new StorageCredentials(accountname, key), accountname, "core.windows.net", true);        
+                var dnsSuffix = configuration["SourceWatcher:StorageDnsSuffix"];
+                if(string.IsNullOrWhiteSpace(dnsSuffix))
+                {
+                    dnsSuffix = "core.windows.net";
+                }
+                var storageAccount = new CloudStorageAccount(new StorageCredentials(accountname, key), accountname, dnsSuffix, true);        
                 tableClient = storageAccount.CreateCloudTableClient();
                 containerClient = storageAccount.CreateCloudBlobClient().GetContainerReference(container);
                 if(accountname.Contains("-secondary", StringComparison.CurrentCultureIgnoreCase))


### PR DESCRIPTION
This gives the flexibility for us to point some endpoints to secondary storage account. As we look to expand storage feature to all endpoints, this is particularly useful for endpoints that are located faraway from the primary storage account and can face higher latency. 