### PR TITLE
Retry Kusto Query Throttled Exception 

### DIFF
--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -64,7 +64,7 @@
       "RetryDelayInSeconds": 3,
       "UseBackupClusterForLastAttempt": true,
       "MaxFailureResponseTimeInSecondsForRetry": 15,
-      "ExceptionsToRetryFor": "Kusto.Data.Exceptions.WeakConsistencyEntityNotFoundException | InternalServiceError (520-UnknownError) | Source: Kusto::CachedStorageObject"
+      "ExceptionsToRetryFor": "Kusto.Data.Exceptions.WeakConsistencyEntityNotFoundException | InternalServiceError (520-UnknownError) | Source: Kusto::CachedStorageObject | Kusto.DataNode.Exceptions.QueryThrottledException"
     }
   },
   "SupportObserver": {


### PR DESCRIPTION
In Last 7 days, there has been ~50 API failures due to this exception 'Kusto.DataNode.Exceptions.QueryThrottledException'. The latency of failure is < 200 ms. 
Including this exception in the Retry logic.