### PR TITLE
Add visible flag

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
@@ -10,15 +10,18 @@ namespace Diagnostics.ModelsAndUtils.Models
         public string Title { get; set; }
 
         public string Description { get; set; }
+        public bool IsVisible { get; set; }
 
         public Rendering()
         {
             Type = RenderingType.TimeSeries;
+            IsVisible = true;
         }
 
         public Rendering(RenderingType type)
         {
             Type = type;
+            IsVisible = true;
         }
     }
 

--- a/src/Diagnostics.ModelsAndUtils/Models/Response.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Response.cs
@@ -80,6 +80,18 @@ namespace Diagnostics.ModelsAndUtils.Models
             Table = new DataTable();
             RenderingProperties = new Rendering();
         }
+
+        public bool IsVisible
+        {
+            get { return RenderingProperties.IsVisible; }
+            set { RenderingProperties.IsVisible = value; }
+        }
+
+        public DiagnosticData Invisible()
+        {
+            IsVisible = false;
+            return this;
+        }
     }
 
     public class DiagnosticApiResponse


### PR DESCRIPTION
This PR adds a new property named IsVisible to the Rendering class. This allows detectors to return responses which are not displayed by graphic objects but still consumable by CLI, including VS Code extension.