### PR TITLE
Create frontdoor-update.ps1

### DIFF
--- a/infrastructure/Scripts/frontdoor-update.ps1
+++ b/infrastructure/Scripts/frontdoor-update.ps1
@@ -1,0 +1,51 @@
+# Parameters defined
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Subscription,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$FrontDoor,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$FrontDoorResourceGroup,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$BackendPoolName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$BackendHostName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$TrafficEnabled
+)
+Write-Host "Setting subscription context: " $Subscription
+#set the subscripton context
+Set-AzContext -SubscriptionId $Subscription
+
+Write-Host "Get FrontDoor Details for: " $FrontDoor
+$frontdoorDetails = Get-AzFrontDoor -ResourceGroupName $FrontDoorResourceGroup -Name $FrontDoor
+
+if($frontdoorDetails) {
+    
+    Write-Host "Retrieved FrontDoor details for: " $FrontDoor "Filtering backendpool for: " $BackendPoolName
+    $FilteredbackendPool = $frontdoorDetails.BackendPools | Where-Object -FilterScript { $_.Name -eq $BackendPoolName }
+    if($FilteredbackendPool) {
+        
+    $UpdateBackend = $FilteredbackendPool.Backends | Where-Object -FilterScript { $_.Address -eq $BackendHostName}
+    Write-Host "Setting " $BackendHostName "to be " $TrafficEnabled
+
+    $UpdateBackend.EnabledState = $TrafficEnabled
+
+    Set-AzFrontDoor -ResourceGroupName $FrontDoorResourceGroup -Name $FrontDoor -BackendPool $frontdoorDetails.BackendPools
+
+    Write-Host "Updated frontdoor settings for " $FrontDoor
+    }
+} else {
+    Write-Host "Could not retrieve frontdoor details for: " $FrontDoor
+}


### PR DESCRIPTION
Part of release pipeline, this script will be used to temporarily remove a backend host from receiving traffic to avoid any SLA dips. After swap is done, it will be reenabled. Currently devops does not have a frontdoor task, so using powershell script to do this. 

Proposed flow:

- Remove a backend from frontdoor
- Wait x secs for the change to be effective
- Update latest secrets from KeyVault as AppSettings to production slot
- Swap from staging to prod
- Wait for x secs for site to come back (May be send a /healthping call) 
- Add the backend back to frontdoor
