### PR TITLE
Enable query shadowing for kusto provider

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
@@ -186,6 +186,20 @@ namespace Diagnostics.DataProviders
         [ConfigurationName("Retry:ExceptionsToRetryFor")]
         public string ExceptionsToRetryFor { get; set; }
 
+        /// <summary>
+        /// List of , separated clusters which requests will be shadowed from
+        /// </summary>
+        [ConfigurationName("QueryShadowingClusterMaping:ClusterNameGroupings")]
+        public string QueryShadowingClusterNameGroupings { get; set; }
+
+        /// <summary>
+        /// List of , separated cluster lists seprated by : which requests will be shadowed to
+        /// </summary>
+        [ConfigurationName("QueryShadowingClusterMaping:TestingClusterNamesGroupings")]
+        public string QueryShadowingTestClustersGroupings { get; set; }
+
+        public ConcurrentDictionary<string, string[]> QueryShadowingClusterMapping;
+
         public List<ITuple> OverridableExceptionsToRetryAgainstLeaderCluster { get; set; }
 
         public IConfiguration config { private get; set; }
@@ -244,6 +258,18 @@ namespace Diagnostics.DataProviders
                     {
                         OverridableExceptionsToRetryAgainstLeaderCluster.Add((ExceptionString, MaxFailureResponseTimeInSeconds));
                     }
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(QueryShadowingClusterNameGroupings) && !string.IsNullOrWhiteSpace(QueryShadowingTestClustersGroupings))
+            {
+                var clusterNamesSplited = QueryShadowingClusterNameGroupings.Split(',');
+                var testClusterGroupSplit = QueryShadowingTestClustersGroupings.Split(',');
+                if (clusterNamesSplited.Length == testClusterGroupSplit.Length)
+                {
+                    QueryShadowingClusterMapping = new ConcurrentDictionary<string, string[]>(
+                        Enumerable.Zip(clusterNamesSplited, testClusterGroupSplit)
+                            .Select(p => KeyValuePair.Create(p.First, p.Second.Split(':'))));
                 }
             }
         }

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
@@ -188,12 +188,14 @@ namespace Diagnostics.DataProviders
 
         /// <summary>
         /// List of , separated clusters which requests will be shadowed from
+        /// e.g. "wawswusfollower,wawseusfollower"
         /// </summary>
         [ConfigurationName("QueryShadowingClusterMaping:ClusterNameGroupings")]
         public string QueryShadowingClusterNameGroupings { get; set; }
 
         /// <summary>
         /// List of , separated cluster lists seprated by : which requests will be shadowed to
+        /// e.g. "wustestcluster1:wustestcluster2,eustestcluster1"
         /// </summary>
         [ConfigurationName("QueryShadowingClusterMaping:TestingClusterNamesGroupings")]
         public string QueryShadowingTestClustersGroupings { get; set; }

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
@@ -188,7 +188,7 @@ namespace Diagnostics.DataProviders
 
         /// <summary>
         /// List of , separated sourceCluster|testCluster1:testCluster2:... and requests will be shadowed from sourceCluster to all the following testClusters
-        /// e.g. "wawswusfollower|wawswus:wawswus,wawseusfollower|wawseus"
+        /// e.g. "wawswusfollower|testwuscluster1:testwuscluster2,wawseusfollower|testeuscluster1"
         /// </summary>
         [ConfigurationName("QueryShadowingClusterMapping")]
         public string QueryShadowingClusterMappingString { get; set; }

--- a/src/Diagnostics.DataProviders/DataProviders.cs
+++ b/src/Diagnostics.DataProviders/DataProviders.cs
@@ -29,7 +29,9 @@ namespace Diagnostics.DataProviders
             Kusto = GetOrAddDataProvider(new KustoLogDecorator(context, new KustoDataProvider(_cache,
                      context.Configuration.KustoConfiguration,
                      context.RequestId,
-                     context.KustoHeartBeatService)));
+                     context.KustoHeartBeatService,
+                     context.QueryStartTime, 
+                     context.QueryEndTime)));
 
             Observer = GetOrAddDataProvider(new ObserverLogDecorator(context, SupportObserverDataProviderFactory.GetDataProvider(_cache, context.Configuration, context)));
 

--- a/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/Base/SupportObserverDataProviderBase.cs
@@ -36,6 +36,7 @@ namespace Diagnostics.DataProviders
             // --------------------------------------------------------------------------
             var client = new HttpClient(handler);
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            client.DefaultRequestHeaders.Add(HeaderConstants.UserAgentHeaderName, "appservice-diagnostics");
             return client;
         });
 

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -27,8 +27,8 @@ namespace Diagnostics.DataProviders
         private string _requestId;
         private IKustoHeartBeatService _kustoHeartBeatService;
         private IKustoMap _kustoMap;
-        private DateTime _queryStartTime;
-        private DateTime _queryEndTime;
+        private DateTime? _queryStartTime;
+        private DateTime? _queryEndTime;
 
         public KustoDataProvider(OperationDataCache cache, KustoDataProviderConfiguration configuration, string requestId, IKustoHeartBeatService kustoHeartBeat, DateTime? startTime = null, DateTime? endTime = null) : base(cache, configuration)
         {
@@ -38,6 +38,8 @@ namespace Diagnostics.DataProviders
             _requestId = requestId;
             _kustoHeartBeatService = kustoHeartBeat;
             _kustoMap = new NullableKustoMap();
+            _queryStartTime = startTime;
+            _queryEndTime = endTime;
 
             if (publicClouds.Any(s => configuration.CloudDomain.Equals(s, StringComparison.CurrentCultureIgnoreCase)))
             {

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoClient.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoClient.cs
@@ -1,13 +1,14 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 using System.Threading.Tasks;
 
 namespace Diagnostics.DataProviders
 {
     public interface IKustoClient
     {
-        Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, int timeoutSeconds, string requestId = null, string operationName = null);
+        Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, int timeoutSeconds, string requestId = null, string operationName = null, DateTime? startTime = null, DateTime? endTime = null);
 
-        Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, string requestId = null, string operationName = null);
+        Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, string requestId = null, string operationName = null, DateTime? startTime = null, DateTime? endTime = null);
 
         Task<KustoQuery> GetKustoQueryAsync(string query, string cluster, string database);
 

--- a/src/Diagnostics.DataProviders/KustoSDKClient.cs
+++ b/src/Diagnostics.DataProviders/KustoSDKClient.cs
@@ -100,8 +100,15 @@ namespace Diagnostics.DataProviders
                 {
                     foreach (string shadowCluster in shadowClusters)
                     {
-                        var shadowKustoClient = Client(shadowCluster, database);
-                        shadowKustoClient.ExecuteQueryAsync(database, query, clientRequestProperties);
+                        try
+                        {
+                            var shadowKustoClient = Client(shadowCluster, database);
+                            shadowKustoClient.ExecuteQueryAsync(database, query, clientRequestProperties);
+                        }
+                        catch (Exception)
+                        {
+                            // swallow this exception
+                        }
                     }
                 }
                 var result = await kustoTask;

--- a/src/Diagnostics.DataProviders/KustoSDKClient.cs
+++ b/src/Diagnostics.DataProviders/KustoSDKClient.cs
@@ -79,12 +79,12 @@ namespace Diagnostics.DataProviders
             return QueryProviderMapping[key];
         }
 
-        public async Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, int timeoutSeconds, string requestId = null, string operationName = null)
+        public async Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, int timeoutSeconds, string requestId = null, string operationName = null, DateTime? startTime = null, DateTime? endTime = null)
         {
             var timeTakenStopWatch = new Stopwatch();
             DataSet dataSet = null;
             ClientRequestProperties clientRequestProperties = new ClientRequestProperties();
-            var kustoClientId = $"Diagnostics.{operationName ?? "Query"};{_requestId}##{0}_{Guid.NewGuid().ToString()}";
+            var kustoClientId = $"Diagnostics.{operationName ?? "Query"};{_requestId};{startTime?.ToString() ?? "UnknownStartTime"};{endTime?.ToString() ?? "UnknownEndTime"}##{0}_{Guid.NewGuid().ToString()}";
             clientRequestProperties.ClientRequestId = kustoClientId;
             clientRequestProperties.SetOption("servertimeout", new TimeSpan(0,0,timeoutSeconds));
             if(cluster.StartsWith("waws",StringComparison.OrdinalIgnoreCase))
@@ -95,7 +95,16 @@ namespace Diagnostics.DataProviders
             {
                 timeTakenStopWatch.Start();
                 var kustoClient = Client(cluster, database);
-                var result = await kustoClient.ExecuteQueryAsync(database, query, clientRequestProperties);
+                var kustoTask = kustoClient.ExecuteQueryAsync(database, query, clientRequestProperties);
+                if (_config.QueryShadowingClusterMapping != null && _config.QueryShadowingClusterMapping.TryGetValue(cluster, out var shadowClusters))
+                {
+                    foreach (string shadowCluster in shadowClusters)
+                    {
+                        var shadowKustoClient = Client(shadowCluster, database);
+                        shadowKustoClient.ExecuteQueryAsync(database, query, clientRequestProperties);
+                    }
+                }
+                var result = await kustoTask;
                 dataSet = result.ToDataSet();
             }
             catch (Exception ex)
@@ -127,7 +136,7 @@ namespace Diagnostics.DataProviders
             return datatable;
         }
 
-        public async Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, string requestId = null, string operationName = null)
+        public async Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, string requestId = null, string operationName = null, DateTime? startTime = null, DateTime? endTime = null)
         {
             int attempt = 0;
             string source = string.IsNullOrWhiteSpace(operationName) ? "KustoSDKClient_ExecuteQueryAsync" : operationName;
@@ -160,7 +169,7 @@ namespace Diagnostics.DataProviders
 
                     invocationStartTime = DateTime.UtcNow;
                     attemptException = null;
-                    executeQueryTask = ExecuteQueryAsync(query, cluster, database, DataProviderConstants.DefaultTimeoutInSeconds, requestId, operationName);
+                    executeQueryTask = ExecuteQueryAsync(query, cluster, database, DataProviderConstants.DefaultTimeoutInSeconds, requestId, operationName, startTime, endTime);
                     dtResult = await executeQueryTask;
                 }
                 catch (Exception ex)

--- a/src/Diagnostics.DataProviders/MockKustoClient.cs
+++ b/src/Diagnostics.DataProviders/MockKustoClient.cs
@@ -12,12 +12,12 @@ namespace Diagnostics.DataProviders
         internal static bool ShouldFailoverHeartbeatSucceed = false;
         internal static int HeartBeatRuns = 0;
 
-        public async Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, int timeoutSeconds, string requestId = null, string operationName = null)
+        public async Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, int timeoutSeconds, string requestId = null, string operationName = null, DateTime? startTime = null, DateTime? endTime = null)
         {
             return await ExecuteQueryAsync(query, cluster, database, requestId, operationName);
         }
 
-            public async Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, string requestId = null, string operationName = null)
+            public async Task<DataTable> ExecuteQueryAsync(string query, string cluster, string database, string requestId = null, string operationName = null, DateTime? startTime = null, DateTime? endTime = null)
         {
             if (string.IsNullOrWhiteSpace(cluster))
             {

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -71,6 +71,10 @@
           "MaxFailureResponseTimeInSeconds": 30
         }
       ]
+    },
+    "QueryShadowingClusterMaping": {
+      "ClusterNameGroupings": "",
+      "TestingClusterNamesGroupings": ""
     }
   },
   "SupportObserver": {

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -72,10 +72,7 @@
         }
       ]
     },
-    "QueryShadowingClusterMaping": {
-      "ClusterNameGroupings": "",
-      "TestingClusterNamesGroupings": ""
-    }
+    "QueryShadowingClusterMapping": ""
   },
   "SupportObserver": {
     "ClientId": "",


### PR DESCRIPTION
Enable query shadowing for kusto provider to help testing the new clusters under the same or nearly same traffic as our current follower cluster has so that we can compare the performance in a more scientific way

Minor changes include
- add start and end time in kusto query client Id
- add user agent header in observer data provider http client