### PR TITLE
Ignore keystone detector in project shield

### DIFF
--- a/src/Diagnostics.AIProjects/TrainingAPI/__app__/TrainingModule/DetectorsFetchHelper.py
+++ b/src/Diagnostics.AIProjects/TrainingAPI/__app__/TrainingModule/DetectorsFetchHelper.py
@@ -2,6 +2,8 @@ from __app__.TrainingModule.AcquireToken import acquireAccessToken
 from __app__.AppSettings.AppSettings import appSettings
 import requests, json
 
+DETECTORS_TO_IGNORE = ["test_keystone_detector"]
+
 def getAllDetectors():
     url = appSettings.DETECTORS_URL
     request_headers = {
@@ -14,10 +16,14 @@ def getAllDetectors():
     if request.status_code == 200:
         try:
             content = json.loads(request.content)
+            rescontent = []
             for detector in content:
+                if detector["id"] in DETECTORS_TO_IGNORE:
+                    continue
                 detector["utterances"] = (json.loads(detector["metadata"] or "[]")["utterances"] if "utterances" in json.loads(detector["metadata"] or "[]") else []) if "metadata" in detector else []
                 detector.pop("metadata", None)
-            return content
+                rescontent.append(detector)
+            return rescontent
         except json.decoder.JSONDecodeError as e:
             raise Exception("Failed to parse Detectors API response as JSON {0}".format(str(e)))
     else:


### PR DESCRIPTION
Keystone detector is public but it is not supposed to show in Project Shield as it doesn't render any default insights, other than keystone insights. Creating a list for public detectors that need to be ignored in shield.