### PR TITLE
Fix updates to storage when github is used

### DIFF
--- a/src/Diagnostics.RuntimeHost/Extensions/StorageServiceExtensions.cs
+++ b/src/Diagnostics.RuntimeHost/Extensions/StorageServiceExtensions.cs
@@ -20,11 +20,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IServiceCollection AddDiagEntitiesStorageService(this IServiceCollection services, IConfiguration configuration)
         {
-            if (Enum.Parse<SourceWatcherType>(configuration[$"SourceWatcher:{RegistryConstants.WatcherTypeKey}"]) == SourceWatcherType.AzureStorage)
+
+            if (configuration.IsPublicAzure() || configuration.IsAirGappedCloud())
             {
                 services.AddSingleton<IStorageService, StorageService>();
             }
-            else
+            if (configuration.IsAzureChinaCloud() || configuration.IsAzureUSGovernment())
             {
                 services.AddSingleton<IStorageService, NullableStorageService>();
             }


### PR DESCRIPTION
`NullableStorageService` was getting injected in public clouds which was failing updates to storage when github watcher is running. Fixing to inject based on cloud domain