### PR TITLE
Disable continuous heartbeats to main kusto clusters

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -31,7 +31,13 @@ namespace Diagnostics.DataProviders
 
         private string[] AppSettingsExistenceCheckList = new string[] { "APPINSIGHTS_INSTRUMENTATIONKEY" };
 
-		public string GeoMasterName { get; }
+        private readonly char[] ValueTerminators = new char[] { '<', '"' };
+
+        private string[] CredentialTokens = new string[] { "Token=", "DefaultEndpointsProtocol=http", "AccountKey=", "Data Source=", "Server=", "Password=", "pwd=", "&amp;sig=", "&sig=", "COMPOSE|", "KUBE|" };
+
+        private const string SecretReplacement = "!!!SECRET-TRAP!!!";
+
+        public string GeoMasterName { get; }
 
         public string RequestId { get; set; }
 
@@ -65,6 +71,29 @@ namespace Diagnostics.DataProviders
             if (Regex.Match(content, @"https*:\/\/[\w.]*[\w]+.core.windows.net?.*sig=.*", RegexOptions.IgnoreCase).Success)
             {
                 content = "https://*.core.windows.net/*";
+            }
+            else
+            {
+                string maskedString = content;
+                foreach (var token in CredentialTokens)
+                {
+                    int startIndex = 0;
+                    while (true)
+                    {
+                        // search for the next token instance
+                        startIndex = maskedString.IndexOf(token, startIndex, StringComparison.OrdinalIgnoreCase);
+                        if (startIndex == -1)
+                        {
+                            break;
+                        }
+
+                        // Find the end of the secret. It most likely ends with either a double quota " or tag opening <
+                        int credentialEnd = maskedString.IndexOfAny(ValueTerminators, startIndex);
+
+                        maskedString = maskedString.Substring(0, startIndex) + SecretReplacement + (credentialEnd != -1 ? maskedString.Substring(credentialEnd) : "");
+                    }
+                }
+                content = maskedString;
             }
 
             return content;

--- a/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
+++ b/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
@@ -232,18 +232,6 @@ namespace Diagnostics.DataProviders
                 
                 string activityId = Guid.NewGuid().ToString();
                 await RunHeartBeatPrimary(activityId);
-
-                //if (string.IsNullOrWhiteSpace(FailoverCluster))
-                //{
-                //    await RunHeartBeatPrimary(activityId);
-                //}
-                //else
-                //{
-                //    var primaryTask = RunHeartBeatPrimary(activityId);
-                //    var failoverTask = RunHeartBeatFailover(activityId);
-                //    await Task.WhenAll(new Task[] { primaryTask, failoverTask });
-                //}
-
                 await Task.Delay(TimeSpan.FromSeconds(_configuration.HeartBeatDelayInSeconds), cancellationToken);
             }
         }

--- a/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
+++ b/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
@@ -159,7 +159,7 @@ namespace Diagnostics.DataProviders
             Exception exceptionForLog = null;
             try
             {
-                var primaryHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOutInSeconds, activityId);
+                var primaryHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, PrimaryCluster, _configuration.HeartBeatTimeOutInSeconds, activityId, "PrimaryHealthPing");
 
                 if (primaryHeartBeat.Rows.Count >= 1)
                 {
@@ -210,7 +210,7 @@ namespace Diagnostics.DataProviders
             Exception exceptionForLog = null;
             try
             {
-                var failoverHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, FailoverCluster, _configuration.HeartBeatTimeOutInSeconds, activityId);
+                var failoverHeartBeat = await _kustoDataProvider.ExecuteQueryForHeartbeat(_configuration.HeartBeatQuery, FailoverCluster, _configuration.HeartBeatTimeOutInSeconds, activityId, "FailoverHealthPing");
 
                 if (failoverHeartBeat.Rows.Count >= 1)
                 {

--- a/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
+++ b/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
@@ -182,12 +182,20 @@ namespace Diagnostics.DataProviders
                 _ConsecutiveSuccessCount = 0;
             }
 
-            // if not in failover state
-            //  should failover?
+            /*
+             * Logic of failing over to failover cluster:
+             *  1. If currently Primary cluster is used
+             *  2. If the heartbeat failure count is more than the failure limit
+             *  3. When both #1 and #2 are TRUE, run a sample heartbeat query to failover cluster,
+             *     and if that succeeds, go ahead with the failover. 
+            */
             if (UsePrimaryCluster && _ConsecutiveFailureCount >= _configuration.HeartBeatConsecutiveFailureLimit)
             {
-                UsePrimaryCluster = false;
-            } // else should stop failover
+                // Check if heartbeat query succeeds on failover cluster
+                bool isFailoverHeartbeatSuccessful = await RunHeartBeatFailover(activityId);
+                UsePrimaryCluster = !isFailoverHeartbeatSuccessful;
+            } 
+            // else Stop the failover
             else if (!UsePrimaryCluster && _ConsecutiveSuccessCount >= _configuration.HeartBeatConsecutiveSuccessLimit)
             {
                 UsePrimaryCluster = true;
@@ -196,7 +204,7 @@ namespace Diagnostics.DataProviders
             LogHeartBeatInformation("Primary", primaryHeartBeatSuccess, PrimaryCluster, activityId, UsePrimaryCluster, exceptionForLog);
         }
 
-        private async Task RunHeartBeatFailover(string activityId)
+        private async Task<bool> RunHeartBeatFailover(string activityId)
         {
             bool failoverHeartBeatSuccess = false;
             Exception exceptionForLog = null;
@@ -215,6 +223,7 @@ namespace Diagnostics.DataProviders
             }
 
             LogHeartBeatInformation("Failover", failoverHeartBeatSuccess, FailoverCluster, activityId, UsePrimaryCluster, exceptionForLog);
+            return failoverHeartBeatSuccess;
         }
 
         public async Task RunHeartBeatTask(CancellationToken cancellationToken)
@@ -222,17 +231,19 @@ namespace Diagnostics.DataProviders
             while (!cancellationToken.IsCancellationRequested) {
                 
                 string activityId = Guid.NewGuid().ToString();
+                await RunHeartBeatPrimary(activityId);
 
-                if (string.IsNullOrWhiteSpace(FailoverCluster))
-                {
-                    await RunHeartBeatPrimary(activityId);
-                }
-                else
-                {
-                    var primaryTask = RunHeartBeatPrimary(activityId);
-                    var failoverTask = RunHeartBeatFailover(activityId);
-                    await Task.WhenAll(new Task[] { primaryTask, failoverTask });
-                }
+                //if (string.IsNullOrWhiteSpace(FailoverCluster))
+                //{
+                //    await RunHeartBeatPrimary(activityId);
+                //}
+                //else
+                //{
+                //    var primaryTask = RunHeartBeatPrimary(activityId);
+                //    var failoverTask = RunHeartBeatFailover(activityId);
+                //    await Task.WhenAll(new Task[] { primaryTask, failoverTask });
+                //}
+
                 await Task.Delay(TimeSpan.FromSeconds(_configuration.HeartBeatDelayInSeconds), cancellationToken);
             }
         }

--- a/tests/Diagnostics.Tests/DataProviderTests/DataProviderTests.cs
+++ b/tests/Diagnostics.Tests/DataProviderTests/DataProviderTests.cs
@@ -236,28 +236,31 @@ namespace Diagnostics.Tests.DataProviderTests
             config.KustoConfiguration.EnableHeartBeatQuery = true;
             var kustoHeartBeatService = new KustoHeartBeatService(config.KustoConfiguration);
 
-            MockKustoClient.ShouldHeartbeatSucceed = true;
+            MockKustoClient.ShouldPrimaryHeartbeatSucceed = true;
+            MockKustoClient.ShouldFailoverHeartbeatSucceed = false;
             int startingHeartBeatRuns = MockKustoClient.HeartBeatRuns;
             do
             {
-                await Task.Delay(100);
+                await Task.Delay(1000);
             } while (startingHeartBeatRuns == MockKustoClient.HeartBeatRuns);
             Assert.Equal(config.KustoConfiguration.KustoClusterNameGroupings, await kustoHeartBeatService.GetClusterNameFromStamp("waws-prod-mockstamp"));
 
 
-            MockKustoClient.ShouldHeartbeatSucceed = false;
+            MockKustoClient.ShouldPrimaryHeartbeatSucceed = false;
+            MockKustoClient.ShouldFailoverHeartbeatSucceed = true;
             startingHeartBeatRuns = MockKustoClient.HeartBeatRuns;
             do
             {
-                await Task.Delay(100);
+                await Task.Delay(1000);
             } while (startingHeartBeatRuns == MockKustoClient.HeartBeatRuns);
             Assert.Equal(config.KustoConfiguration.KustoClusterFailoverGroupings, await kustoHeartBeatService.GetClusterNameFromStamp("waws-prod-mockstamp"));
 
-            MockKustoClient.ShouldHeartbeatSucceed = true;
+            MockKustoClient.ShouldPrimaryHeartbeatSucceed = true;
+            MockKustoClient.ShouldFailoverHeartbeatSucceed = false;
             startingHeartBeatRuns = MockKustoClient.HeartBeatRuns;
             do
             {
-                await Task.Delay(100);
+                await Task.Delay(1000);
             } while (startingHeartBeatRuns == MockKustoClient.HeartBeatRuns);
             Assert.Equal(config.KustoConfiguration.KustoClusterNameGroupings, await kustoHeartBeatService.GetClusterNameFromStamp("waws-prod-mockstamp"));
 


### PR DESCRIPTION
 ### Problem:
- Our Heartbeat query count is very high on main kusto clusters and is deemed expensive. It is affecting other operations like wawsalerting etc.

### Solution:
1. Stop continuous pings to main kusto clusters.
2. Whenever failover is required from follower to main, run a heartbeat query on main cluster and if successful, then perform a failover. (Currently, we dont check anything on the main cluster when doing failover :) )
3. Kusto Dashboards will be impacted by this. However not a big thing as we will not see any synthetic SLA for main clusters. We will still continue to see synthetic SLA and failover telemetry for follower clusters.