### PR TITLE
Redirect partner queries using ExecuteClusterQuery directly to the target cluster.

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -65,10 +65,8 @@ namespace Diagnostics.DataProviders
                     string targetCluster = element.Groups["cluster"].Value.Trim(new char[] { '\'', '\"' });
                     string targetDatabase = element.Groups["database"].Value.Trim(new char[] { '\'', '\"' });                    
 
-                    if (!string.IsNullOrWhiteSpace(targetCluster) && !string.IsNullOrWhiteSpace(targetDatabase)
-                        && targetCluster.Equals("Aks", StringComparison.OrdinalIgnoreCase) && targetDatabase.Equals("AKSprod", StringComparison.OrdinalIgnoreCase))
+                    if (!string.IsNullOrWhiteSpace(targetCluster) && !string.IsNullOrWhiteSpace(targetDatabase))
                     {
-                        //Apply this only for Aks at the moment.
                         return await ExecuteClusterQuery(query, targetCluster, targetCluster, requestId, operationName);
                     }
                 }

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -57,6 +57,23 @@ namespace Diagnostics.DataProviders
 
         public async Task<DataTable> ExecuteClusterQuery(string query, string requestId = null, string operationName = null)
         {
+            var matches = Regex.Matches(query, @"cluster\((?<cluster>([^\)]+))\).database\((?<database>([^\)]+))\)\.");
+            if (matches.Any())
+            {
+                foreach (Match element in matches)
+                {
+                    string targetCluster = element.Groups["cluster"].Value.Trim(new char[] { '\'', '\"' });
+                    string targetDatabase = element.Groups["database"].Value.Trim(new char[] { '\'', '\"' });                    
+
+                    if (!string.IsNullOrWhiteSpace(targetCluster) && !string.IsNullOrWhiteSpace(targetDatabase)
+                        && targetCluster.Equals("Aks", StringComparison.OrdinalIgnoreCase) && targetDatabase.Equals("AKSprod", StringComparison.OrdinalIgnoreCase))
+                    {
+                        //Apply this only for Aks at the moment.
+                        return await ExecuteClusterQuery(query, targetCluster, targetCluster, requestId, operationName);
+                    }
+                }
+            }
+
             return await ExecuteQuery(query, DataProviderConstants.FakeStampForAnalyticsCluster, requestId, operationName);
         }
 

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -67,7 +67,7 @@ namespace Diagnostics.DataProviders
 
                     if (!string.IsNullOrWhiteSpace(targetCluster) && !string.IsNullOrWhiteSpace(targetDatabase))
                     {
-                        return await ExecuteClusterQuery(query, targetCluster, targetCluster, requestId, operationName);
+                        return await ExecuteClusterQuery(query, targetCluster, targetDatabase, requestId, operationName);
                     }
                 }
             }


### PR DESCRIPTION
Extract cluster and database name from the query and if it is AKS, connect to the AKS cluster instead of using the Antares cluster as a proxy. Once we ensure this is working, we can apply the logic for all partners wherever we find a cluster and database mentioned in the query.