### PR TITLE
Reduce cancellation token timeout for Change Analysis

### DIFF
--- a/src/Diagnostics.DataProviders/ChangeAnalysisClient.cs
+++ b/src/Diagnostics.DataProviders/ChangeAnalysisClient.cs
@@ -363,7 +363,7 @@ namespace Diagnostics.DataProviders
                 requestMessage.Content = new StringContent(JsonConvert.SerializeObject(postBody), Encoding.UTF8, "application/json");
             }
 
-            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(DataProviderConstants.DefaultTimeoutInSeconds));
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(DataProviderConstants.ChangeAnalyisRequestTimeoutInSeconds));
             HttpResponseMessage responseMessage = await httpClient.SendAsync(requestMessage, cancellationTokenSource.Token);
             string content = await responseMessage.Content.ReadAsStringAsync();
             if (!responseMessage.IsSuccessStatusCode)

--- a/src/Diagnostics.DataProviders/DataProviderConstants.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConstants.cs
@@ -59,6 +59,12 @@ namespace Diagnostics.DataProviders
             };
 
         #endregion Time Grain Constants
+
+        #region Change Analysis Constants
+
+        public static int ChangeAnalyisRequestTimeoutInSeconds = 30;
+
+        #endregion
     }
 
     public class KustoOperations


### PR DESCRIPTION
Service Health Item : User Story 1656: Reduce default timeout for Change Analysis

#### Background : 
The Change Analysis detector today only gets surfaced as insight in Web App down analysis. 
If customer clicks on that insight or clicks on 'Application Changes' in the left side menu, we open Application change analysis Blade (owned by Azure tools team). So we dont open the detector view in any scenario.

#### Current Issue:
If this detector fails due to change analysis timeouts, there is no customer experience degradation as its only part of Web app down analysis. The analysis continue to work as is even if change analysis timeouts. However, the API failures impact our SLA (even though there is no customer experience degradation)

#### Fix:
Its a two-fold fix. 
A) Catch any exception in the detector. Log the exception in the kusto and consume the exception (This is already done)
B) Reduce the CT Timeout (to 30 sec instead of 60 sec) on calling Change Analysis endpoint, so that it expires before the whole API CT expiry and doesnt cause the 60 sec timeout at runtimehost level. (This change is part of the PR)