### PR TITLE
Update execute cluster query overload in detector templates for partners

### DIFF
--- a/data/templates/Detector_ApiManagementService.csx
+++ b/data/templates/Detector_ApiManagementService.csx
@@ -15,7 +15,11 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ApiMan
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt))
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "YOUR_KUSTO_CLUSTER", "YOUR_KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
     });
 
     return res;

--- a/data/templates/Detector_AppServiceCertificate.csx
+++ b/data/templates/Detector_AppServiceCertificate.csx
@@ -15,7 +15,11 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<AppSer
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt))
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
     });
 
     return res;

--- a/data/templates/Detector_AppServiceDomain.csx
+++ b/data/templates/Detector_AppServiceDomain.csx
@@ -15,7 +15,11 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<AppSer
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt))
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table){
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
     });
 
     return res;

--- a/data/templates/Detector_Automation.csx
+++ b/data/templates/Detector_Automation.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,7 +20,7 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
         RenderingProperties = new Rendering(RenderingType.Table){
             Title = "Sample Table", 
             Description = "Some description here"

--- a/data/templates/Detector_Batch.csx
+++ b/data/templates/Detector_Batch.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		|where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,7 +20,7 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
         RenderingProperties = new Rendering(RenderingType.Table){
             Title = "Sample Table", 
             Description = "Some description here"

--- a/data/templates/Detector_BotService.csx
+++ b/data/templates/Detector_BotService.csx
@@ -7,8 +7,8 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
-		| where Timestamp == startTime and Timestamp == endTime
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
 		YOUR_QUERY
 	";
 }
@@ -20,7 +20,7 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt)),
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
         RenderingProperties = new Rendering(RenderingType.Table){
             Title = "Sample Table", 
             Description = "Some description here"

--- a/data/templates/Detector_ClassicStorageAccount.csx
+++ b/data/templates/Detector_ClassicStorageAccount.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,7 +20,7 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
         RenderingProperties = new Rendering(RenderingType.Table){
             Title = "Sample Table", 
             Description = "Some description here"

--- a/data/templates/Detector_ContainerInstance.csx
+++ b/data/templates/Detector_ContainerInstance.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		|where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,7 +20,7 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
         RenderingProperties = new Rendering(RenderingType.Table){
             Title = "Sample Table", 
             Description = "Some description here"

--- a/data/templates/Detector_ContainerRegistry.csx
+++ b/data/templates/Detector_ContainerRegistry.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		|where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,7 +20,7 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
         RenderingProperties = new Rendering(RenderingType.Table){
             Title = "Sample Table", 
             Description = "Some description here"

--- a/data/templates/Detector_EventHub.csx
+++ b/data/templates/Detector_EventHub.csx
@@ -7,8 +7,8 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
-		| where Timestamp == startTime and Timestamp == endTime
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
 		YOUR_QUERY
 	";
 }
@@ -20,10 +20,10 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt)),
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
         RenderingProperties = new Rendering(RenderingType.Table)
-        {
-            Title = "Sample Table",
+		{
+            Title = "Sample Table", 
             Description = "Some description here"
         }
     });

--- a/data/templates/Detector_HostingEnvironment.csx
+++ b/data/templates/Detector_HostingEnvironment.csx
@@ -12,7 +12,12 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<Hostin
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteQuery(GetQuery(cxt), cxt.Resource.InternalName)
+        Table = await dp.Kusto.ExecuteQuery(GetQuery(cxt), cxt.Resource.InternalName),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
     });
 
     return res;

--- a/data/templates/Detector_ISE.csx
+++ b/data/templates/Detector_ISE.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,8 +20,9 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
-        RenderingProperties = new Rendering(RenderingType.Table){
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
             Title = "Sample Table", 
             Description = "Some description here"
         }

--- a/data/templates/Detector_KubernetesService.csx
+++ b/data/templates/Detector_KubernetesService.csx
@@ -4,7 +4,7 @@ private static string GetQuery(OperationContext<AzureKubernetesService> cxt)
     $@"
         let startTime = datetime({cxt.StartTime});
         let endTime = datetime({cxt.EndTime});
-        cluster('Aks').database('AKSprod').<YOUR_TABLE_NAME>
+        <YOUR_TABLE_NAME>
         | where Timestamp >= startTime and Timestamp <= endTime
         | <YOUR_QUERY>";
 }
@@ -15,8 +15,9 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<AzureK
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt)),
-        RenderingProperties = new Rendering(RenderingType.Table){
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "Aks", "AKSprod", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
             Title = "Sample Table", 
             Description = "Some description here"
         }

--- a/data/templates/Detector_LogicApp.csx
+++ b/data/templates/Detector_LogicApp.csx
@@ -15,7 +15,12 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<LogicA
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt))
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
     });
 
     return res;

--- a/data/templates/Detector_MachineLearningServices.csx
+++ b/data/templates/Detector_MachineLearningServices.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,8 +20,9 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
-        RenderingProperties = new Rendering(RenderingType.Table){
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
             Title = "Sample Table", 
             Description = "Some description here"
         }

--- a/data/templates/Detector_NetAppAccounts.csx
+++ b/data/templates/Detector_NetAppAccounts.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,8 +20,9 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
-        RenderingProperties = new Rendering(RenderingType.Table){
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
             Title = "Sample Table", 
             Description = "Some description here"
         }

--- a/data/templates/Detector_OpenShiftManagedClusters.csx
+++ b/data/templates/Detector_OpenShiftManagedClusters.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where Timestamp == startTime and Timestamp == endTime
 		YOUR_QUERY
 	";
@@ -20,8 +20,9 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt)),
-        RenderingProperties = new Rendering(RenderingType.Table){
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
             Title = "Sample Table", 
             Description = "Some description here"
         }

--- a/data/templates/Detector_OpenShiftManagedClusters.csx
+++ b/data/templates/Detector_OpenShiftManagedClusters.csx
@@ -8,7 +8,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
 		YOUR_TABLE_NAME
-		| where Timestamp == startTime and Timestamp == endTime
+		| where Timestamp >= startTime and Timestamp <= endTime
 		YOUR_QUERY
 	";
 }

--- a/data/templates/Detector_ServiceBus.csx
+++ b/data/templates/Detector_ServiceBus.csx
@@ -7,8 +7,8 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
-		| where Timestamp == startTime and Timestamp == endTime
+		YOUR_TABLE_NAME
+		| where Timestamp >= startTime and Timestamp <= endTime
 		YOUR_QUERY
 	";
 }
@@ -20,10 +20,10 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt)),
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
         RenderingProperties = new Rendering(RenderingType.Table)
-        {
-            Title = "Sample Table",
+		{
+            Title = "Sample Table", 
             Description = "Some description here"
         }
     });

--- a/data/templates/Detector_ServiceFabric.csx
+++ b/data/templates/Detector_ServiceFabric.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where Timestamp >= startTime and Timestamp <= endTime
 		YOUR_QUERY
 	";
@@ -20,8 +20,9 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
-        RenderingProperties = new Rendering(RenderingType.Table){
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
             Title = "Sample Table", 
             Description = "Some description here"
         }

--- a/data/templates/Detector_SignalRService.csx
+++ b/data/templates/Detector_SignalRService.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,8 +20,9 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
-        RenderingProperties = new Rendering(RenderingType.Table){
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
             Title = "Sample Table", 
             Description = "Some description here"
         }

--- a/data/templates/Detector_SpringCloudService.csx
+++ b/data/templates/Detector_SpringCloudService.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where Timestamp >= startTime and Timestamp <= endTime
 		YOUR_QUERY
 	";
@@ -20,8 +20,9 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"),
-        RenderingProperties = new Rendering(RenderingType.Table){
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
             Title = "Sample Table", 
             Description = "Some description here"
         }

--- a/data/templates/Detector_StorageAccount.csx
+++ b/data/templates/Detector_StorageAccount.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,8 +20,9 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
-        RenderingProperties = new Rendering(RenderingType.Table){
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
             Title = "Sample Table", 
             Description = "Some description here"
         }

--- a/data/templates/Detector_VirtualMachines.csx
+++ b/data/templates/Detector_VirtualMachines.csx
@@ -7,7 +7,7 @@ private static string GetQuery(OperationContext<ArmResource> cxt)
     $@"
 		let startTime = datetime({cxt.StartTime});
 		let endTime = datetime({cxt.EndTime});
-		cluster('ClusterName').database('DBName').YOUR_TABLE_NAME
+		YOUR_TABLE_NAME
 		| where TIMESTAMP >= startTime and TIMESTAMP <= endTime
 		YOUR_QUERY
 	";
@@ -20,8 +20,9 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<ArmRes
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), null, "GetQuery"), 
-        RenderingProperties = new Rendering(RenderingType.Table){
+        Table = await dp.Kusto.ExecuteClusterQuery(GetQuery(cxt), "KUSTO_CLUSTER_NAME", "KUSTO_DB_NAME", null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
             Title = "Sample Table", 
             Description = "Some description here"
         }

--- a/data/templates/Detector_WebApp.csx
+++ b/data/templates/Detector_WebApp.csx
@@ -12,7 +12,12 @@ public async static Task<Response> Run(DataProviders dp, OperationContext<App> c
 {
     res.Dataset.Add(new DiagnosticData()
     {
-        Table = await dp.Kusto.ExecuteQuery(GetQuery(cxt), cxt.Resource.Stamp.Name)
+        Table = await dp.Kusto.ExecuteQuery(GetQuery(cxt), cxt.Resource.Stamp.Name, null, "GetQuery"),
+        RenderingProperties = new Rendering(RenderingType.Table)
+		{
+            Title = "Sample Table", 
+            Description = "Some description here"
+        }
     });
 
     return res;

--- a/data/templates/Detector_WebApp_Management.csx
+++ b/data/templates/Detector_WebApp_Management.csx
@@ -4,7 +4,7 @@ private static string OPERATION_NAME = "<YOUR_OPERATION_NAME>";  // eg:- Update,
 [Definition(Id = "<YOUR_DETECTOR_ID>", Name = "<YOUR_DETECTOR_NAME>", Author = "<YOUR_ALIAS>", Description = "Checks for all management operation of a given type and finds out how many of them succeeded, failed and prints out details of the failed operations")]
 public async static Task<Response> Run(DataProviders dp, OperationContext<App> cxt, Response res)
 {
-    var tblOperations = await dp.Kusto.ExecuteQuery(GetManagementOperations(cxt, OPERATION_NAME), cxt.Resource.Stamp.Name);
+    var tblOperations = await dp.Kusto.ExecuteQuery(GetManagementOperations(cxt, OPERATION_NAME), cxt.Resource.Stamp.Name, null, "GetManagementOperations");
     
     res.AddDataSummary(GetOperationSummary(tblOperations));
 
@@ -104,7 +104,7 @@ private static async Task ShowFailedOperationDetails(OperationContext<App> cxt, 
     var failedOperations = GetFailedOperationList(tblOperations, "Status <> 'Success'");
     if (failedOperations.Count > 0)
     {
-        var operationDetails  = await dp.Kusto.ExecuteQuery(GetFailedOperationDetailsQuery(cxt, failedOperations), cxt.Resource.Stamp.Name);
+        var operationDetails  = await dp.Kusto.ExecuteQuery(GetFailedOperationDetailsQuery(cxt, failedOperations), cxt.Resource.Stamp.Name, null, "GetFailedOperationDetailsQuery");
         foreach (var failedActivityId in failedOperations)
        {
             DataView failedOperationDetailsView = operationDetails.DefaultView;


### PR DESCRIPTION
We introduced a new overload of the ExecuteClusterQuery(queryText, clusterName, databaseName, requestId, source) and we want partners to use this overload instead of the older overload of ExecuteClusterQuery(queryText, requestId, source).

The older overload will force the connection to go though wawseus and have Antares kusto act as a proxy increasing the load on our clusters. The new overload will directly connect to the partner's kusto cluster not only speeding up the query by reducing a hop but also reducing load on Antares clusters.

A change in detector template will help ensure any future detectors use the correct overload going forward.