### PR TITLE
Remove outbound calls to KeyVault for Prod and Staging

### DIFF
--- a/infrastructure/Scripts/keyvault-appsettings.ps1
+++ b/infrastructure/Scripts/keyvault-appsettings.ps1
@@ -63,7 +63,7 @@ foreach ($secret in $allsecrets) {
     $hash[$appsettingName] = $secretValueText;
     $stickySlotSettings += $appsettingName
 }
-
+$hash["Secrets:KeyVaultEnabled"] = "false"
 Write-Host "Applying keyvault secrets to app settings for Webapp:" $WebappName ", Resource Group:" $WebappResourceGroup", Slot:" $WebappSlot
 Set-AzWebAppSlot -ResourceGroupName $WebappResourceGroup -Name $WebappName -AppSettings $hash -Slot $WebappSlot
 
@@ -73,4 +73,4 @@ $stickSlotConfigObject = @{"appSettingNames" = $stickySlotSettings;}
 
 Write-Host "Applying sticky slot app settings for Webapp:" $WebappName ", Resource Group:" $WebappResourceGroup", Slot:" $WebappSlot
 
-$result = Set-AzureRmResource -PropertyObject $stickSlotConfigObject -ResourceGroupName $WebappResourceGroup -ResourceType Microsoft.Web/sites/config -ResourceName $WebappName/slotConfigNames -ApiVersion 2015-08-01 -Force
+$result = Set-AzResource -Properties $stickSlotConfigObject -ResourceGroupName $WebappResourceGroup  -ResourceType Microsoft.Web/sites/config -ResourceName $WebappName/slotConfigNames -ApiVersion 2018-02-01 -Force

--- a/src/Diagnostics.CompilerHost/Startup.cs
+++ b/src/Diagnostics.CompilerHost/Startup.cs
@@ -45,7 +45,8 @@ namespace Diagnostics.CompilerHost
 
             var builtConfig = builder.Build();
 
-            if (builtConfig.GetValue<bool>("Secrets:KeyVaultEnabled", true))
+            // For production and staging, skip outbound call to keyvault for AppSettings
+            if (builtConfig.GetValue<bool>("Secrets:KeyVaultEnabled", true) || hostingEnvironment.IsDevelopment())
             {
                 string keyVaultConfig = Helpers.GetKeyvaultforEnvironment(hostingEnvironment.EnvironmentName);
                 var tokenProvider = new AzureServiceTokenProvider(azureAdInstance: builtConfig["Secrets:AzureAdInstance"]);

--- a/src/Diagnostics.DataProviders/ConfigurationFactory.cs
+++ b/src/Diagnostics.DataProviders/ConfigurationFactory.cs
@@ -32,15 +32,19 @@ namespace Diagnostics.DataProviders
 
             var builtConfig = builder.Build();
 
-            var tokenProvider = new AzureServiceTokenProvider(azureAdInstance: builtConfig["Secrets:AzureAdInstance"]);
-            var keyVaultClient = new KeyVaultClient(
-                new KeyVaultClient.AuthenticationCallback(
-                    tokenProvider.KeyVaultTokenCallback
-                )
-            );
+            // For production and staging, skip outbound call to keyvault for AppSettings
+            if (env.IsDevelopment())
+            {
+                var tokenProvider = new AzureServiceTokenProvider(azureAdInstance: builtConfig["Secrets:AzureAdInstance"]);
+                var keyVaultClient = new KeyVaultClient(
+                    new KeyVaultClient.AuthenticationCallback(
+                        tokenProvider.KeyVaultTokenCallback
+                    )
+                );
 
-            string keyVaultConfig = Helpers.GetKeyvaultforEnvironment(env.EnvironmentName);
-            builder.AddAzureKeyVault(builtConfig[keyVaultConfig], keyVaultClient, new DefaultKeyVaultSecretManager());
+                string keyVaultConfig = Helpers.GetKeyvaultforEnvironment(env.EnvironmentName);
+                builder.AddAzureKeyVault(builtConfig[keyVaultConfig], keyVaultClient, new DefaultKeyVaultSecretManager());
+            }
             builder.AddEnvironmentVariables();
 
             _configuration = builder.Build();

--- a/src/Diagnostics.DataProviders/ConfigurationFactory.cs
+++ b/src/Diagnostics.DataProviders/ConfigurationFactory.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Win32;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.Configuration.AzureKeyVault;
@@ -31,9 +29,13 @@ namespace Diagnostics.DataProviders
                 .AddEnvironmentVariables();
 
             var builtConfig = builder.Build();
-
+            var keyvaultEnabled = false;
+            if( bool.TryParse(builtConfig["Secrets:KeyVaultEnabled"], out bool result))
+            {
+                keyvaultEnabled = result;
+            }
             // For production and staging, skip outbound call to keyvault for AppSettings
-            if (env.IsDevelopment())
+            if ( keyvaultEnabled || env.IsDevelopment())
             {
                 var tokenProvider = new AzureServiceTokenProvider(azureAdInstance: builtConfig["Secrets:AzureAdInstance"]);
                 var keyVaultClient = new KeyVaultClient(

--- a/src/Diagnostics.RuntimeHost/Program.cs
+++ b/src/Diagnostics.RuntimeHost/Program.cs
@@ -42,14 +42,17 @@ namespace Diagnostics.RuntimeHost
             return WebHost.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((context, config) =>
                 {
-                    var (keyVaultUri, keyVaultClient) = GetKeyVaultSettings(context, config);
-
-                    config
-                        .AddAzureKeyVault(
-                            keyVaultUri,
-                            keyVaultClient,
-                            new DefaultKeyVaultSecretManager())
-                        .AddEnvironmentVariables()
+                    // For production and staging, skip outbound call to keyvault for AppSettings
+                    if(context.HostingEnvironment.IsDevelopment())
+                    {
+                        var (keyVaultUri, keyVaultClient) = GetKeyVaultSettings(context, config);
+                        config
+                            .AddAzureKeyVault(
+                                keyVaultUri,
+                                keyVaultClient,
+                                new DefaultKeyVaultSecretManager());
+                    }
+                        config.AddEnvironmentVariables()
                         .AddCommandLine(args)
                         .Build();
                 })

--- a/src/Diagnostics.RuntimeHost/Program.cs
+++ b/src/Diagnostics.RuntimeHost/Program.cs
@@ -42,10 +42,11 @@ namespace Diagnostics.RuntimeHost
             return WebHost.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((context, config) =>
                 {
+                    var builtConfig = config.Build();
                     // For production and staging, skip outbound call to keyvault for AppSettings
-                    if(context.HostingEnvironment.IsDevelopment())
+                    if(builtConfig.GetValue<bool>("Secrets:KeyVaultEnabled", true) || context.HostingEnvironment.IsDevelopment())
                     {
-                        var (keyVaultUri, keyVaultClient) = GetKeyVaultSettings(context, config);
+                        var (keyVaultUri, keyVaultClient) = GetKeyVaultSettings(context, builtConfig);
                         config
                             .AddAzureKeyVault(
                                 keyVaultUri,
@@ -59,9 +60,8 @@ namespace Diagnostics.RuntimeHost
                 .UseStartup<Startup>();
         }
 
-        private static Tuple<string, KeyVaultClient> GetKeyVaultSettings(WebHostBuilderContext context, IConfigurationBuilder config)
+        private static Tuple<string, KeyVaultClient> GetKeyVaultSettings(WebHostBuilderContext context, IConfigurationRoot builtConfig)
         {
-            var builtConfig = config.Build();
             var azureServiceTokenProvider = new AzureServiceTokenProvider(azureAdInstance: builtConfig["Secrets:AzureAdInstance"]);
             var keyVaultClient = new KeyVaultClient(
                 new KeyVaultClient.AuthenticationCallback(

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -3,7 +3,8 @@
     "DevKeyVaultName": "https://appservicediagnostics.vault.azure.net/",
     "StagingKeyVaultName": "https://AppServiceDiagnosticsKV.vault.azure.net/",
     "ProdKeyVaultName": "https://AppServiceDiagnosticsKV.vault.azure.net/",
-    "AzureAdInstance": "https://login.microsoftonline.com/"
+    "AzureAdInstance": "https://login.microsoftonline.com/",
+    "KeyVaultEnabled":  true
   },
   "Logging": {
     "IncludeScopes": false,


### PR DESCRIPTION
Created separate branch for removing outbound keyvault calls. I will merge this branch to main once the devops pipeline is integrated with the [script ](https://github.com/Azure/Azure-AppServices-Diagnostics/pull/598)and tested. 

- For production and staging, skip outbound calls 

- @hforeste , Can you review this for N-clouds. From your email I learnt that N-clouds is using keyvault app setting reference so it shouldn't be affected. 