### PR TITLE
Remove the httpClientHandler to limit connections per server and inst…

### DIFF
--- a/src/Diagnostics.RuntimeHost/Services/HealthCheckService/HealthCheckService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/HealthCheckService/HealthCheckService.cs
@@ -53,13 +53,13 @@ namespace Diagnostics.RuntimeHost.Services
             this.cache = cache;
         }
 
-        private Task<HttpResponseMessage> Get(HttpRequestMessage request)
+        private async Task<HttpResponseMessage> Get(HttpRequestMessage request)
         {
             //Sleep for a while so that we do not create outbound connections too aggressively causing SNAT port exhaustion.
-            System.Threading.Thread.Sleep(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimeSpan.FromSeconds(1));
             using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
             {
-                return _httpClient.SendAsync(request, cts.Token);
+                return await _httpClient.SendAsync(request, cts.Token);
             }
         }
 

--- a/src/Diagnostics.RuntimeHost/Services/HealthCheckService/HealthCheckService.cs
+++ b/src/Diagnostics.RuntimeHost/Services/HealthCheckService/HealthCheckService.cs
@@ -10,6 +10,7 @@ using Microsoft.IdentityModel.Tokens;
 using System.Linq;
 using Diagnostics.DataProviders.DataProviderConfigurations;
 using Microsoft.Extensions.Caching.Memory;
+using System.Threading;
 
 namespace Diagnostics.RuntimeHost.Services
 {
@@ -54,7 +55,12 @@ namespace Diagnostics.RuntimeHost.Services
 
         private Task<HttpResponseMessage> Get(HttpRequestMessage request)
         {
-            return _httpClient.SendAsync(request);
+            //Sleep for a while so that we do not create outbound connections too aggressively causing SNAT port exhaustion.
+            System.Threading.Thread.Sleep(TimeSpan.FromSeconds(1));
+            using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+            {
+                return _httpClient.SendAsync(request, cts.Token);
+            }
         }
 
         public async Task<bool> HealthCheckPing()
@@ -158,13 +164,8 @@ namespace Diagnostics.RuntimeHost.Services
 
         private void InitializeHttpClient()
         {
-            var handler = new HttpClientHandler
-            {
-                MaxConnectionsPerServer = 10 // Set only max of 10 concurrent connections to google endpoint.
-            };
-            _httpClient = new HttpClient(handler);
+            _httpClient = new HttpClient();
             _httpClient.MaxResponseContentBufferSize = Int32.MaxValue;
-            _httpClient.Timeout = TimeSpan.FromSeconds(3);
         }
     }
 }


### PR DESCRIPTION
Removed the httpClientHandler maxConnectionsPerServer as it may lead to a deadlock and thread starvation. We can introduce it back once we move to .NET Core 3.

Based on my tests, I observed when timeout is enforced via cancellation tokens, it keeps the number of threads lower than when the timeout property is used. Cancellation token will also enforce the timeout but somehow it seems better and managing number of threads.

https://github.com/dotnet/corefx/blob/master/src/System.Net.Http/src/System/Net/Http/HttpClient.cs

![image](https://user-images.githubusercontent.com/20996681/107080550-4e404900-67a6-11eb-83a0-4618f6c219a1.png)


Also added a sleep of 1 second so that we do not create connections too aggressively, as we are timing out the connections after 3 second, a RST will be sent on the channel and SLB will be able to reclaim these connections a lot quicker. Taking a pause "might" just allow us to avoid SNAT. 


Although I wasn't able to repro the deadlock scenario we encountered, these changes should help.
