### PR TITLE
Change AzSupport kusto cluster to follower

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/SupportTopicService/SupportTopicService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/SupportTopicService/SupportTopicService.cs
@@ -41,7 +41,7 @@ namespace Diagnostics.RuntimeHost.Services
         }
 
         private string GetSupportTopicKustoQuery() {
-            string query = $@"cluster('azsupport').database('AzureSupportability').ActiveSupportTopicTree
+            string query = $@"ActiveSupportTopicTree
                             | where Timestamp > ago(3d)
                             | extend SupportTopicId = iff(SupportTopicL3Id != '' and SupportTopicL3Id != ' ', SupportTopicL3Id, SupportTopicL2Id) 
                             | where SupportTopicId != ''
@@ -56,7 +56,7 @@ namespace Diagnostics.RuntimeHost.Services
             var dp = new DataProviders.DataProviders(dataProviderContext);
             DataTable supportTopicMappingTable = new DataTable();
             Guid requestIdGuid = Guid.NewGuid();
-            supportTopicMappingTable = await dp.Kusto.ExecuteClusterQuery(GetSupportTopicKustoQuery(), requestIdGuid.ToString(), operationName: "PopulateSupportTopicCache");
+            supportTopicMappingTable = await dp.Kusto.ExecuteClusterQuery(GetSupportTopicKustoQuery(), "azsupportfollower.westus2", "AzureSupportability", requestIdGuid.ToString(), operationName: "PopulateSupportTopicCache");
             foreach(DataRow row in supportTopicMappingTable.Rows)
             {
                 _supportTopicCache[getSupportTopicCacheKey(row["SupportTopicPath"].ToString())] = new SupportTopicModel(row);


### PR DESCRIPTION
Change AzSupport kusto cluster to follower and use the right overload of ExecuteClusterQuery so we directly connect to the follower instead of using our cluster as a proxy.