### PR TITLE
Allow spn prefix for AAD audience

### DIFF
--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -63,7 +63,7 @@ namespace Diagnostics.RuntimeHost
             var signingKeys = config.SigningKeys;
             // Adding both custom cert auth handler and Azure AAD JWT token handler to support multiple forms of auth.
             if (Environment.IsProduction() || Environment.IsStaging() )
-            {
+            {         
                 services.AddAuthentication().AddCertificateAuth(CertificateAuthDefaults.AuthenticationScheme,
                     options =>
                     {
@@ -74,7 +74,7 @@ namespace Diagnostics.RuntimeHost
                     }).AddJwtBearer("AzureAd", options => {
                     options.TokenValidationParameters = new TokenValidationParameters
                     {
-                        ValidAudience = Configuration["SecuritySettings:ClientId"],
+                        ValidAudiences =  new[] { Configuration["SecuritySettings:ClientId"], $"spn:{Configuration["SecuritySettings:ClientId"]}" },
                         ValidIssuers = new[] { issuer, $"{issuer}/v2.0" },
                         IssuerSigningKeys = signingKeys
                     };


### PR DESCRIPTION
- Adding spn: prefix for Client id since AKS team is using ADAL and getting 401 response because ADAL prefixes 'spn:' as audience for token. 
- This doesn't impact current auth as Client id without spn: prefix is also listed

References: [https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/issues/128](url), [https://docs.microsoft.com/en-us/azure/active-directory/develop/single-sign-on-saml-protocol#audience](url)