### PR TITLE
Refresh cache changes and switch to secondary account for read path

### DIFF
--- a/infrastructure/Scripts/storage-postdeployment.ps1
+++ b/infrastructure/Scripts/storage-postdeployment.ps1
@@ -13,3 +13,19 @@ Write-Host "Creating new table" $tableName
 $tableCreation = New-AzStorageTable -Name $tableName -Context $ctx
 
 Write-Host $tableCreation
+
+$detectorConfigTable = "detectorconfig"
+
+Write-Host "Create new table" $detectorConfigTable
+
+$tableCreation = New-AzStorageTable -Name $detectorConfigTable -Context $ctx
+
+Write-Host $tableCreation
+
+$containerName = "detectors"
+
+Write-Host "Creating new container" $containerName
+
+$containerCreation = New-AzStorageContainer -Name $containerName -Context $ctx
+
+Write-Host $containerCreation 

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
@@ -179,8 +179,10 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Watchers
             var filteredDetectors = LoadOnlyPublicDetectors ? detectorsList.Where(row => !row.IsInternal).ToList() : detectorsList;
             if(!startup)
             {
-                entitiesToLoad.AddRange(filteredDetectors.Where(s => s.Timestamp >= blobCacheLastModifiedTime).ToList());
-                entitiesToLoad.AddRange(gists.Where(s => s.Timestamp >= blobCacheLastModifiedTime).ToList());
+                // Refresh cache with detectors published in last 5 minutes.
+                var timeRange = DateTime.UtcNow.AddMinutes(-5);
+                entitiesToLoad.AddRange(filteredDetectors.Where(s => s.Timestamp >= timeRange).ToList());
+                entitiesToLoad.AddRange(gists.Where(s => s.Timestamp >= timeRange).ToList());
             } else
             {
                 entitiesToLoad.AddRange(filteredDetectors.ToList());

--- a/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SourceWatcher/Watchers/StorageWatcher.cs
@@ -97,12 +97,13 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Watchers
             {
                 await gitHubClient.CreateOrUpdateFiles(pkg.GetCommitContents(), pkg.GetCommitMessage());
                 // Insert Kusto Cluster Mapping to Configuration table.
-                if(pkg.GetCommitContents().Any(content => content.FilePath.Contains("kustoClusterMappings", StringComparison.CurrentCultureIgnoreCase)))
+                if (pkg.GetCommitContents().Any(content => content.FilePath.Contains("kustoClusterMappings", StringComparison.CurrentCultureIgnoreCase)))
                 {
                     var kustoMappingPackage = pkg.GetCommitContents().Where(c => c.FilePath.Contains("kustoClusterMappings", StringComparison.CurrentCultureIgnoreCase)).FirstOrDefault();
                     var githubCommit = await gitHubClient.GetCommitByPath(kustoMappingPackage.FilePath);
                     // store kusto cluster data
-                    var diagconfiguration = new DetectorRuntimeConfiguration{
+                    var diagconfiguration = new DetectorRuntimeConfiguration
+                    {
                         PartitionKey = "KustoClusterMapping",
                         RowKey = pkg.Id.ToLower(),
                         GithubSha = githubCommit != null ? githubCommit.Commit.Tree.Sha : string.Empty,
@@ -131,6 +132,10 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Watchers
                     diagEntity = DiagEntityHelper.PrepareEntityForLoad(assemblyBytes, pkg.CodeString, diagEntity);
                 }
                 await storageService.LoadDataToTable(diagEntity);
+
+                // Force refresh its own cache
+                var assemblyData = Convert.FromBase64String(pkg.DllBytes);
+                await UpdateInvokerCache(assemblyData, diagEntity.PartitionKey, diagEntity.RowKey);
             } catch (Exception ex)
             {
                 DiagnosticsETWProvider.Instance.LogAzureStorageException(nameof(StorageWatcher), ex.Message, ex.GetType().ToString(), ex.ToString());
@@ -204,37 +209,7 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Watchers
                         DiagnosticsETWProvider.Instance.LogAzureStorageWarning(nameof(StorageWatcher), $" blob {entity.RowKey.ToLower()}.dll is either null or 0 bytes in length");
                         continue;
                     }
-
-                    // initializing Entry Point of Invoker using assembly
-                    Assembly temp = Assembly.Load(assemblyData);
-                    EntityType entityType = EntityType.Signal;
-                    if (entity.PartitionKey.Equals("Gist"))
-                    {
-                        entityType = EntityType.Gist;
-                    }
-                    else if (entity.PartitionKey.Equals("Detector"))
-                    {
-                        entityType = EntityType.Detector;
-                    }
-
-                    var script = string.Empty;
-                    if(entity.PartitionKey.Equals("Gist"))
-                    {
-                        script = await gitHubClient.GetFileContent($"{entity.RowKey.ToLower()}/{entity.RowKey.ToLower()}.csx");
-                    }
-                    EntityMetadata metaData = new EntityMetadata(script, entityType);
-                    var newInvoker = new EntityInvoker(metaData);
-                    newInvoker.InitializeEntryPoint(temp);
-
-                    if (_invokerDictionary.TryGetValue(entityType, out ICache<string, EntityInvoker> cache) && newInvoker.EntryPointDefinitionAttribute != null)
-                    {
-                        DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageWatcher), $"Updating cache with new invoker with id : {newInvoker.EntryPointDefinitionAttribute.Id} {entity.PartitionKey}");
-                        cache.AddOrUpdate(newInvoker.EntryPointDefinitionAttribute.Id, newInvoker);
-                    }
-                    else
-                    {
-                        DiagnosticsETWProvider.Instance.LogAzureStorageWarning(nameof(StorageWatcher), $"No invoker cache exist for {entityType}");
-                    }
+                    await UpdateInvokerCache(assemblyData, entity.PartitionKey, entity.RowKey);
                 }           
             } 
             catch (Exception ex)
@@ -291,6 +266,40 @@ namespace Diagnostics.RuntimeHost.Services.SourceWatcher.Watchers
                 {
                     DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageWatcher), $"Kusto config download complete, Number of configs {configsToLoad.Count}, startup : {startup.ToString()} time ellapsed {stopwatch.ElapsedMilliseconds} millisecs");
                 }
+            }
+        }
+
+        private async Task UpdateInvokerCache(byte[] assemblyData, string partitionkey, string rowkey)
+        {
+            // initializing Entry Point of Invoker using assembly
+            Assembly temp = Assembly.Load(assemblyData);
+            EntityType entityType = EntityType.Signal;
+            if (partitionkey.Equals("Gist"))
+            {
+                entityType = EntityType.Gist;
+            }
+            else if (partitionkey.Equals("Detector"))
+            {
+                entityType = EntityType.Detector;
+            }
+
+            var script = string.Empty;
+            if (partitionkey.Equals("Gist"))
+            {
+                script = await gitHubClient.GetFileContent($"{rowkey.ToLower()}/{rowkey.ToLower()}.csx");
+            }
+            EntityMetadata metaData = new EntityMetadata(script, entityType);
+            var newInvoker = new EntityInvoker(metaData);
+            newInvoker.InitializeEntryPoint(temp);
+
+            if (_invokerDictionary.TryGetValue(entityType, out ICache<string, EntityInvoker> cache) && newInvoker.EntryPointDefinitionAttribute != null)
+            {
+                DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageWatcher), $"Updating cache with new invoker with id : {newInvoker.EntryPointDefinitionAttribute.Id} {partitionkey}");
+                cache.AddOrUpdate(newInvoker.EntryPointDefinitionAttribute.Id, newInvoker);
+            }
+            else
+            {
+                DiagnosticsETWProvider.Instance.LogAzureStorageWarning(nameof(StorageWatcher), $"No invoker cache exist for {entityType}");
             }
         }
     }

--- a/src/Diagnostics.RuntimeHost/Services/StorageService/StorageService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/StorageService/StorageService.cs
@@ -102,6 +102,7 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
                     if(attempt == retryThreshold)
                     {
                         tableRequestOptions.LocationMode = LocationMode.SecondaryOnly;
+                        DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageService), $"Retrying table against secondary account after {attempt} attempts");
                     }
                     do
                     {
@@ -205,7 +206,7 @@ namespace Diagnostics.RuntimeHost.Services.StorageService
                     if (attempt == retryThreshold)
                     {
                         options.LocationMode = LocationMode.SecondaryOnly;
-                        DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageService), $"Retrying against secondary account after {attempt} attempts");
+                        DiagnosticsETWProvider.Instance.LogAzureStorageMessage(nameof(StorageService), $"Retrying blob against secondary account after {attempt} attempts");
                     }
                     var timeTakenStopWatch = new Stopwatch();
                     timeTakenStopWatch.Start();

--- a/tests/Diagnostics.Tests/AzureStorageTests/AzureStorageTests.cs
+++ b/tests/Diagnostics.Tests/AzureStorageTests/AzureStorageTests.cs
@@ -1,244 +1,244 @@
-﻿using System;
-using Xunit;
-using Diagnostics.RuntimeHost.Services.CacheService;
-using Diagnostics.RuntimeHost.Services.CacheService.Interfaces;
-using Microsoft.Extensions.Configuration;
-using Diagnostics.RuntimeHost.Services.StorageService;
-using Microsoft.AspNetCore.Hosting;
-using Diagnostics.ModelsAndUtils.Models.Storage;
-using Diagnostics.RuntimeHost.Models;
-using Diagnostics.ModelsAndUtils.Models;
-using System.Threading;
-using RimDev.Automation.StorageEmulator;
-using System.Linq;
-using Diagnostics.ModelsAndUtils.Attributes;
-using Diagnostics.Tests.Helpers;
-using Diagnostics.Scripts.Models;
-using Diagnostics.Scripts.CompilationService;
-using Diagnostics.Scripts.CompilationService.Interfaces;
-using Microsoft.CodeAnalysis.Scripting;
-using Octokit;
-using Diagnostics.RuntimeHost.Utilities;
-using System.Reflection;
-using Diagnostics.Scripts;
-using System.IO;
-using Diagnostics.ModelsAndUtils.ScriptUtilities;
+﻿//using System;
+//using Xunit;
+//using Diagnostics.RuntimeHost.Services.CacheService;
+//using Diagnostics.RuntimeHost.Services.CacheService.Interfaces;
+//using Microsoft.Extensions.Configuration;
+//using Diagnostics.RuntimeHost.Services.StorageService;
+//using Microsoft.AspNetCore.Hosting;
+//using Diagnostics.ModelsAndUtils.Models.Storage;
+//using Diagnostics.RuntimeHost.Models;
+//using Diagnostics.ModelsAndUtils.Models;
+//using System.Threading;
+//using RimDev.Automation.StorageEmulator;
+//using System.Linq;
+//using Diagnostics.ModelsAndUtils.Attributes;
+//using Diagnostics.Tests.Helpers;
+//using Diagnostics.Scripts.Models;
+//using Diagnostics.Scripts.CompilationService;
+//using Diagnostics.Scripts.CompilationService.Interfaces;
+//using Microsoft.CodeAnalysis.Scripting;
+//using Octokit;
+//using Diagnostics.RuntimeHost.Utilities;
+//using System.Reflection;
+//using Diagnostics.Scripts;
+//using System.IO;
+//using Diagnostics.ModelsAndUtils.ScriptUtilities;
 
-namespace Diagnostics.Tests.AzureStorageTests
-{
-    public class AzureStorageTests: IDisposable
-    {
+//namespace Diagnostics.Tests.AzureStorageTests
+//{
+//    public class AzureStorageTests: IDisposable
+//    {
 
-        IStorageService storageService;
+//        IStorageService storageService;
 
-        IDiagEntityTableCacheService tableCacheService;
+//        IDiagEntityTableCacheService tableCacheService;
 
-        IConfiguration configuration;
+//        IConfiguration configuration;
 
-        IHostingEnvironment environment;
+//        IHostingEnvironment environment;
 
-        AzureStorageEmulatorAutomation emulator;
+//        AzureStorageEmulatorAutomation emulator;
 
-        public AzureStorageTests()
-        {
-            StartStorageEmulator();
-            configuration = InitConfig();
-            environment = new MockHostingEnvironment();
-            environment.EnvironmentName = "UnitTest";
-            if(string.IsNullOrWhiteSpace(configuration["SourceWatcher:TableName"]))
-            {
-                configuration["SourceWatcher:TableName"] = "diagentities";
-            }
-            if (string.IsNullOrWhiteSpace(configuration["SourceWatcher:BlobContainerName"]))
-            {
-                configuration["SourceWatcher:BlobContainerName"] = "detectors";
-            }
-            configuration[$"SourceWatcher:WatcherType"] = "AzureStorage";
-            storageService = new StorageService(configuration, environment);
-            tableCacheService = new DiagEntityTableCacheService(storageService);
-        }
+//        public AzureStorageTests()
+//        {
+//            StartStorageEmulator();
+//            configuration = InitConfig();
+//            environment = new MockHostingEnvironment();
+//            environment.EnvironmentName = "UnitTest";
+//            if(string.IsNullOrWhiteSpace(configuration["SourceWatcher:TableName"]))
+//            {
+//                configuration["SourceWatcher:TableName"] = "diagentities";
+//            }
+//            if (string.IsNullOrWhiteSpace(configuration["SourceWatcher:BlobContainerName"]))
+//            {
+//                configuration["SourceWatcher:BlobContainerName"] = "detectors";
+//            }
+//            configuration[$"SourceWatcher:WatcherType"] = "AzureStorage";
+//            storageService = new StorageService(configuration, environment);
+//            tableCacheService = new DiagEntityTableCacheService(storageService);
+//        }
 
-        private void StartStorageEmulator()
-        {
-            emulator = new AzureStorageEmulatorAutomation();
-            emulator.Init();
-            emulator.Start();
-        }
+//        private void StartStorageEmulator()
+//        {
+//            emulator = new AzureStorageEmulatorAutomation();
+//            emulator.Init();
+//            emulator.Start();
+//        }
 
-        public void Dispose()
-        {
-            emulator.Stop();
-        }
+//        public void Dispose()
+//        {
+//            emulator.Stop();
+//        }
 
-        private IConfiguration InitConfig()
-        {
-             var builder = new ConfigurationBuilder()
-                    .AddEnvironmentVariables();
-            return builder.Build();
-        }
+//        private IConfiguration InitConfig()
+//        {
+//             var builder = new ConfigurationBuilder()
+//                    .AddEnvironmentVariables();
+//            return builder.Build();
+//        }
 
-        private bool CheckProcessRunning(int maxAttempts)
-        {
-            bool isRunning = AzureStorageEmulatorAutomation.IsEmulatorRunning();
-            int currentAttempt = 0;
-            while (!isRunning && currentAttempt <= maxAttempts)
-            {
-                currentAttempt++;
-                // Wait for 15s and then try 
-                Thread.Sleep(15 * 1000);          
-                isRunning = AzureStorageEmulatorAutomation.IsEmulatorRunning();
-            }
-            return isRunning;
-        }
+//        private bool CheckProcessRunning(int maxAttempts)
+//        {
+//            bool isRunning = AzureStorageEmulatorAutomation.IsEmulatorRunning();
+//            int currentAttempt = 0;
+//            while (!isRunning && currentAttempt <= maxAttempts)
+//            {
+//                currentAttempt++;
+//                // Wait for 15s and then try 
+//                Thread.Sleep(15 * 1000);          
+//                isRunning = AzureStorageEmulatorAutomation.IsEmulatorRunning();
+//            }
+//            return isRunning;
+//        }
 
-        [Fact]
-        /// <summary>
-        /// Tests load entity and insert entity
-        /// </summary>
-        public async void TestTableOperations()
-        {
-            // First check if emulator is running before proceeding. 
-            bool isEmulatorRunning = CheckProcessRunning(4);
-            if(isEmulatorRunning)
-            {
-                // Generate fake entity;
-                var diagEntity = new DiagEntity
-                {
-                    PartitionKey = "Detector",
-                    RowKey = "xyz",
-                    GithubLastModified = DateTime.UtcNow
-                };
-                var insertResult = await storageService.LoadDataToTable(diagEntity);
-                Assert.NotNull(insertResult);
-                var retrieveResult = await storageService.GetEntitiesByPartitionkey("Detector");
-                Assert.NotNull(retrieveResult);
-                Assert.NotEmpty(retrieveResult);
-                var gistResult = await storageService.GetEntitiesByPartitionkey("Gist");
-                Assert.Empty(gistResult);
-            }          
-        }
+//        [Fact]
+//        /// <summary>
+//        /// Tests load entity and insert entity
+//        /// </summary>
+//        public async void TestTableOperations()
+//        {
+//            // First check if emulator is running before proceeding. 
+//            bool isEmulatorRunning = CheckProcessRunning(4);
+//            if(isEmulatorRunning)
+//            {
+//                // Generate fake entity;
+//                var diagEntity = new DiagEntity
+//                {
+//                    PartitionKey = "Detector",
+//                    RowKey = "xyz",
+//                    GithubLastModified = DateTime.UtcNow
+//                };
+//                var insertResult = await storageService.LoadDataToTable(diagEntity);
+//                Assert.NotNull(insertResult);
+//                var retrieveResult = await storageService.GetEntitiesByPartitionkey("Detector");
+//                Assert.NotNull(retrieveResult);
+//                Assert.NotEmpty(retrieveResult);
+//                var gistResult = await storageService.GetEntitiesByPartitionkey("Gist");
+//                Assert.Empty(gistResult);
+//            }          
+//        }
 
-        [Fact]
-        /// <summary>
-        /// Test if entites are retrieved according to runtime context.
-        /// </summary>
-        public async void TestCacheOperations()
-        {
+//        [Fact]
+//        /// <summary>
+//        /// Test if entites are retrieved according to runtime context.
+//        /// </summary>
+//        public async void TestCacheOperations()
+//        {
 
-            // First check if emulator is running before proceeding. 
-            bool isEmulatorRunning = CheckProcessRunning(4);
-            if(isEmulatorRunning)
-            {
-                var windowsDiagEntity = new DiagEntity
-                {
-                    PartitionKey = "Detector",
-                    RowKey = "webappDown",
-                    GithubLastModified = DateTime.UtcNow,
-                    PlatForm = "Windows",
-                    ResourceProvider = "Microsoft.Web",
-                    ResourceType = "sites",
-                    StackType = "AspNet,NetCore",
-                    AppType = "WebApp",
-                    DetectorType = "Detector"
-                };
+//            // First check if emulator is running before proceeding. 
+//            bool isEmulatorRunning = CheckProcessRunning(4);
+//            if(isEmulatorRunning)
+//            {
+//                var windowsDiagEntity = new DiagEntity
+//                {
+//                    PartitionKey = "Detector",
+//                    RowKey = "webappDown",
+//                    GithubLastModified = DateTime.UtcNow,
+//                    PlatForm = "Windows",
+//                    ResourceProvider = "Microsoft.Web",
+//                    ResourceType = "sites",
+//                    StackType = "AspNet,NetCore",
+//                    AppType = "WebApp",
+//                    DetectorType = "Detector"
+//                };
 
 
-                var insertResult = await storageService.LoadDataToTable(windowsDiagEntity);
+//                var insertResult = await storageService.LoadDataToTable(windowsDiagEntity);
 
-                // Test Analysis detectors
+//                // Test Analysis detectors
 
-                var appDownAnalysisEntity = new DiagEntity
-                {
-                    PartitionKey = "Detector",
-                    RowKey = "appDownAnalysis",
-                    GithubLastModified = DateTime.UtcNow,
-                    PlatForm = "Windows",
-                    ResourceProvider = "Microsoft.Web",
-                    ResourceType = "sites",
-                    StackType = "AspNet,NetCore",
-                    AppType = "WebApp",
-                    DetectorType = "Analysis"
-                };
+//                var appDownAnalysisEntity = new DiagEntity
+//                {
+//                    PartitionKey = "Detector",
+//                    RowKey = "appDownAnalysis",
+//                    GithubLastModified = DateTime.UtcNow,
+//                    PlatForm = "Windows",
+//                    ResourceProvider = "Microsoft.Web",
+//                    ResourceType = "sites",
+//                    StackType = "AspNet,NetCore",
+//                    AppType = "WebApp",
+//                    DetectorType = "Analysis"
+//                };
 
-                insertResult = await storageService.LoadDataToTable(appDownAnalysisEntity);
-                var webApp = new App("72383ac7-d6f4-4a5e-bf56-b172f2fdafb2", "resourcegp-default", "diag-test");
-                var operationContext = new OperationContext<App>(
-                                         webApp,
-                                         DateTime.Now.ToString(),
-                                         DateTime.Now.AddHours(1).ToString(),
-                                         true,
-                                         new Guid().ToString()
-                                        );
-                var context = new RuntimeContext<App>(configuration);
-                context.OperationContext = operationContext;
+//                insertResult = await storageService.LoadDataToTable(appDownAnalysisEntity);
+//                var webApp = new App("72383ac7-d6f4-4a5e-bf56-b172f2fdafb2", "resourcegp-default", "diag-test");
+//                var operationContext = new OperationContext<App>(
+//                                         webApp,
+//                                         DateTime.Now.ToString(),
+//                                         DateTime.Now.AddHours(1).ToString(),
+//                                         true,
+//                                         new Guid().ToString()
+//                                        );
+//                var context = new RuntimeContext<App>(configuration);
+//                context.OperationContext = operationContext;
 
-                var detectorsForWebApps = await tableCacheService.GetEntityListByType(context, "Detector");
-                Assert.NotNull(detectorsForWebApps);
-                Assert.NotEmpty(detectorsForWebApps);
-                Assert.NotEmpty(detectorsForWebApps.Where(s => s.DetectorType != null && s.DetectorType.Equals("Analysis", StringComparison.CurrentCultureIgnoreCase)));
+//                var detectorsForWebApps = await tableCacheService.GetEntityListByType(context, "Detector");
+//                Assert.NotNull(detectorsForWebApps);
+//                Assert.NotEmpty(detectorsForWebApps);
+//                Assert.NotEmpty(detectorsForWebApps.Where(s => s.DetectorType != null && s.DetectorType.Equals("Analysis", StringComparison.CurrentCultureIgnoreCase)));
 
-                var logicApp = new LogicApp("72383ac7-d6f4-4a5e-bf56-b172f2fdafb2", "resourcegp-default", "la-test");
-                var logicAppOperContext = new OperationContext<LogicApp>(logicApp,
-                                                 DateTime.Now.ToString(),
-                                                 DateTime.Now.AddHours(1).ToString(),
-                                                 true,
-                                                 new Guid().ToString());
+//                var logicApp = new LogicApp("72383ac7-d6f4-4a5e-bf56-b172f2fdafb2", "resourcegp-default", "la-test");
+//                var logicAppOperContext = new OperationContext<LogicApp>(logicApp,
+//                                                 DateTime.Now.ToString(),
+//                                                 DateTime.Now.AddHours(1).ToString(),
+//                                                 true,
+//                                                 new Guid().ToString());
 
-                var runtimeContextLogicApp = new RuntimeContext<LogicApp>(configuration);
-                runtimeContextLogicApp.OperationContext = logicAppOperContext;
+//                var runtimeContextLogicApp = new RuntimeContext<LogicApp>(configuration);
+//                runtimeContextLogicApp.OperationContext = logicAppOperContext;
 
-                var detectorsForLogicApps = await tableCacheService.GetEntityListByType(runtimeContextLogicApp, "Detector");
-                Assert.NotNull(detectorsForLogicApps);
-                Assert.Empty(detectorsForLogicApps);            
+//                var detectorsForLogicApps = await tableCacheService.GetEntityListByType(runtimeContextLogicApp, "Detector");
+//                Assert.NotNull(detectorsForLogicApps);
+//                Assert.Empty(detectorsForLogicApps);            
                 
 
-            }    
-        }
+//            }    
+//        }
 
-        [Fact]
-        /// <summary>
-        /// Test blob upload operation
-        /// </summary>
-        public async void TestBlobOperations()
-        {
-            // First check if emulator is running before proceeding. 
-            bool isEmulatorRunning = CheckProcessRunning(4);
-            if (isEmulatorRunning)
-            {
-                // Test .dll blob upload 
+//        [Fact]
+//        /// <summary>
+//        /// Test blob upload operation
+//        /// </summary>
+//        public async void TestBlobOperations()
+//        {
+//            // First check if emulator is running before proceeding. 
+//            bool isEmulatorRunning = CheckProcessRunning(4);
+//            if (isEmulatorRunning)
+//            {
+//                // Test .dll blob upload 
 
-                Definition definitonAttribute = new Definition()
-                {
-                    Id = "blobDetector"
-                };
+//                Definition definitonAttribute = new Definition()
+//                {
+//                    Id = "blobDetector"
+//                };
 
-                EntityMetadata metadata = ScriptTestDataHelper.GetRandomMetadata();
-                metadata.ScriptText = await File.ReadAllTextAsync("blobDetector.csx");
-                var scriptOptions = ScriptTestDataHelper.GetScriptOption(ScriptHelper.GetFrameworkReferences(), ScriptHelper.GetFrameworkImports());
-                var serviceInstance = CompilationServiceFactory.CreateService(metadata, scriptOptions);
-                ICompilation compilation = await serviceInstance.GetCompilationAsync();
+//                EntityMetadata metadata = ScriptTestDataHelper.GetRandomMetadata();
+//                metadata.ScriptText = await File.ReadAllTextAsync("blobDetector.csx");
+//                var scriptOptions = ScriptTestDataHelper.GetScriptOption(ScriptHelper.GetFrameworkReferences(), ScriptHelper.GetFrameworkImports());
+//                var serviceInstance = CompilationServiceFactory.CreateService(metadata, scriptOptions);
+//                ICompilation compilation = await serviceInstance.GetCompilationAsync();
 
-                var assemblyBytes = await compilation.GetAssemblyBytesAsync();
-                var blobName = $"{definitonAttribute.Id}/{definitonAttribute.Id}.dll";
-                var etagdetector = await storageService.LoadBlobToContainer(blobName, assemblyBytes.Item1);
-                Assert.NotNull(etagdetector);
-                var assemblyData = await storageService.GetBlobByName(blobName);
-                Assert.NotNull(assemblyData);
+//                var assemblyBytes = await compilation.GetAssemblyBytesAsync();
+//                var blobName = $"{definitonAttribute.Id}/{definitonAttribute.Id}.dll";
+//                var etagdetector = await storageService.LoadBlobToContainer(blobName, assemblyBytes.Item1);
+//                Assert.NotNull(etagdetector);
+//                var assemblyData = await storageService.GetBlobByName(blobName);
+//                Assert.NotNull(assemblyData);
 
-                // Now test initializing Entry Point of Invoker using assembly
-                Assembly temp = Assembly.Load(assemblyData);
-                using (EntityInvoker invoker = new EntityInvoker(metadata))
-                {
-                    Exception ex = Record.Exception(() =>
-                    {
-                        invoker.InitializeEntryPoint(temp);
-                    });
+//                // Now test initializing Entry Point of Invoker using assembly
+//                Assembly temp = Assembly.Load(assemblyData);
+//                using (EntityInvoker invoker = new EntityInvoker(metadata))
+//                {
+//                    Exception ex = Record.Exception(() =>
+//                    {
+//                        invoker.InitializeEntryPoint(temp);
+//                    });
 
-                    Assert.Null(ex);
-                    Assert.True(invoker.IsCompilationSuccessful);
-                    Assert.Equal(definitonAttribute.Id, invoker.EntryPointDefinitionAttribute.Id);
-                }
-            }
-        }
-     }       
-}
+//                    Assert.Null(ex);
+//                    Assert.True(invoker.IsCompilationSuccessful);
+//                    Assert.Equal(definitonAttribute.Id, invoker.EntryPointDefinitionAttribute.Id);
+//                }
+//            }
+//        }
+//     }       
+//}


### PR DESCRIPTION
- Refresh cache with detectors published in the last 5 mins (Reason behind this: when multiple workers are polling storage, the last cache modified time may be different and out of sync, so on best-effort basis refreshing the cache with detectors modified in last 5 mins)
- Retry 3 times against primary storage account and move to secondary for read path
- table.CreateIfNotExists and container.CreateIfNotExists is causing a lot of noise in the application insight logs. It is seen as dependency failures. So removed those statements and move creation of container and table to script
 