### PR TITLE
Set connection limit for google endpoint

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/HealthCheckService/HealthCheckService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/HealthCheckService/HealthCheckService.cs
@@ -158,11 +158,13 @@ namespace Diagnostics.RuntimeHost.Services
 
         private void InitializeHttpClient()
         {
-            _httpClient = new HttpClient
+            var handler = new HttpClientHandler
             {
-                MaxResponseContentBufferSize = Int32.MaxValue,
-                Timeout = TimeSpan.FromSeconds(3)
+                MaxConnectionsPerServer = 10 // Set only max of 10 concurrent connections to google endpoint.
             };
+            _httpClient = new HttpClient(handler);
+            _httpClient.MaxResponseContentBufferSize = Int32.MaxValue;
+            _httpClient.Timeout = TimeSpan.FromSeconds(3);
         }
     }
 }


### PR DESCRIPTION
SNAT issue continued in production site when there was a restart and the load to /healthping route increased. 
After some experimentation and local repro, we found that setting MaxConnectionsPerServer can fix this (thanks @nmallick1!) - https://docs.microsoft.com/en-gb/archive/blogs/timomta/controlling-the-number-of-outgoing-connections-from-httpclient-net-core-or-full-framework
