### PR TITLE
Remove type id from response

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Attributes/Definition.cs
+++ b/src/Diagnostics.ModelsAndUtils/Attributes/Definition.cs
@@ -64,7 +64,7 @@ namespace Diagnostics.ModelsAndUtils.Attributes
         public string AnalysisType { get; set; } = string.Empty;
 
         [JsonIgnore]
-        protected Guid instanceGUID;
+        private Guid instanceGUID;
 
         [JsonIgnore]
         public override object TypeId { get { return (object)instanceGUID; } }

--- a/src/Diagnostics.ModelsAndUtils/Attributes/Definition.cs
+++ b/src/Diagnostics.ModelsAndUtils/Attributes/Definition.cs
@@ -16,6 +16,11 @@ namespace Diagnostics.ModelsAndUtils.Attributes
     /// </summary>
     public class Definition : Attribute, IEquatable<Definition>
     {
+        public Definition()
+        {
+            this.instanceGUID = Guid.NewGuid();
+        }
+
         /// <summary>
         /// Id of the detector(unique).
         /// </summary>
@@ -57,6 +62,12 @@ namespace Diagnostics.ModelsAndUtils.Attributes
 
         [JsonIgnore]
         public string AnalysisType { get; set; } = string.Empty;
+
+        [JsonIgnore]
+        protected Guid instanceGUID;
+
+        [JsonIgnore]
+        public override object TypeId { get { return (object)instanceGUID; } }
 
         /// <summary>
         /// Gets Analysis Types for which this detector should apply to.


### PR DESCRIPTION
Override the TypeId property in Definition Attribute and apply a JsonIgnore attribute to it.