### PR TITLE
Increase Response time for Kusto Retry

### DIFF
--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -63,7 +63,7 @@
       "MaxRetryCount": 2,
       "RetryDelayInSeconds": 3,
       "UseBackupClusterForLastAttempt": true,
-      "MaxFailureResponseTimeInSecondsForRetry": 15,
+      "MaxFailureResponseTimeInSecondsForRetry": 22,
       "ExceptionsToRetryFor": "Kusto.Data.Exceptions.WeakConsistencyEntityNotFoundException | InternalServiceError (520-UnknownError) | Source: Kusto::CachedStorageObject | Kusto.DataNode.Exceptions.QueryThrottledException"
     }
   },


### PR DESCRIPTION
From service health meeting today, we noticed EUSFOLLOWER getting upgraded and lot of queries failing with Internal Service Error with 21 sec latency.
Increasing the timeout for kusto retries in order to retry these queries against leader