### PR TITLE
Fix logging exception while using cxt.Logger

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Diagnostics.ModelsAndUtils.csproj
+++ b/src/Diagnostics.ModelsAndUtils/Diagnostics.ModelsAndUtils.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="CommonMark.NET" Version="0.15.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.15" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />


### PR DESCRIPTION
One of our partners reported the following exception while using cxt.Logger -

System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Extensions.Logging.Abstractions, Version=3.1.15.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified. File name: 'Microsoft.Extensions.Logging.Abstractions, Version=3.1.15.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' 

Updating the library version to fix this