### PR TITLE
fix bug1685

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/SupportObserverDataProviderConfiguration.cs
@@ -64,6 +64,7 @@ namespace Diagnostics.DataProviders
         }
 
         [ConfigurationName("UnsupportedApis")]
+        [Required]
         public string UnsupportedApis { get; set; }
     }
 }


### PR DESCRIPTION
Fix bug [1685](https://dev.azure.com/app-service-diagnostics-portal/app-service-diagnostics-portal/_workitems/edit/1685) by adding a `[Required]` attribute to `UnsupportedApis` of in `SupportObserverDataProviderConfiguration.cs `