### PR TITLE
Fix for ExecuteClusterQuery if it the query contains FQDN cluster name

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -70,6 +70,7 @@ namespace Diagnostics.DataProviders
 
                         if (!string.IsNullOrWhiteSpace(targetCluster) && !string.IsNullOrWhiteSpace(targetDatabase))
                         {
+                            targetCluster = targetCluster.Replace(".kusto.windows.net", string.Empty, StringComparison.OrdinalIgnoreCase);
                             return await ExecuteClusterQuery(query, targetCluster, targetDatabase, requestId, operationName);
                         }
                     }


### PR DESCRIPTION
Extract cluster name if the cluster was specified as FQDN in the query.