### PR TITLE
Use static httpclient

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/CompilerHostClient.cs
+++ b/src/Diagnostics.RuntimeHost/Services/CompilerHostClient.cs
@@ -25,7 +25,7 @@ namespace Diagnostics.RuntimeHost.Services
         private IHostingEnvironment _env;
         private IConfiguration _configuration;
         private string _compilerHostUrl;
-        private HttpClient _httpClient;
+        private static HttpClient _httpClient;
         private string _eventSource;
 
         public CompilerHostClient(IHostingEnvironment env, IConfiguration configuration)

--- a/src/Diagnostics.RuntimeHost/Services/GithubClient/GithubClient.cs
+++ b/src/Diagnostics.RuntimeHost/Services/GithubClient/GithubClient.cs
@@ -54,7 +54,7 @@ namespace Diagnostics.RuntimeHost.Services
         private string _repoName;
         private string _branch;
         private string _accessToken;
-        private HttpClient _httpClient;
+        private static HttpClient _httpClient;
         private Octokit.GitHubClient _octokitClient;
 
         public string UserName => _userName;

--- a/src/Diagnostics.RuntimeHost/Services/HealthCheckService/HealthCheckService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/HealthCheckService/HealthCheckService.cs
@@ -22,7 +22,7 @@ namespace Diagnostics.RuntimeHost.Services
     public class HealthCheckService : IHealthCheckService
     {
         private string OutboundConnectivityCheckUrl;
-        private HttpClient _httpClient;
+        private static HttpClient _httpClient;
         private readonly ISourceWatcher _sourceWatcher;
         IConfiguration _configuration;
         IDataSourcesConfigurationService _dataSourcesConfigurationService;

--- a/src/Diagnostics.RuntimeHost/Services/SearchService/SearchService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SearchService/SearchService.cs
@@ -30,7 +30,7 @@ namespace Diagnostics.RuntimeHost.Services
         private string FreeModelUrl;
         private string TriggerTrainingUrl;
         private string TriggerModelRefreshUrl;
-        private HttpClient _httpClient;
+        private static HttpClient _httpClient;
         SearchServiceProviderConfiguration configuration;
 
         public SearchService(IDataSourcesConfigurationService dataSourcesConfigService)


### PR DESCRIPTION
During SNAT investigation, found an issue where outbound connections spike to google.com/generate_204 with the increase in the request to healthping endpoints. This should be avoided. Hence making http client static.