### PR TITLE
API for data table filter

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
@@ -52,8 +52,7 @@ namespace Diagnostics.ModelsAndUtils.Models
         public dynamic TableOptions { get; set; }
 
         public bool AllowColumnSearch { get; set; }
-
-        public IEnumerable<TableFilter> TableFilters { get; set; }
+        public IEnumerable<TableColumnOption> ColumnOptions { get; set; }
 
         public TableRendering() : base(RenderingType.Table)
         {
@@ -61,7 +60,7 @@ namespace Diagnostics.ModelsAndUtils.Models
             GroupByColumnName = null;
             DescriptionColumnName = null;
             AllowColumnSearch = false;
-            TableFilters = null;
+            ColumnOptions = null;
         }
     }
 
@@ -288,7 +287,8 @@ namespace Diagnostics.ModelsAndUtils.Models
 
     public enum FileterSelectionOption
     {
-        Single = 0,
+        None = 0,
+        Single,
         Multiple
     }
 
@@ -302,5 +302,18 @@ namespace Diagnostics.ModelsAndUtils.Models
             SelectionOption = selectionOption;
             ColumnName = colunmName;
         }
-    } 
+    }
+    
+    public class TableColumnOption
+    {
+        public string Name { get; set; }
+
+        public int MinWidth { get; set; }
+
+        public int MaxWidth { get; set; }
+
+        public FileterSelectionOption SelectionOption { get; set; } = FileterSelectionOption.None;
+
+        public bool Visible { get; set; } = true;
+    }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
@@ -287,33 +287,44 @@ namespace Diagnostics.ModelsAndUtils.Models
 
     public enum FileterSelectionOption
     {
+        /// <summary>
+        /// No Selection Filter
+        /// </summary>
         None = 0,
+        /// <summary>
+        /// Single selection with radio button
+        /// </summary>
         Single,
+        /// <summary>
+        /// Multiple selection with checkbox
+        /// </summary>
         Multiple
-    }
-
-    public class TableFilter
-    {
-        public FileterSelectionOption SelectionOption { get; set; }
-        public string ColumnName { get; set; }
-
-        public TableFilter(string colunmName, FileterSelectionOption selectionOption)
-        {
-            SelectionOption = selectionOption;
-            ColumnName = colunmName;
-        }
-    }
-    
+    }    
     public class TableColumnOption
     {
+        /// <summary>
+        /// Column name
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Column Min Width
+        /// </summary>
         public int MinWidth { get; set; }
 
+        /// <summary>
+        /// Column Max Width
+        /// </summary>
         public int MaxWidth { get; set; }
 
+        /// <summary>
+        /// Filter Selelction(Single, Multiple)
+        /// </summary>
         public FileterSelectionOption SelectionOption { get; set; } = FileterSelectionOption.None;
 
+        /// <summary>
+        /// Hide or show column
+        /// </summary>
         public bool Visible { get; set; } = true;
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
@@ -53,12 +53,15 @@ namespace Diagnostics.ModelsAndUtils.Models
 
         public bool AllowColumnSearch { get; set; }
 
+        public IEnumerable<TableFilter> TableFilters { get; set; }
+
         public TableRendering() : base(RenderingType.Table)
         {
             DisplayColumnNames = null;
             GroupByColumnName = null;
             DescriptionColumnName = null;
             AllowColumnSearch = false;
+            TableFilters = null;
         }
     }
 
@@ -282,4 +285,22 @@ namespace Diagnostics.ModelsAndUtils.Models
         StackedAreaGraph,
         StackedBarGraph
     }
+
+    public enum FileterSelectionOption
+    {
+        Single = 0,
+        Multiple
+    }
+
+    public class TableFilter
+    {
+        public FileterSelectionOption SelectionOption { get; set; }
+        public string ColumnName { get; set; }
+
+        public TableFilter(string colunmName, FileterSelectionOption selectionOption)
+        {
+            SelectionOption = selectionOption;
+            ColumnName = colunmName;
+        }
+    } 
 }


### PR DESCRIPTION
Add API for extending data table column configuration to customize width and add filters and detector code as shown below 

Along with UI PR, [Add Table Filters #1055](https://github.com/Azure/Azure-AppServices-Diagnostics-Portal/pull/1055)

```
var columnOptions = new List<TableColumnOption>();

//Config "Computer" column to be invisible with single selection filter
columnOptions.Add(new TableColumnOption(){
                Name = "Computer",
                SelectionOption = FileterSelectionOption.Single,
                Visible = false
 });

//Config "Source" column to be multiple choice with customized width
columnOptions.Add(new TableColumnOption(){
                Name = "Source",
                SelectionOption = FileterSelectionOption.Multiple,
                MinWidth= 300,
                MaxWidth= 500
});

//Add table into response
res.Dataset.Add(new DiagnosticData(){
    Table = table,
    RenderingProperties = new TableRendering{
        ColumnOptions = columnOptions 
    }
};
```