### PR TITLE
Shareable Gists

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Attributes/ResourceFilter/ResourceFilterBase.cs
+++ b/src/Diagnostics.ModelsAndUtils/Attributes/ResourceFilter/ResourceFilterBase.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Diagnostics.ModelsAndUtils.Models;
+using Diagnostics.ModelsAndUtils.Models.Storage;
+using System;
 
 namespace Diagnostics.ModelsAndUtils.Attributes
 {
@@ -18,6 +20,52 @@ namespace Diagnostics.ModelsAndUtils.Attributes
         {
             this.ResourceType = resourceType;
             this.InternalOnly = internalOnly;
+        }
+
+        public bool IsApplicable<TFilterType>(IResourceFilter incomingResourceFilter, string resourceProvider, string resourceTypeName, bool customFilterLogicResult = true) where TFilterType : IResourceFilter
+        {
+            bool isApplicable = incomingResourceFilter != null
+                && incomingResourceFilter is TFilterType
+                && incomingResourceFilter.ResourceType == this.ResourceType
+                && customFilterLogicResult;
+
+            return isApplicable || IsApplicableViaSharedProviderOrService(incomingResourceFilter, resourceProvider, resourceTypeName);
+        }
+
+        public bool IsApplicable(DiagEntity diagEntity, string resourceProvider, string resourceTypeName)
+        {
+            if (diagEntity == null || diagEntity.ResourceType == null || diagEntity.ResourceProvider == null)
+            {
+                return false;
+            }
+
+            ArmResourceFilter tempFilter = new ArmResourceFilter(diagEntity.ResourceProvider, diagEntity.ResourceType);
+            return IsApplicableViaSharedProviderOrService(tempFilter, resourceProvider, resourceTypeName);
+        }
+
+        /// <summary>
+        /// Returns True if the Detector/Gist is applicable (via sharable provider or service) for a resource.
+        /// </summary>
+        private bool IsApplicableViaSharedProviderOrService(IResourceFilter incomingResourceFilter, string resourceProvider, string resourceTypeName)
+        {
+            if (incomingResourceFilter == null)
+            {
+                return false;
+            }
+
+            bool isApplicable = false;
+
+            // Check if this is a shared resource filter.
+            if (incomingResourceFilter is ArmResourceFilter armResFilter && 
+                !string.IsNullOrWhiteSpace(armResFilter.Provider) && 
+                !string.IsNullOrWhiteSpace(armResFilter.ResourceTypeName))
+            {
+                isApplicable = (armResFilter.Provider == "*") ||
+                                (armResFilter.Provider.Equals(resourceProvider, StringComparison.OrdinalIgnoreCase) && armResFilter.ResourceTypeName == "*") ||
+                                (armResFilter.Provider.Equals(resourceProvider, StringComparison.OrdinalIgnoreCase) && armResFilter.ResourceTypeName.Equals(resourceTypeName, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return isApplicable;
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/ApiManagementService.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/ApiManagementService.cs
@@ -80,7 +80,7 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(IResourceFilter filter)
         {
-            return filter is ApiManagementServiceFilter;
+            return base.IsApplicable<ApiManagementServiceFilter>(filter, this.Provider, this.ResourceTypeName);
         }
 
         /// <summary>
@@ -90,11 +90,7 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(DiagEntity diagEntity)
         {
-            if(diagEntity == null || diagEntity.ResourceType == null || diagEntity.ResourceProvider == null)
-            {
-                return false;
-            }
-            return diagEntity.ResourceProvider == this.Provider && diagEntity.ResourceType == this.ResourceTypeName;
+            return base.IsApplicable(diagEntity, this.Provider, this.ResourceTypeName);
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/App.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/App.cs
@@ -113,19 +113,21 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <summary>
         /// Determines whether the app resource is applicable after filtering.
         /// </summary>
-        /// <param name="filter">App Resource Filter</param>
+        /// <param name="filter">Resource Filter</param>
         /// <returns>True, if app resource passes the filter. False otherwise</returns>
         public bool IsApplicable(IResourceFilter filter)
         {
+            bool customFilterLogicResult = true;
             if (filter is AppFilter appFilter)
             {
-                return ((appFilter.AppType & this.AppType) > 0) &&
+                customFilterLogicResult =
+                    ((appFilter.AppType & this.AppType) > 0) &&
                     ((appFilter.PlatformType & this.PlatformType) > 0) &&
                     ((this.StackType == StackType.None) || (appFilter.StackType & this.StackType) > 0) &&
                     ((appFilter.StampType & this.StampType) > 0);
             }
 
-            return false;
+            return base.IsApplicable<AppFilter>(filter, this.Provider, this.ResourceTypeName, customFilterLogicResult);
         }
 
         /// <summary>
@@ -135,17 +137,29 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(DiagEntity diagEntity)
         {
-            if(diagEntity == null || diagEntity.AppType == null || diagEntity.PlatForm == null || diagEntity.StackType == null)
+            if(diagEntity == null)
             {
                 return false;
             }
-            AppType tableRowAppType = (AppType)Enum.Parse(typeof(AppType), diagEntity.AppType);
-            PlatformType tableRowPlatformType = (PlatformType)Enum.Parse(typeof(PlatformType), diagEntity.PlatForm);
-            StackType tableRowStacktype = (StackType)Enum.Parse(typeof(StackType), diagEntity.StackType);
 
-            return ((tableRowAppType & this.AppType) > 0) &&
-                    ((tableRowPlatformType & this.PlatformType) > 0) &&
-                    ((this.StackType == StackType.None) || (tableRowStacktype & this.StackType) > 0);
+            if(diagEntity.AppType != null)
+            {
+                if(diagEntity.PlatForm == null || diagEntity.StackType == null)
+                {
+                    return false;
+                }
+
+                AppType tableRowAppType = (AppType)Enum.Parse(typeof(AppType), diagEntity.AppType);
+                PlatformType tableRowPlatformType = (PlatformType)Enum.Parse(typeof(PlatformType), diagEntity.PlatForm);
+                StackType tableRowStacktype = (StackType)Enum.Parse(typeof(StackType), diagEntity.StackType);
+
+                return ((tableRowAppType & this.AppType) > 0) &&
+                        ((tableRowPlatformType & this.PlatformType) > 0) &&
+                        ((this.StackType == StackType.None) || (tableRowStacktype & this.StackType) > 0);
+
+            }
+
+            return base.IsApplicable(diagEntity, this.Provider, this.ResourceTypeName);
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/AppServiceCertificate.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/AppServiceCertificate.cs
@@ -80,7 +80,7 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(IResourceFilter filter)
         {
-            return filter is AppServiceCertificateFilter;
+            return base.IsApplicable<AppServiceCertificateFilter>(filter, this.Provider, this.ResourceTypeName);
         }
 
         /// <summary>
@@ -90,11 +90,7 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(DiagEntity diagEntity)
         {
-            if (diagEntity == null || diagEntity.ResourceType == null || diagEntity.ResourceProvider == null)
-            {
-                return false;
-            }
-            return diagEntity.ResourceProvider == this.Provider && diagEntity.ResourceType == this.ResourceTypeName;
+            return base.IsApplicable(diagEntity, this.Provider, this.ResourceTypeName);
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/AppServiceDomain.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/AppServiceDomain.cs
@@ -80,7 +80,7 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(IResourceFilter filter)
         {
-            return filter is AppServiceDomainFilter;
+            return base.IsApplicable<AppServiceDomainFilter>(filter, this.Provider, this.ResourceTypeName);
         }
 
         /// <summary>
@@ -90,11 +90,7 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(DiagEntity diagEntity)
         {
-            if (diagEntity == null || diagEntity.ResourceType == null || diagEntity.ResourceProvider == null)
-            {
-                return false;
-            }
-            return diagEntity.ResourceProvider == this.Provider && diagEntity.ResourceType == this.ResourceTypeName;
+            return base.IsApplicable(diagEntity, this.Provider, this.ResourceTypeName);
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/ArmResource.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/ArmResource.cs
@@ -42,24 +42,6 @@ namespace Diagnostics.ModelsAndUtils.Models
         }
 
         /// <summary>
-        /// Determines whether the current arm resource is applicable after filtering.
-        /// </summary>
-        /// <param name="filter">App Resource Filter</param>
-        /// <returns>True, if app resource passes the filter. False otherwise</returns>
-        public bool IsApplicable(IResourceFilter filter)
-        {
-            if (filter is ArmResourceFilter)
-            {
-                ArmResourceFilter armFilter = filter as ArmResourceFilter;
-                return (string.Compare(armFilter.Provider, this.Provider, true) == 0) && (string.Compare(armFilter.ResourceTypeName, this.ResourceTypeName, true) == 0);
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
         /// Subscription Location Placement id
         /// </summary>
         public string SubscriptionLocationPlacementId
@@ -77,17 +59,32 @@ namespace Diagnostics.ModelsAndUtils.Models
         }
 
         /// <summary>
+        /// Determines whether the current arm resource is applicable after filtering.
+        /// </summary>
+        /// <param name="filter">Resource Filter</param>
+        /// <returns>True, if resource passes the filter. False otherwise</returns>
+        public bool IsApplicable(IResourceFilter filter)
+        {
+            bool customFilterLogicResult = true;
+            if (filter is ArmResourceFilter armResFilter)
+            {
+                customFilterLogicResult = !string.IsNullOrWhiteSpace(armResFilter.Provider) &&
+                                        !string.IsNullOrWhiteSpace(armResFilter.ResourceTypeName) &&
+                                        armResFilter.Provider.Equals(this.Provider, StringComparison.OrdinalIgnoreCase) &&
+                                        armResFilter.ResourceTypeName.Equals(this.ResourceTypeName, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return base.IsApplicable<ArmResourceFilter>(filter, this.Provider, this.ResourceTypeName, customFilterLogicResult);
+        }
+
+        /// <summary>
         /// Determines whether the diag entity retrieved from table is applicable after filtering.
         /// </summary>
         /// <param name="diagEntity">Diag Entity from table</param>
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(DiagEntity diagEntity)
         {
-            if (diagEntity == null || diagEntity.ResourceType == null || diagEntity.ResourceProvider == null)
-            {
-                return false;
-            }
-            return diagEntity.ResourceProvider.Equals(this.Provider, StringComparison.CurrentCultureIgnoreCase) && diagEntity.ResourceType.Equals(this.ResourceTypeName, StringComparison.CurrentCultureIgnoreCase);
+            return base.IsApplicable(diagEntity, this.Provider, this.ResourceTypeName);
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/AzureKubernetesService.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/AzureKubernetesService.cs
@@ -62,16 +62,6 @@ namespace Diagnostics.ModelsAndUtils.Models
             get; set;
         }
 
-        /// <summary>
-        /// Determines whether the Azure Kubernetes Service resource is applicable after filtering.
-        /// </summary>
-        /// <param name="filter">Resource Filter</param>
-        /// <returns>True, if resource passes the filter. False otherwise</returns>
-        public bool IsApplicable(IResourceFilter filter)
-        {
-            return filter is AzureKubernetesServiceFilter;
-        }
-
         public AzureKubernetesService(string subscriptionId, string resourceGroup, string resourceName, string subLocationPlacementId = null) : base()
         {
             this.SubscriptionId = subscriptionId;
@@ -81,17 +71,23 @@ namespace Diagnostics.ModelsAndUtils.Models
         }
 
         /// <summary>
+        /// Determines whether the Azure Kubernetes Service resource is applicable after filtering.
+        /// </summary>
+        /// <param name="filter">Resource Filter</param>
+        /// <returns>True, if resource passes the filter. False otherwise</returns>
+        public bool IsApplicable(IResourceFilter filter)
+        {
+            return base.IsApplicable<AzureKubernetesServiceFilter>(filter, this.Provider, this.ResourceTypeName);
+        }
+
+        /// <summary>
         /// Determines whether the diag entity retrieved from table is applicable after filtering.
         /// </summary>
         /// <param name="diagEntity">Diag Entity from table</param>
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(DiagEntity diagEntity)
         {
-            if (diagEntity == null || diagEntity.ResourceType == null || diagEntity.ResourceProvider == null)
-            {
-                return false;
-            }
-            return diagEntity.ResourceProvider == this.Provider && diagEntity.ResourceType == this.ResourceTypeName;
+            return base.IsApplicable(diagEntity, this.Provider, this.ResourceTypeName);
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/HostingEnvironment.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/HostingEnvironment.cs
@@ -122,13 +122,14 @@ namespace Diagnostics.ModelsAndUtils.Models
 
         public bool IsApplicable(IResourceFilter filter)
         {
+            bool customFilterLogicResult = true;
             if (filter is HostingEnvironmentFilter envFilter)
             {
-                return ((envFilter.PlatformType & this.PlatformType) > 0) &&
+                customFilterLogicResult = ((envFilter.PlatformType & this.PlatformType) > 0) &&
                     ((envFilter.HostingEnvironmentType & this.HostingEnvironmentType) > 0);
             }
 
-            return false;
+            return base.IsApplicable<HostingEnvironmentFilter>(filter, this.Provider, this.ResourceTypeName, customFilterLogicResult);
         }
 
         /// <summary>
@@ -138,15 +139,25 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(DiagEntity diagEntity)
         {
-            if (diagEntity == null || diagEntity.PlatForm == null || diagEntity.HostingEnvironmentType == null)
+            if (diagEntity == null)
             {
                 return false;
             }
 
-            PlatformType tableRowPlatformType = (PlatformType)Enum.Parse(typeof(PlatformType), diagEntity.PlatForm);
-            HostingEnvironmentType tableRowHostingEnv = (HostingEnvironmentType)Enum.Parse(typeof(HostingEnvironmentType), diagEntity.HostingEnvironmentType);
-            return ((tableRowPlatformType & this.PlatformType) > 0) &&
-                 ((tableRowHostingEnv & this.HostingEnvironmentType) > 0);
+            if(diagEntity.HostingEnvironmentType != null)
+            {
+                if(diagEntity.PlatForm == null)
+                {
+                    return false;
+                }
+
+                PlatformType tableRowPlatformType = (PlatformType)Enum.Parse(typeof(PlatformType), diagEntity.PlatForm);
+                HostingEnvironmentType tableRowHostingEnv = (HostingEnvironmentType)Enum.Parse(typeof(HostingEnvironmentType), diagEntity.HostingEnvironmentType);
+                return ((tableRowPlatformType & this.PlatformType) > 0) &&
+                     ((tableRowHostingEnv & this.HostingEnvironmentType) > 0);
+            }
+
+            return base.IsApplicable(diagEntity, this.Provider, this.ResourceTypeName);
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Resource/LogicApp.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Resource/LogicApp.cs
@@ -77,7 +77,7 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(IResourceFilter filter)
         {
-            return filter is LogicAppFilter;
+            return base.IsApplicable<LogicAppFilter>(filter, this.Provider, this.ResourceTypeName);
         }
 
         /// <summary>
@@ -87,11 +87,7 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <returns>True, if resource passes the filter. False otherwise</returns>
         public bool IsApplicable(DiagEntity diagEntity)
         {
-            if (diagEntity == null || diagEntity.ResourceType == null || diagEntity.ResourceProvider == null)
-            {
-                return false;
-            }
-            return diagEntity.ResourceProvider == Provider && diagEntity.ResourceType == ResourceTypeName;
+            return base.IsApplicable(diagEntity, this.Provider, this.ResourceTypeName);
         }
     }
 }

--- a/src/Diagnostics.RuntimeHost/Program.cs
+++ b/src/Diagnostics.RuntimeHost/Program.cs
@@ -49,7 +49,6 @@ namespace Diagnostics.RuntimeHost
                             keyVaultUri,
                             keyVaultClient,
                             new DefaultKeyVaultSecretManager())
-                         //.AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                         .AddEnvironmentVariables()
                         .AddCommandLine(args)
                         .Build();

--- a/src/Diagnostics.RuntimeHost/Program.cs
+++ b/src/Diagnostics.RuntimeHost/Program.cs
@@ -49,6 +49,7 @@ namespace Diagnostics.RuntimeHost
                             keyVaultUri,
                             keyVaultClient,
                             new DefaultKeyVaultSecretManager())
+                         //.AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                         .AddEnvironmentVariables()
                         .AddCommandLine(args)
                         .Build();

--- a/src/Diagnostics.RuntimeHost/Services/CacheService/InvokerCacheService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/CacheService/InvokerCacheService.cs
@@ -51,7 +51,7 @@ namespace Diagnostics.RuntimeHost.Services.CacheService
 
             if (list == null || !list.Any()) return list;
 
-            list = list.Where(item => ((item.SystemFilter == null) && (item.ResourceFilter != null) && (item.ResourceFilter.ResourceType & context.OperationContext.Resource.ResourceType) > 0) && (context.ClientIsInternal || !item.ResourceFilter.InternalOnly));
+            list = list.Where(item => ((item.SystemFilter == null) && (item.ResourceFilter != null) && (context.ClientIsInternal || !item.ResourceFilter.InternalOnly))).ToList();
             List<EntityInvoker> filteredList = new List<EntityInvoker>();
             list.ToList().ForEach(item =>
             {

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/SourceWatcherService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/SourceWatcherService.cs
@@ -35,6 +35,8 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher
                 default:
                     throw new NotSupportedException("Source Watcher Type not supported");
             }
+
+            _watcher.Start();
         }
     }
 }

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/GitHubWatcher.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/GitHubWatcher.cs
@@ -93,8 +93,6 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher
             };
             
             #endregion Initialize Github Worker
-
-            Start();
         }
 
         /// <summary>

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/LocalFileSystemWatcher.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/LocalFileSystemWatcher.cs
@@ -31,7 +31,6 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher
             : base(env, configuration, invokerCache, gistCache, null, "LocalFileSystemWatcher")
         {
             LoadConfigurations();
-            Start();
             _invokerDictionary = new Dictionary<EntityType, ICache<string, EntityInvoker>>
             {
                 { EntityType.Detector, invokerCache},

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
@@ -66,7 +66,6 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Watchers
                 { EntityType.Gist, gistCache}
             };
             kustoMappingsCacheService = kustoMappingsCache;
-            Start();
         }
 
         public virtual async Task<HealthCheckResult> CheckHealthAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/tests/Diagnostics.Tests/Diagnostics.Tests.csproj
+++ b/tests/Diagnostics.Tests/Diagnostics.Tests.csproj
@@ -43,11 +43,10 @@
   </PropertyGroup>
 
   <Target Name="AfterBuildScript" AfterTargets="Build">
-    <Copy SourceFiles="..\..\data\templates\Detector_WebApp.csx" DestinationFolder="$(OutputPath)\templates" ContinueOnError="true" />
-    <Copy SourceFiles="..\..\data\templates\Detector_HostingEnvironment.csx" DestinationFolder="$(OutputPath)\templates" ContinueOnError="true" />
-    <Copy SourceFiles="..\..\data\templates\SystemInvokerTest.csx" DestinationFolder="$(OutputPath)\templates" ContinueOnError="true" />
-    <Copy SourceFiles="..\..\data\templates\Gist_WebApp.csx" DestinationFolder="$(OutputPath)\templates" ContinueOnError="true" />
-    <Copy SourceFiles="..\..\data\templates\Gist_HostingEnvironment.csx" DestinationFolder="$(OutputPath)\templates" ContinueOnError="true" />
+    <ItemGroup>
+      <TEMPL Include="..\..\data\templates\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(TEMPL)" DestinationFolder="$(OutputPath)\templates" ContinueOnError="true" />
   </Target>
 
   <Import Project="..\..\data\samples\Diagnostics.Samples\Diagnostics.Samples.projitems" Label="Shared" />

--- a/tests/Diagnostics.Tests/Helpers/ScriptTestDataHelper.cs
+++ b/tests/Diagnostics.Tests/Helpers/ScriptTestDataHelper.cs
@@ -78,14 +78,20 @@ namespace Diagnostics.Tests.Helpers
             {
                 template = await File.ReadAllTextAsync(@"templates/Gist_HostingEnvironment.csx");
             }
+            else if(resourceType == ResourceType.ArmResource)
+            {
+                template = await File.ReadAllTextAsync(@"templates/Gist_EventHub.csx");
+            }
             else
             {
                 template = await File.ReadAllTextAsync(@"templates/Gist_WebApp.csx");
             }
 
-            template = template.Replace("<YOUR_CLASS_NAME>", "GistClass");
-
-            return template.Replace("<YOUR_GIST_ID>", def.Id);
+            return template
+                .Replace("<YOUR_GIST_ID>", def.Id)
+                .Replace("<YOUR_ALIAS>", def.Author)
+                .Replace("Name = \"\"", $"Name = \"{def.Name}\"")
+                .Replace("<YOUR_CLASS_NAME>", "GistClass");
         }
 
         public static async Task<string> GetDetectorScriptWithMultipleSupportTopics(Definition def, bool isInternal, SupportTopic topic1, SupportTopic topic2)

--- a/tests/Diagnostics.Tests/ScriptsTests/EntityInvokerTests.cs
+++ b/tests/Diagnostics.Tests/ScriptsTests/EntityInvokerTests.cs
@@ -355,7 +355,7 @@ namespace Diagnostics.Tests.ScriptsTests
         }
 
         [Fact]
-        public async void EntityInvoker_TestValidSharableGists()
+        public async void EntityInvoker_TestValidShareableGists()
         {
             Definition definitonAttribute = new Definition()
             {
@@ -389,7 +389,7 @@ namespace Diagnostics.Tests.ScriptsTests
         }
 
         [Fact]
-        public async void EntityInvoker_TestInvalidSharableGist()
+        public async void EntityInvoker_TestInvalidShareableGist()
         {
             Definition definitonAttribute = new Definition()
             {

--- a/tests/Diagnostics.Tests/ScriptsTests/EntityInvokerTests.cs
+++ b/tests/Diagnostics.Tests/ScriptsTests/EntityInvokerTests.cs
@@ -54,7 +54,9 @@ namespace Diagnostics.Tests.ScriptsTests
         {
             Definition definitonAttribute = new Definition()
             {
-                Id = "TestId"
+                Id = "TestId",
+                Author = "Test Author",
+                Name = "Test Gist"
             };
 
             EntityMetadata metadata = ScriptTestDataHelper.GetRandomMetadata(EntityType.Gist);
@@ -218,7 +220,9 @@ namespace Diagnostics.Tests.ScriptsTests
             // First Create and Save a assembly for test purposes.
             Definition definitonAttribute = new Definition()
             {
-                Id = "TestId"
+                Id = "TestId",
+                Author = "Test Author",
+                Name = "Test Name"
             };
 
             string assemblyPath = $@"{AppContext.BaseDirectory}/{Guid.NewGuid().ToString()}";
@@ -347,6 +351,63 @@ namespace Diagnostics.Tests.ScriptsTests
 
                 Assert.False(invoker.IsCompilationSuccessful);
                 Assert.NotEmpty(invoker.CompilationOutput);
+            }
+        }
+
+        [Fact]
+        public async void EntityInvoker_TestValidSharableGists()
+        {
+            Definition definitonAttribute = new Definition()
+            {
+                Id = "testGistId",
+                Author = "testAuthor",
+                Name = "Test Gist"
+            };
+
+            string assemblyPath = string.Empty;
+            string gistScript = await ScriptTestDataHelper.GetGistScript(definitonAttribute, ResourceType.ArmResource);
+
+            // 1. Testing Gist Compilation that are shared globally
+            EntityMetadata metadata  = new EntityMetadata(gistScript, EntityType.Gist);
+            metadata.ScriptText = gistScript.Replace("Microsoft.EventHub", "*").Replace("namespaces", "*");
+            
+
+            using (EntityInvoker invoker = new EntityInvoker(metadata, ScriptHelper.GetFrameworkReferences(), ScriptHelper.GetFrameworkImports()))
+            {
+                await invoker.InitializeEntryPointAsync();
+                Assert.True(invoker.IsCompilationSuccessful);
+            }
+
+            // 2. Testing Gist Compilation that are shared within one RP only
+            metadata.ScriptText = gistScript.Replace("namespaces", "*");
+
+            using (EntityInvoker invoker = new EntityInvoker(metadata, ScriptHelper.GetFrameworkReferences(), ScriptHelper.GetFrameworkImports()))
+            {
+                await invoker.InitializeEntryPointAsync();
+                Assert.True(invoker.IsCompilationSuccessful);
+            }
+        }
+
+        [Fact]
+        public async void EntityInvoker_TestInvalidSharableGist()
+        {
+            Definition definitonAttribute = new Definition()
+            {
+                Id = "testGistId",
+                Author = "testAuthor",
+                Name = "Test Gist"
+            };
+
+            string assemblyPath = string.Empty;
+            string gistScript = await ScriptTestDataHelper.GetGistScript(definitonAttribute, ResourceType.ArmResource);
+
+            EntityMetadata metadata = new EntityMetadata(gistScript, EntityType.Gist);
+            metadata.ScriptText = gistScript.Replace("Microsoft.EventHub", "*");
+
+            using (EntityInvoker invoker = new EntityInvoker(metadata, ScriptHelper.GetFrameworkReferences(), ScriptHelper.GetFrameworkImports()))
+            {
+                await invoker.InitializeEntryPointAsync();
+                Assert.False(invoker.IsCompilationSuccessful);
             }
         }
     }


### PR DESCRIPTION
Gists can now be created in following  three modes:


| Access Level|Description|  How To Use|
|:----------:|:----------:|:----------:|
| **_Global_**|  Gists are accessible for any resource type |  `[ArmResourceFilter(provider: "*", resourceTypeName: "*")]`  |
| **_RP Level_**|  Gists are accessible for any resource types with same RP |  `[ArmResourceFilter(provider: "Microsoft.FooBar", resourceTypeName: "*")]`  |
| **_Service Level_**|  Gists are only accessible for one particular resource type |  `[ArmResourceFilter(provider: "Microsoft.FooBar", resourceTypeName: "yourServiceName")]`  |


- **Please Note** - Detectors are not sharable as of now. If we need to achieve that, we need to figure out support for different resource type objects to be accepted by one detector. Not in scope of this PR.
- Added Basic unit tests
