### PR TITLE
Show storage account name with masked key from AzureWebJobsStorage setting

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/GeoMasterDataProvider.cs
@@ -101,6 +101,20 @@ namespace Diagnostics.DataProviders
                     string value = CredentialTrapper.Obfuscate(item.Value);
                     appSettings.Add(item.Key, value);
                 }
+                else if(string.Compare(item.Key, "AzureWebJobsStorage", StringComparison.CurrentCulture) == 0)
+                {
+                    var storageAccountMatch = Regex.Match(item.Value.ToString(), @".*AccountName=(?<StorageAccount>.+?);.*");
+                    if (storageAccountMatch.Success)
+                    {
+                        string value = storageAccountMatch.Groups["StorageAccount"].Value;
+                        value = string.Concat("****AccountName=", value, "*****");
+                        appSettings.Add(item.Key, value);
+                    }
+                    else
+                    {
+                        appSettings.Add(item.Key, "******");
+                    }
+                }
                 else
                 {
                     appSettings.Add(item.Key, "******");


### PR DESCRIPTION
This PR is to retrieve storage account name from AzureWebJobsStorage settings and return the masked value. This is what AzureWebJobsStorage value looks like:

DefaultEndpointsProtocol=https;AccountName=[name];AccountKey=[key]

