### PR TITLE
Add retry for Geomaster

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/GeoMasterDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/GeoMasterDataProviderConfiguration.cs
@@ -30,5 +30,11 @@
         /// </summary>
         [ConfigurationName("GeoCertSubjectName")]
         public string GeoCertSubjectName { get; set; }
+
+        [ConfigurationName("Retry:MaxRetryCount")]
+        public int MaxCountRetry { get; set; }
+
+        [ConfigurationName("Retry:RetryDelayInSeconds")]
+        public int RetryDelayInSeconds { get; set; }
     }
 }

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -81,7 +81,11 @@
     "GeoEndpointAddress": "",
     "Token": "",
     "Enabled": true,
-    "GeoCertSubjectName": ""
+    "GeoCertSubjectName": "",
+    "Retry": {
+      "MaxRetryCount": 2,
+      "RetryDelayInSeconds": 3
+    }
   },
   "AppInsights": {
     "EncryptionKey": ""


### PR DESCRIPTION
I am trying to add retry for GeoMaster as for [WI 1657](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1657), for now I add a similar logic as we implemented for Kusto.

But didn't find a pretty generic solution to extend across different data providers yet, since some DPs might have edge cases like for last retry or when to stop retry.   

Maybe folks can raise some ideas about how to extend retry logic for different DPs in a more generic way in this PR