### PR TITLE
Add RebootWorker to geomaster data provider

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -518,6 +518,26 @@ namespace Diagnostics.DataProviders
         /// </example>
         public Task<string> RebootWorker(string subscriptionId, string resourceGroup, string serverFarmName, string workerName, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (string.IsNullOrWhiteSpace(subscriptionId))
+            {
+                throw new ArgumentNullException(nameof(subscriptionId));
+            }
+
+            if (string.IsNullOrWhiteSpace(resourceGroup))
+            {
+                throw new ArgumentNullException(nameof(resourceGroup));
+            }
+
+            if (string.IsNullOrWhiteSpace(serverFarmName))
+            {
+                throw new ArgumentNullException(nameof(serverFarmName));
+            }
+
+            if (string.IsNullOrWhiteSpace(workerName))
+            {
+                throw new ArgumentNullException(nameof(workerName));
+            }
+
             var path = $"subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Web/serverFarms/{serverFarmName}/workers/{workerName}/reboot";
             return HttpPost<string, string>(path, cancellationToken: cancellationToken);
         }

--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -490,6 +490,39 @@ namespace Diagnostics.DataProviders
         }
 
         /// <summary>
+        /// Reboots a worker
+        /// </summary>
+        /// <param name="subscriptionId">Subscription Id for the resource</param>
+        /// <param name="resourceGroupName">The resource group that the resource is part of </param>
+        /// <param name="serverFarmName">Name of the app service plan</param>
+        /// <param name="workerName">Worker machine name (eg. RD0123456789)</param>
+        /// <returns></returns>
+        /// <example>
+        /// This sample shows how you can call this function to get the NSG rules
+        /// for this App Service environment
+        /// <code>
+        ///  public async static Task<![CDATA[<Response>]]> Run(DataProviders dp, OperationContext<![CDATA[<App>]]> cxt, Response res)
+        /// {
+        ///     var subId = cxt.Resource.SubscriptionId;
+        ///     var rg = cxt.Resource.ResourceGroup;
+        ///     var name = cxt.Resource.Name;
+        ///     var url = $"https://wawsobserver.azurewebsites.windows.net/sites/{name}"
+        ///
+        ///     var observerData = await dp.Observer.GetResource(url);
+        ///     var serverFarmName = (string)observerData.server_farm_name;
+        ///     var machineName = "RD0123456789";
+        ///
+        ///     var results = await dp.GeoMaster.RebootWorker(subId, rg, serverFarmName, machineName);
+        /// }
+        /// </code>
+        /// </example>
+        public Task<string> RebootWorker(string subscriptionId, string resourceGroup, string serverFarmName, string workerName, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var path = $"subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Web/serverFarms/{serverFarmName}/workers/{workerName}/reboot";
+            return HttpPost<string, string>(path, cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
         /// Using this method you can invoke any API on a SiteExtension that is installed on the Web App
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/src/Diagnostics.DataProviders/GeoMasterLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/GeoMasterLogDecorator.cs
@@ -61,6 +61,11 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(DataProvider.GetLinuxContainerLogs(subscriptionId, resourceGroupName, name, slotName));
         }
 
+        public Task<string> RebootWorker(string subscriptionId, string resourceGroupName, string serverFarmName, string workerName, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return MakeDependencyCall(DataProvider.RebootWorker(subscriptionId, resourceGroupName, serverFarmName, workerName, cancellationToken));
+        }
+
         public Task<T> InvokeDaasExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string daasApiPath, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken))
         {
             return MakeDependencyCall(DataProvider.InvokeDaasExtension<T>(subscriptionId, resourceGroupName, name, slotName, daasApiPath, apiVersion, cancellationToken));

--- a/src/Diagnostics.DataProviders/Interfaces/IGeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IGeoMasterDataProvider.cs
@@ -31,6 +31,8 @@ namespace Diagnostics.DataProviders
 
         Task<string> GetLinuxContainerLogs(string subscriptionId, string resourceGroupName, string name, string slotName);
 
+        Task<string> RebootWorker(string subscriptionId, string resourceGroup, string serverFarmName, string workerName, CancellationToken cancellationToken = default(CancellationToken));
+
         Task<T> InvokeDaasExtension<T>(string subscriptionId, string resourceGroupName, string name, string slotName, string daasApiPath, string apiVersion = GeoMasterConstants.August2016Version, CancellationToken cancellationToken = default(CancellationToken));
     }
 }


### PR DESCRIPTION
This PR adds a new API to the geomaster data provider named RebootWorker. This allows detectors to reboot a worker in the specified server farm.