### PR TITLE
Fix DateTimeHelper logic for endTimeUtc > currentUtcTime

### DIFF
--- a/src/Diagnostics.RuntimeHost/Utilities/DateTimeHelper.cs
+++ b/src/Diagnostics.RuntimeHost/Utilities/DateTimeHelper.cs
@@ -143,19 +143,20 @@ namespace Diagnostics.RuntimeHost.Utilities
 
             if (endTimeUtc > currentUtcTime.AddMinutes(kustoDelayInMinutes))
             {
-                /* Creteria for adjusting the time here:
+                /* Criteria for adjusting the time here:
                  *  1. forceAdjustStartAndEndTimes Flag set to True, or
-                 *  2. If Endtime is more than "currentTime - kustoDelay" and is very close the current time.
+                 *  2. If Endtime is more than "currentTime - kustoDelay" and is very close the current time, but less than or equal to the currentTime.
                  *          - We got a sev2 incident for this issue where we returned a bunch of BAD Requests to the clients.
                  *          - This can happen if client machine time is little bit off from the server machine time.
                  *          - We will only adjust if that offset is no more than 15 mins. If Client machine time is way off than server time, we will throw BAD REQUEST
                 */
-                if (forceAdjustStartAndEndTimes || (currentUtcTime - endTimeUtc).TotalMinutes < 15)
+                if (forceAdjustStartAndEndTimes || (endTimeUtc <= currentUtcTime && (currentUtcTime - endTimeUtc).TotalMinutes < 15))
                 {
-                    if(endTimeUtc - startTimeUtc < TimeSpan.FromHours(24))
+                    var duration = endTimeUtc - startTimeUtc;
+                    if (duration < TimeSpan.FromHours(24))
                     {
                         endTimeUtc = currentUtcTime.AddMinutes(kustoDelayInMinutes);
-                        startTimeUtc = endTimeUtc.AddHours((endTimeUtc - startTimeUtc).TotalHours * -1);
+                        startTimeUtc = endTimeUtc - duration;
                     }
                     else
                     {


### PR DESCRIPTION
This PR fixes PrepareStartEndTimeUtc() in DateTimeHelper. It unexpectedly handles if endTimeUtc > currentUtcTime.