### PR TITLE
Add Insight status for display

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/ResponseExtensions/KeystoneComponent.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/ResponseExtensions/KeystoneComponent.cs
@@ -8,16 +8,18 @@ namespace Diagnostics.ModelsAndUtils.Models.ResponseExtensions
 {
     public class KeystoneInsight
     {
+        public InsightStatus Status;
         public string Title;
-        public string Summary;
+        public string Description;
         public Solution Solution;
         public DateTime StartDate;
         public DateTime ExpiryDate;
 
-        public KeystoneInsight(string title, string summary, Solution solution=null, DateTime? startDate= null, DateTime? expiryDate = null)
+        public KeystoneInsight(InsightStatus status, string title, string description, Solution solution=null, DateTime? startDate= null, DateTime? expiryDate = null)
         {
+            Status = status;
             Title = title;
-            Summary = summary;
+            Description = description;
             Solution = solution;
             StartDate = startDate ?? DateTime.UtcNow;
             ExpiryDate = expiryDate ?? DateTime.MaxValue;
@@ -30,9 +32,9 @@ namespace Diagnostics.ModelsAndUtils.Models.ResponseExtensions
         {
             try
             {
-                if (string.IsNullOrWhiteSpace(keystoneInsight.Title) || string.IsNullOrWhiteSpace(keystoneInsight.Summary))
+                if (keystoneInsight.Status == null || string.IsNullOrWhiteSpace(keystoneInsight.Title) || string.IsNullOrWhiteSpace(keystoneInsight.Description))
                 {
-                    throw new Exception("Required attributes Title, and Summary cannot be null or empty for KeystoneInsight.");
+                    throw new Exception("Required attributes Status, Title, and Description cannot be null or empty for KeystoneInsight.");
                 }
                 if (DateTime.Compare(keystoneInsight.ExpiryDate, DateTime.UtcNow) <= 0)
                 {


### PR DESCRIPTION
Insight status can be added to insight like below:
`var myInsight = new KeystoneInsight(InsightStatus.Critical, "Need help with TLS 1.3?",
        "TLS 1.3 is not supported on Azure", null, DateTime.UtcNow, DateTime.UtcNow.AddDays(14));`
    `res.AddKeystoneComponent(myInsight);`

It can be used in UI to show the user the criticality and importance of a keystone insight.