### PR TITLE
ExecuteClusterQuery fix to avoid high cpu

### DIFF
--- a/src/Diagnostics.DataProviders/KustoLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/KustoLogDecorator.cs
@@ -24,8 +24,8 @@ namespace Diagnostics.DataProviders
 
 		public Task<DataTable> ExecuteClusterQuery(string query, string cluster, string databaseName, string requestId, string operationName)
 		{
-			return ExecuteClusterQuery(query, cluster, databaseName, requestId, operationName);
-		}
+            return MakeDependencyCall(DataProvider.ExecuteClusterQuery(query, cluster, databaseName, requestId, operationName));
+        }
 
 		public Task<KustoQuery> GetKustoQuery(string query, string stampName)
 		{


### PR DESCRIPTION
Call the appropriate method on KustoClient passing in cluster and database name.