### PR TITLE
Support custom time grain aggregation in MDM data provider

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/MdmDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/MdmDataProvider.cs
@@ -151,6 +151,23 @@ namespace Diagnostics.DataProviders
         }
 
         /// <summary>
+        /// Gets the time series with specified time granularity.
+        /// </summary>
+        /// <param name="startTimeUtc">The start time UTC.</param>
+        /// <param name="endTimeUtc">The end time UTC.</param>
+        /// <param name="sampling">The sampling type.</param>
+        /// <param name="metricNamespace">The metric namespace.</param>
+        /// <param name="metricName">The metric name.</param>
+        /// <param name="seriesResolutionInMinutes">The resolution window used to reduce the resolution of the returned series.</param>
+        /// <param name="dimension">The dimension.</param>
+        /// <returns>The time series for the given definition.</returns>
+        public async Task<IEnumerable<DataTable>> GetTimeSeriesAsync(DateTime startTimeUtc, DateTime endTimeUtc, Sampling sampling, string metricNamespace, string metricName, int seriesResolutionInMinutes, IDictionary<string, string> dimension)
+        {
+            var definition = Tuple.Create<string, string, IEnumerable<KeyValuePair<string, string>>>(metricNamespace, metricName, dimension);
+            return await GetMultipleTimeSeriesAsync(startTimeUtc, endTimeUtc, sampling, seriesResolutionInMinutes, new List<Tuple<string, string, IEnumerable<KeyValuePair<string, string>>>> { definition });
+        }
+
+        /// <summary>
         /// Gets a list of the time series.
         /// </summary>
         /// <param name="startTimeUtc">The start time UTC.</param>

--- a/src/Diagnostics.DataProviders/Interfaces/IMdmDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IMdmDataProvider.cs
@@ -64,6 +64,19 @@ namespace Diagnostics.DataProviders.Interfaces
         Task<IEnumerable<DataTable>> GetTimeSeriesAsync(DateTime startTimeUtc, DateTime endTimeUtc, Sampling sampling, string metricNamespace, string metricName, IDictionary<string, string> dimension);
 
         /// <summary>
+        /// Gets the time series with specified time granularity.
+        /// </summary>
+        /// <param name="startTimeUtc">The start time UTC.</param>
+        /// <param name="endTimeUtc">The end time UTC.</param>
+        /// <param name="sampling">The sampling type.</param>
+        /// <param name="metricNamespace">The metric namespace.</param>
+        /// <param name="metricName">The metric name.</param>
+        /// <param name="seriesResolutionInMinutes">The resolution window used to reduce the resolution of the returned series.</param>
+        /// <param name="dimension">The dimension.</param>
+        /// <returns>The time series for the given definition.</returns>
+        Task<IEnumerable<DataTable>> GetTimeSeriesAsync(DateTime startTimeUtc, DateTime endTimeUtc, Sampling sampling, string metricNamespace, string metricName, int seriesResolutionInMinutes, IDictionary<string, string> dimension);        
+
+        /// <summary>
         /// Gets a list of the time series.
         /// </summary>
         /// <param name="startTimeUtc">The start time UTC.</param>

--- a/src/Diagnostics.DataProviders/MdmLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/MdmLogDecorator.cs
@@ -45,7 +45,12 @@ namespace Diagnostics.DataProviders
 			return MakeDependencyCall(DataProvider.GetTimeSeriesAsync(startTimeUtc, endTimeUtc, sampling, metricNamespace, metricName, dimension));
 		}
 
-		public Task<IEnumerable<DataTable>> GetMultipleTimeSeriesAsync(DateTime startTimeUtc, DateTime endTimeUtc, Sampling sampling, int seriesResolutionInMinutes, IEnumerable<Tuple<string, string, IEnumerable<KeyValuePair<string, string>>>> definitions)
+        public Task<IEnumerable<DataTable>> GetTimeSeriesAsync(DateTime startTimeUtc, DateTime endTimeUtc, Sampling sampling, string metricNamespace, string metricName, int seriesResolutionInMinutes, IDictionary<string, string> dimension)
+        {
+            return MakeDependencyCall(DataProvider.GetTimeSeriesAsync(startTimeUtc, endTimeUtc, sampling, metricNamespace, metricName, seriesResolutionInMinutes, dimension));
+        }
+
+        public Task<IEnumerable<DataTable>> GetMultipleTimeSeriesAsync(DateTime startTimeUtc, DateTime endTimeUtc, Sampling sampling, int seriesResolutionInMinutes, IEnumerable<Tuple<string, string, IEnumerable<KeyValuePair<string, string>>>> definitions)
 		{
 			return MakeDependencyCall(DataProvider.GetMultipleTimeSeriesAsync(startTimeUtc, endTimeUtc, sampling, seriesResolutionInMinutes, definitions));
 		}


### PR DESCRIPTION
Add support for custom time grain aggregation while fetching time series in MDM data provider.