### PR TITLE
Enable for different metric types

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
@@ -294,7 +294,12 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// <summary>
         /// Data Rendered as section
         /// </summary>
-        Section
+        Section,
+
+        /// <summary>
+        /// StepViews component of Network Troubleshooter
+        /// </summary>
+        StepViews
     }
 
     /// <summary>

--- a/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
@@ -370,6 +370,10 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// </summary>
         Avg,
         /// <summary>
+        /// Min value for chart
+        /// </summary>
+        Min,
+        /// <summary>
         /// Max value for chart
         /// </summary>
         Max,

--- a/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Rendering.cs
@@ -81,13 +81,13 @@ namespace Diagnostics.ModelsAndUtils.Models
 
         public IEnumerable<string> SeriesColumns { get; set; }
 
-        public bool ShowMetrics { get; set; }
+        public MetricType MetricType { get; set; }
 
         public TimeSeriesRendering()
         {
             DefaultValue = 0;
             GraphType = TimeSeriesType.LineGraph;
-            ShowMetrics = false;
+            MetricType = MetricType.Avg;
         }
     }
 
@@ -113,13 +113,13 @@ namespace Diagnostics.ModelsAndUtils.Models
 
         public string SelectedInstance { get; set; }
 
-        public bool ShowMetrics { get; set; }
+        public MetricType MetricType { get; set; }
 
         public TimeSeriesPerInstanceRendering() : base(RenderingType.TimeSeriesPerInstance)
         {
             DefaultValue = 0;
             GraphType = TimeSeriesType.LineGraph;
-            ShowMetrics = false;
+            MetricType = MetricType.Avg;
         }
     }
 
@@ -354,5 +354,28 @@ namespace Diagnostics.ModelsAndUtils.Models
         /// Hide or show column
         /// </summary>
         public bool Visible { get; set; } = true;
+    }
+
+    /// <summary>
+    /// Default metric value show below graph
+    /// </summary>
+    public enum MetricType
+    {
+        /// <summary>
+        /// Not show metric
+        /// </summary>
+        None,
+        /// <summary>
+        /// Average value for chart
+        /// </summary>
+        Avg,
+        /// <summary>
+        /// Max value for chart
+        /// </summary>
+        Max,
+        /// <summary>
+        /// Sum value for chart
+        /// </summary>
+        Sum
     }
 }


### PR DESCRIPTION
 When is not hovering the graph, it will display `--` in metric now, ideally it will show number(by calculating Average/Sum/Max) for each line in graph 
This PR is to allow detector author to specify different ways they want to calculate for metric 
![image](https://user-images.githubusercontent.com/23129934/121275898-78079a80-c882-11eb-8b34-92d5e20aa1ac.png)
