### PR TITLE
Fixing potential SNAT issues

### DIFF
--- a/src/Diagnostics.DataProviders/AppInsightsClient.cs
+++ b/src/Diagnostics.DataProviders/AppInsightsClient.cs
@@ -32,7 +32,7 @@ namespace Diagnostics.DataProviders
         /// </summary>
         private const string BaseURL = "https://api.applicationinsights.io/v1/apps/{0}/query";
 
-        private readonly Lazy<HttpClient> _client = new Lazy<HttpClient>(() =>
+        private static readonly Lazy<HttpClient> _client = new Lazy<HttpClient>(() =>
         {
             var client = new HttpClient();
             client.DefaultRequestHeaders.Accept.Clear();

--- a/src/Diagnostics.DataProviders/ChangeAnalysisClient.cs
+++ b/src/Diagnostics.DataProviders/ChangeAnalysisClient.cs
@@ -44,7 +44,7 @@ namespace Diagnostics.DataProviders
 
         private string requestId;
 
-        private readonly Lazy<HttpClient> client = new Lazy<HttpClient>(() =>
+        private static readonly Lazy<HttpClient> client = new Lazy<HttpClient>(() =>
         {
             var client = new HttpClient();
             client.DefaultRequestHeaders.Accept.Clear();

--- a/src/Diagnostics.DataProviders/KustoSDKClient.cs
+++ b/src/Diagnostics.DataProviders/KustoSDKClient.cs
@@ -19,7 +19,7 @@ using System.Linq;
 
 namespace Diagnostics.DataProviders
 {
-    class KustoSDKClient : IKustoClient
+    public class KustoSDKClient : IKustoClient
     {
         private readonly KustoDataProviderConfiguration _config;
         private string _requestId;
@@ -70,10 +70,8 @@ namespace Diagnostics.DataProviders
                 };
 
                 var queryProvider = Kusto.Data.Net.Client.KustoClientFactory.CreateCslQueryProvider(connectionStringBuilder);
-                if (!QueryProviderMapping.TryAdd(key, queryProvider))
-                {
-                    queryProvider.Dispose();
-                }
+                QueryProviderMapping.TryAdd(key, queryProvider);
+                queryProvider.Dispose();
             }
 
             return QueryProviderMapping[key];

--- a/src/Diagnostics.DataProviders/MdmClient/MdmClient.cs
+++ b/src/Diagnostics.DataProviders/MdmClient/MdmClient.cs
@@ -27,7 +27,7 @@ namespace Diagnostics.DataProviders
         /// <summary>
         /// Gets the http client.
         /// </summary>
-        public HttpClient HttpClient { get; private set; }
+        public static HttpClient HttpClient { get; private set; }
 
         /// <summary>
         /// Gets the endpoint.


### PR DESCRIPTION
Fixing potential SNAT issues that could come from DataProviders

- For Kusto, the QueryProviderMapping was static, but the temporary `ICslQueryProvider` object created was not getting disposed after adding to dictionary
- Did a check across other clients and made static HTTP client wherever possible.

After deploying to staging, will monitor and see if it fixes SNAT problems.

