### PR TITLE
Add ExecuteOnAllKustoCluster method

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -101,7 +101,7 @@ namespace Diagnostics.DataProviders
             return await _kustoClient.ExecuteQueryAsync(Helpers.MakeQueryCloudAgnostic(_kustoMap, query), _kustoMap.MapCluster(cluster) ?? cluster, _kustoMap.MapDatabase(_configuration.DBName) ?? _configuration.DBName, requestId, operationName);
         }
 
-        public async Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string requestId = null, string operationName = null)
+        public async Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string operationName)
         {
             if (string.IsNullOrWhiteSpace(operationName))
             {
@@ -111,39 +111,38 @@ namespace Diagnostics.DataProviders
             {
                 throw new ArgumentNullException(nameof(query), "Query cannot be empty. Please supply a query to execute.");
             }
+
+            List<Task<DataTable>> queryTask = new List<Task<DataTable>>();
+
+            if(IsPublicCloud)
+            {
+                queryTask.Add(ExecuteQuery(query, "waws-prod-bay-153", null, operationName));
+                queryTask.Add(ExecuteQuery(query, "waws-prod-blu-189", null, operationName));
+                queryTask.Add(ExecuteQuery(query, "waws-prod-dm1-187", null, operationName));
+                queryTask.Add(ExecuteQuery(query, "waws-prod-am2-329", null, operationName));
+                queryTask.Add(ExecuteQuery(query, "waws-prod-db3-169", null, operationName));
+                queryTask.Add(ExecuteQuery(query, "waws-prod-hk1-029", null, operationName));
+            }
             else
             {
-                List<Task<DataTable>> queryTask = new List<Task<DataTable>>();
-
-                if(IsPublicCloud)
-                {
-                    queryTask.Add(ExecuteQuery(query, "waws-prod-bay-153", null, $"ExecuteQueryOnAllAntaresClusters|{operationName}|WestUS"));
-                    queryTask.Add(ExecuteQuery(query, "waws-prod-blu-189", null, $"ExecuteQueryOnAllAntaresClusters|{operationName}|EastUS"));
-                    queryTask.Add(ExecuteQuery(query, "waws-prod-dm1-187", null, $"ExecuteQueryOnAllAntaresClusters|{operationName}|CentralUS"));
-                    queryTask.Add(ExecuteQuery(query, "waws-prod-am2-329", null, $"ExecuteQueryOnAllAntaresClusters|{operationName}|WestEurope"));
-                    queryTask.Add(ExecuteQuery(query, "waws-prod-db3-169", null, $"ExecuteQueryOnAllAntaresClusters|{operationName}|NorthEurope"));
-                    queryTask.Add(ExecuteQuery(query, "waws-prod-hk1-029", null, $"ExecuteQueryOnAllAntaresClusters|{operationName}|EastAsia"));
-                }
-                else
-                {
-                    queryTask.Add(ExecuteQuery(query, DataProviderConstants.FakeStampForAnalyticsCluster, null, $"ExecuteQueryOnAllAntaresClusters|{operationName}|{_configuration.CloudDomain}"));
-                }
-
-                var queryResult = await Task.WhenAll(queryTask.ToArray());
-                DataTable mergedTable = new DataTable();
-                foreach (DataTable dt in queryResult)
-                {
-                    if (dt.Rows.Count > 0)
-                    {
-                        if(dt.Rows.Count > 3000)
-                        {
-                            throw new Exception($"Query {operationName} returned more than 3000 rows. Please modify the query to fetch fewer rows while running across all app service clusters.");
-                        }
-                        mergedTable.Merge(dt, false, MissingSchemaAction.Add);
-                    }
-                }
-                return mergedTable;
+                queryTask.Add(ExecuteQuery(query, DataProviderConstants.FakeStampForAnalyticsCluster, null, operationName));
             }
+
+            var queryResult = await Task.WhenAll(queryTask.ToArray());
+            DataTable mergedTable = new DataTable();
+            foreach (DataTable dt in queryResult)
+            {
+                if (dt.Rows.Count > 0)
+                {
+                    if(dt.Rows.Count > 3000)
+                    {
+                        throw new Exception($"Query {operationName} returned more than 3000 rows. Please modify the query to fetch fewer rows while running across all app service clusters.");
+                    }
+                    mergedTable.Merge(dt, false, MissingSchemaAction.Add);
+                }
+            }
+            return mergedTable;
+
         }
 
         public Task<KustoQuery> GetKustoClusterQuery(string query)

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -55,7 +55,7 @@ namespace Diagnostics.DataProviders
             };
         }
 
-        private bool isPublicCloud
+        private bool IsPublicCloud
         {
             get {
                 var publicClouds = new string[] { DataProviderConstants.AzureCloud, DataProviderConstants.AzureCloudAlternativeName };
@@ -101,7 +101,7 @@ namespace Diagnostics.DataProviders
             return await _kustoClient.ExecuteQueryAsync(Helpers.MakeQueryCloudAgnostic(_kustoMap, query), _kustoMap.MapCluster(cluster) ?? cluster, _kustoMap.MapDatabase(_configuration.DBName) ?? _configuration.DBName, requestId, operationName);
         }
 
-        public async Task<DataTable> ExecuteQueryOnAllAntaresClusters(string query, string requestId = null, string operationName = null)
+        public async Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string requestId = null, string operationName = null)
         {
             if (string.IsNullOrWhiteSpace(operationName))
             {
@@ -115,7 +115,7 @@ namespace Diagnostics.DataProviders
             {
                 List<Task<DataTable>> queryTask = new List<Task<DataTable>>();
 
-                if(isPublicCloud)
+                if(IsPublicCloud)
                 {
                     queryTask.Add(ExecuteQuery(query, "waws-prod-bay-153", null, $"ExecuteQueryOnAllAntaresClusters|{operationName}|WestUS"));
                     queryTask.Add(ExecuteQuery(query, "waws-prod-blu-189", null, $"ExecuteQueryOnAllAntaresClusters|{operationName}|EastUS"));
@@ -135,10 +135,14 @@ namespace Diagnostics.DataProviders
                 {
                     if (dt.Rows.Count > 0)
                     {
+                        if(dt.Rows.Count > 3000)
+                        {
+                            throw new Exception($"Query {operationName} returned more than 3000 rows. Please modify the query to fetch fewer rows while running across all app service clusters.");
+                        }
                         mergedTable.Merge(dt, false, MissingSchemaAction.Add);
                     }
                 }
-                return mergedTable;                
+                return mergedTable;
             }
         }
 

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -11,7 +11,7 @@ namespace Diagnostics.DataProviders
 
         Task<DataTable> ExecuteQuery(string query, string stampName, string requestId = null, string operationName = null);
 
-        Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string requestId = null, string operationName = null);
+        Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string operationName);
 
         Task<KustoQuery> GetKustoQuery(string query, string stampName);
 

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -11,7 +11,7 @@ namespace Diagnostics.DataProviders
 
         Task<DataTable> ExecuteQuery(string query, string stampName, string requestId = null, string operationName = null);
 
-        Task<DataTable> ExecuteQueryOnAllAntaresClusters(string query, string requestId = null, string operationName = null);
+        Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string requestId = null, string operationName = null);
 
         Task<KustoQuery> GetKustoQuery(string query, string stampName);
 

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -11,6 +11,8 @@ namespace Diagnostics.DataProviders
 
         Task<DataTable> ExecuteQuery(string query, string stampName, string requestId = null, string operationName = null);
 
+        Task<DataTable> ExecuteQueryOnAllAntaresClusters(string query, string requestId = null, string operationName = null);
+
         Task<KustoQuery> GetKustoQuery(string query, string stampName);
 
         Task<KustoQuery> GetKustoClusterQuery(string query);

--- a/src/Diagnostics.DataProviders/KustoLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/KustoLogDecorator.cs
@@ -17,14 +17,19 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(DataProvider.ExecuteQuery(query, stampName, _requestId, operationName));
         }
 
+        public Task<DataTable> ExecuteQueryOnAllAntaresClusters(string query, string requestId = null, string operationName = null)
+        {
+            return MakeDependencyCall(DataProvider.ExecuteQueryOnAllAntaresClusters(query, _requestId, operationName));
+        }
+
         public Task<DataTable> ExecuteClusterQuery(string query, string requestId = null, string operationName = null)
         {
-            return MakeDependencyCall(DataProvider.ExecuteClusterQuery(query, requestId, operationName));
+            return MakeDependencyCall(DataProvider.ExecuteClusterQuery(query, _requestId, operationName));
         }
 
         public Task<DataTable> ExecuteClusterQuery(string query, string cluster, string databaseName, string requestId, string operationName)
         {
-            return MakeDependencyCall(DataProvider.ExecuteClusterQuery(query, cluster, databaseName, requestId, operationName));
+            return MakeDependencyCall(DataProvider.ExecuteClusterQuery(query, cluster, databaseName, _requestId, operationName));
         }
 
         public Task<KustoQuery> GetKustoQuery(string query, string stampName)

--- a/src/Diagnostics.DataProviders/KustoLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/KustoLogDecorator.cs
@@ -17,9 +17,9 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(DataProvider.ExecuteQuery(query, stampName, _requestId, operationName));
         }
 
-        public Task<DataTable> ExecuteQueryOnAllAntaresClusters(string query, string requestId = null, string operationName = null)
+        public Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string requestId = null, string operationName = null)
         {
-            return MakeDependencyCall(DataProvider.ExecuteQueryOnAllAntaresClusters(query, _requestId, operationName));
+            return MakeDependencyCall(DataProvider.ExecuteQueryOnAllAppAppServiceClusters(query, _requestId, operationName));
         }
 
         public Task<DataTable> ExecuteClusterQuery(string query, string requestId = null, string operationName = null)

--- a/src/Diagnostics.DataProviders/KustoLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/KustoLogDecorator.cs
@@ -17,9 +17,9 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(DataProvider.ExecuteQuery(query, stampName, _requestId, operationName));
         }
 
-        public Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string requestId = null, string operationName = null)
+        public Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string operationName)
         {
-            return MakeDependencyCall(DataProvider.ExecuteQueryOnAllAppAppServiceClusters(query, _requestId, operationName));
+            return MakeDependencyCall(DataProvider.ExecuteQueryOnAllAppAppServiceClusters(query, operationName));
         }
 
         public Task<DataTable> ExecuteClusterQuery(string query, string requestId = null, string operationName = null)

--- a/src/Diagnostics.Scripts/EntityInvoker.cs
+++ b/src/Diagnostics.Scripts/EntityInvoker.cs
@@ -380,7 +380,7 @@ namespace Diagnostics.Scripts
                            {
                                 "ERROR : Use of All('TableName') kusto function is not supported.",
                                 "Valid Options:",
-                                "- Use dp.Kusto.ExecuteQueryOnAllAppAppServiceClusters(string query, string requestId = null, string operationName = null) instead."
+                                "- Use dp.Kusto.ExecuteQueryOnAllAppAppServiceClusters(string query, string operationName) instead."
                            });
                     throw new ScriptCompilationException("Use of All('TableName') in kusto query is not allowed. Use dp.Kusto.ExecuteQueryOnAllAppAppServiceClusters instead.");
                 }

--- a/src/Diagnostics.Scripts/EntityInvoker.cs
+++ b/src/Diagnostics.Scripts/EntityInvoker.cs
@@ -369,6 +369,21 @@ namespace Diagnostics.Scripts
                 {
                     throw new ScriptCompilationException("Detector is marked with both SystemFilter and ResourceFilter. System Invoker should not include any ResourceFilter attribute.");
                 }
+
+                if(this._entityMetaData.ScriptText.Contains("All('") && 
+                    (this._resourceFilter.ResourceType == ResourceType.App 
+                    || this._resourceFilter.ResourceType == ResourceType.HostingEnvironment 
+                    || this._resourceFilter.ResourceType == ResourceType.AppServiceCertificate
+                    || this._resourceFilter.ResourceType == ResourceType.AppServiceDomain))
+                {
+                    this.CompilationOutput = this.CompilationOutput.Concat(new string[]
+                           {
+                                "ERROR : Use of All('TableName') kusto function is not supported.",
+                                "Valid Options:",
+                                "- Use dp.Kusto.ExecuteQueryOnAllAntaresClusters(string query, string requestId = null, string operationName = null) instead."
+                           });
+                    throw new ScriptCompilationException(string.Empty);
+                }
             }
         }
 

--- a/src/Diagnostics.Scripts/EntityInvoker.cs
+++ b/src/Diagnostics.Scripts/EntityInvoker.cs
@@ -370,7 +370,7 @@ namespace Diagnostics.Scripts
                     throw new ScriptCompilationException("Detector is marked with both SystemFilter and ResourceFilter. System Invoker should not include any ResourceFilter attribute.");
                 }
 
-                if(this._entityMetaData.ScriptText.Contains("All('") && 
+                if((this._entityMetaData.ScriptText.Contains("All('") || this._entityMetaData.ScriptText.Contains("All(\"")) && 
                     (this._resourceFilter.ResourceType == ResourceType.App 
                     || this._resourceFilter.ResourceType == ResourceType.HostingEnvironment 
                     || this._resourceFilter.ResourceType == ResourceType.AppServiceCertificate
@@ -380,9 +380,9 @@ namespace Diagnostics.Scripts
                            {
                                 "ERROR : Use of All('TableName') kusto function is not supported.",
                                 "Valid Options:",
-                                "- Use dp.Kusto.ExecuteQueryOnAllAntaresClusters(string query, string requestId = null, string operationName = null) instead."
+                                "- Use dp.Kusto.ExecuteQueryOnAllAppAppServiceClusters(string query, string requestId = null, string operationName = null) instead."
                            });
-                    throw new ScriptCompilationException(string.Empty);
+                    throw new ScriptCompilationException("Use of All('TableName') in kusto query is not allowed. Use dp.Kusto.ExecuteQueryOnAllAppAppServiceClusters instead.");
                 }
             }
         }


### PR DESCRIPTION
Provide a way to execute a query across all of our kusto clusters as All has a heavy toll
throw a compiler error if we detect the use of All in any of the Antares detectors.