### PR TITLE
Mitigate GetStampName not found unhandled http 500 exception for RuntimeHost

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/SupportObserverDataProvider.cs
@@ -234,7 +234,21 @@ namespace Diagnostics.DataProviders
             if (string.IsNullOrWhiteSpace(resourceGroupName))
                 throw new ArgumentNullException(nameof(resourceGroupName));
 
-            var siteObjects = await GetAdminSitesAsync(siteName);
+            JArray siteObjects = null;
+            try
+            {
+                siteObjects = await GetAdminSitesAsync(siteName);
+                
+            }
+            catch (HttpRequestException e)
+            {
+                if (!e.Message.Contains("404"))
+                {
+                    // swallow 404 exception here
+                    throw;
+                }
+            }
+
             if (siteObjects == null || !siteObjects.Any())
                 throw new Exception($"Could not get admin sites for site {siteName}");
 

--- a/src/Diagnostics.ModelsAndUtils/Utilities/AzureSupportCenterInsightUtilities.cs
+++ b/src/Diagnostics.ModelsAndUtils/Utilities/AzureSupportCenterInsightUtilities.cs
@@ -152,7 +152,7 @@ namespace Diagnostics.ModelsAndUtils.Utilities
                 RecommendedAction = new RecommendedAction()
                 {
                     Id = Guid.NewGuid(),
-                    Text = new Text("Check in Resource Explorer to see if site exists, or check the resource deletion records in kusto to see if it was deleted in last 30 days.")
+                    Text = new Text("Check in Resource Explorer if the site exists or check the resource deletion records in Kusto see if it was already deleted.")
                 },
                 ConfidenceLevel = InsightConfidenceLevel.High,
                 Scope = InsightScope.ResourceLevel,

--- a/src/Diagnostics.ModelsAndUtils/Utilities/AzureSupportCenterInsightUtilities.cs
+++ b/src/Diagnostics.ModelsAndUtils/Utilities/AzureSupportCenterInsightUtilities.cs
@@ -152,7 +152,7 @@ namespace Diagnostics.ModelsAndUtils.Utilities
                 RecommendedAction = new RecommendedAction()
                 {
                     Id = Guid.NewGuid(),
-                    Text = new Text("Check in Resource Explorer if the site exists or check the resource deletion records in Kusto see if it was already deleted.")
+                    Text = new Text("Check in Resource Explorer if the site exists or check the resource deletion records in Kusto to see if it was already deleted.")
                 },
                 ConfidenceLevel = InsightConfidenceLevel.High,
                 Scope = InsightScope.ResourceLevel,

--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
@@ -13,6 +13,7 @@ using Microsoft.CSharp.RuntimeBinder;
 using Diagnostics.Logger;
 using Microsoft.Extensions.Primitives;
 using System.Linq;
+using Diagnostics.ModelsAndUtils.Utilities;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -193,7 +194,14 @@ namespace Diagnostics.RuntimeHost.Controllers
                             "SiteNotFoundForGetInsightsRequestFromASC",
                             $"Observer adminsites API could not find the site subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/sites/{siteName}/");
 
-                        return NotFound();
+                        var response = new AzureSupportCenterInsightEnvelope()
+                        {
+                            CorrelationId = Guid.NewGuid(),
+                            ErrorMessage = null,
+                            TotalInsightsFound = 1,
+                            Insights = new[] { AzureSupportCenterInsightUtilites.CreateSiteNotFoundInsight(subscriptionId, resourceGroupName, siteName) }
+                        };
+                        return Ok(response);
                     }
                     else
                     {


### PR DESCRIPTION
For mitigating [BUG 1401: Failure to execute detectors when invoked from ASC. GetStampName exception](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1401)

Some requests from ASC to RuntimeHost /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/
providers/Microsoft.Web/sites/{siteName}/**insights** route failed with http 500 because of the site no longer existed.

This PR mitigates this issue by handling the exception raised by `SupportObserverDataProvider.GetStampName()`, logging it to kusto and returning a SiteNotFound insight.

![image](https://user-images.githubusercontent.com/68874830/94316503-50151880-ff39-11ea-9242-91fda8901fb6.png)
with a kusto link to site deletion records in 30 days, see sample [here](https://dataexplorer.azure.com/clusters/wawswus.kusto.windows.net/databases/wawsprod?query=All%28%27AntaresAdminSubscriptionAuditEvents%27%29%0D%0A++++%7C+where+PreciseTimeStamp+%3E%3D+ago%2830d%29%0D%0A++++%7C+where+SubscriptionId+%3D%7E+%274fb46acd-5bae-4fc1-9244-17bc477e17d8%27+and+ResourceGroupName+%3D%7E+%27nnbecuretestrg%27+and+SiteName+%3D%7E+%27nnbecuretestfuncapp%27%0D%0A++++%7C+where+OperationType+%3D%7E%27Delete%27+and+EntityType+%3D%7E%27WebSite%27+and+OperationStatus+%3D%7E+%27Success%27%0D%0A++++%7C+where+ResourceGroupName+%21%3D+%27%27+and++ResourceGroupName+%21%3D+%27None%27+%0D%0A++++%7C+order+by+PreciseTimeStamp+asc%0D%0A++++%7C+project+PreciseTimeStamp%2C+SubscriptionId+%2C+ResourceGroupName+%2C+SiteName+%2C+StampName%2C+EventStampName%2C+Address%0D%0A++++%7C+summarize+Timestamps+%3D+make_set%28bin%28PreciseTimeStamp%2C+1d%29%29+by+SubscriptionId+%2C+ResourceGroupName+%2C+SiteName+%2C+StampName%2C+EventStampName%2C+Address%0D%0A++++%7C+project-reorder+Timestamps) for /subscriptions/4fb46acd-5bae-4fc1-9244-17bc477e17d8/resourceGroups/nnbecuretestrg/providers/Microsoft.Web/sites/nnbecuretestfuncapp/