### PR TITLE
Fix the kusto link in "SITE NOT FOUND" ASC insight

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/GeoMaster/AzureSupportCenterInsight.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/GeoMaster/AzureSupportCenterInsight.cs
@@ -71,6 +71,8 @@ namespace Diagnostics.ModelsAndUtils.Models
 
     public class Link
     {
+        // 0 - Uri, 1 - Resource, 2 - AppLens
+        // See https://msazure.visualstudio.com/DefaultCollection/One/_git/EngSys-Supportability-AzureSupportCenter?path=%2Fsrc%2FAzSupCenter%2FDTO%2FModels%2FDiagnosticService%2FLinkModel.cs&_a=contents&version=GBdev
         public int Type { get; set; }
 
         public string Text { get; set; }

--- a/src/Diagnostics.ModelsAndUtils/Utilities/AzureSupportCenterInsightUtilities.cs
+++ b/src/Diagnostics.ModelsAndUtils/Utilities/AzureSupportCenterInsightUtilities.cs
@@ -160,7 +160,7 @@ namespace Diagnostics.ModelsAndUtils.Utilities
                 {
                     new Link()
                         {
-                            Type = 2,
+                            Type = 0,
                             Text = "Kusto Query",
                             Uri = kustoWebLink
                         }


### PR DESCRIPTION
For fixing [BUG 1552: The Azure Data Explorer link in the ASC insight does not work](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1552/)

![image](https://user-images.githubusercontent.com/68874830/98303473-ff023680-1f72-11eb-986c-e23bb7e53e27.png)

Figured out that Link Type should be 0 instead of 2. Also added comments to Link.Type field.