### PR TITLE
Accept Forms and return as query params in Insights API detector links

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/ApiManagement/ApiManagementController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ApiManagement/ApiManagementController.cs
@@ -40,7 +40,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.DiagnosticReport)]
-        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string serviceName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string serviceName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null, [FromQuery][ModelBinder(typeof(FormModelBinder))] Form form = null)
         {
             var validateBody = InsightsAPIHelpers.ValidateQueryBody(queryBody);
             if (!validateBody.Status)
@@ -51,7 +51,7 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 return BadRequest(errorMessage);
             }
-            return await base.GetDiagnosticReport(GetResource(subscriptionId, resourceGroupName, serviceName), queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan);
+            return await base.GetDiagnosticReport(GetResource(subscriptionId, resourceGroupName, serviceName), queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan, form:form);
         }
 
         [HttpPost(UriElements.Detectors + UriElements.DetectorResource + UriElements.StatisticsQuery)]

--- a/src/Diagnostics.RuntimeHost/Controllers/ArmResource/ArmResourceController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ArmResource/ArmResourceController.cs
@@ -50,7 +50,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.DiagnosticReport)]
-        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string provider, string resourceTypeName, string resourceName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string provider, string resourceTypeName, string resourceName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null, [FromQuery][ModelBinder(typeof(FormModelBinder))] Form form = null)
         {
             var validateBody = InsightsAPIHelpers.ValidateQueryBody(queryBody);
             if (!validateBody.Status)
@@ -61,7 +61,7 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 return BadRequest(errorMessage);
             }
-            return await base.GetDiagnosticReport(new ArmResource(subscriptionId, resourceGroupName, provider, resourceTypeName, resourceName, GetLocation()), queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan);
+            return await base.GetDiagnosticReport(new ArmResource(subscriptionId, resourceGroupName, provider, resourceTypeName, resourceName, GetLocation()), queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan, form:form);
         }
 
         [HttpPost(UriElements.Detectors + UriElements.DetectorResource + UriElements.StatisticsQuery)]

--- a/src/Diagnostics.RuntimeHost/Controllers/AzureKubernetesService/AzureKubernetesServiceController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/AzureKubernetesService/AzureKubernetesServiceController.cs
@@ -40,7 +40,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.DiagnosticReport)]
-        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string clusterName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string clusterName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null, [FromQuery][ModelBinder(typeof(FormModelBinder))] Form form = null)
         {
             var validateBody = InsightsAPIHelpers.ValidateQueryBody(queryBody);
             if (!validateBody.Status)
@@ -51,7 +51,7 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 return BadRequest(errorMessage);
             }
-            return await base.GetDiagnosticReport(GetResource(subscriptionId, resourceGroupName, clusterName), queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan);
+            return await base.GetDiagnosticReport(GetResource(subscriptionId, resourceGroupName, clusterName), queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan, form: form);
         }
 
         [HttpPost(UriElements.Detectors + UriElements.DetectorResource + UriElements.StatisticsQuery)]

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -530,7 +530,7 @@ namespace Diagnostics.RuntimeHost.Controllers
 
             if (filteredDetectorsToRun.Count > 0)
             {
-                var insightGroups = await Task.WhenAll(filteredDetectorsToRun.Select(detector => GetDiagnosticInsightsFromDetector(cxt, detector, filteredDetectorsToRun, true, form)));
+                var insightGroups = await Task.WhenAll(filteredDetectorsToRun.Select(detector => GetDiagnosticInsightsFromDetector(cxt, detector, filteredDetectorsToRun, true)));
                 foreach (var insightList in insightGroups)
                 {
                     if (insightList.Count() > 0 && detectorInsights.Where(x => x.DetectorId == insightList.First().DetectorId).Count() > 0)
@@ -594,7 +594,7 @@ namespace Diagnostics.RuntimeHost.Controllers
 
 
 
-        private async Task<IEnumerable<DiagnosticReportInsight>> GetDiagnosticInsightsFromDetector(RuntimeContext<TResource> context, DiagnosticApiResponse detector, List<DiagnosticApiResponse> detectorsRunning, bool runChildren = false, Form form = null)
+        private async Task<IEnumerable<DiagnosticReportInsight>> GetDiagnosticInsightsFromDetector(RuntimeContext<TResource> context, DiagnosticApiResponse detector, List<DiagnosticApiResponse> detectorsRunning, bool runChildren = false)
         {
             Response response = null;
             List<DiagnosticReportInsight> resultInsights = new List<DiagnosticReportInsight>();
@@ -636,7 +636,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                                     DetectorId = detector.Metadata.Id,
                                     Title = renderingProperties.Title,
                                     Description = renderingProperties.Description,
-                                    DetailsLink = InsightsAPIHelpers.GetDetectorLink(detector, context.OperationContext.Resource.ResourceUri, context.OperationContext.StartTime, context.OperationContext.EndTime, context.OperationContext.Form, context.OperationContext.QueryParams),
+                                    DetailsLink = InsightsAPIHelpers.GetDetectorLink(detector, context.OperationContext.Resource.ResourceUri, context.OperationContext.StartTime, context.OperationContext.EndTime, context.OperationContext.QueryParams),
                                     Table = set.Table
                                 };
                             }
@@ -676,7 +676,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                                             Title = insightMessage,
                                             Description = insightDescription,
                                             Solutions = allSolutions,
-                                            DetailsLink = InsightsAPIHelpers.GetDetectorLink(detector, context.OperationContext.Resource.ResourceUri, context.OperationContext.StartTime, context.OperationContext.EndTime, context.OperationContext.Form, context.OperationContext.QueryParams)
+                                            DetailsLink = InsightsAPIHelpers.GetDetectorLink(detector, context.OperationContext.Resource.ResourceUri, context.OperationContext.StartTime, context.OperationContext.EndTime, context.OperationContext.QueryParams)
                                         };
                                         break;
                                     }

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -484,9 +484,9 @@ namespace Diagnostics.RuntimeHost.Controllers
             return ex;
         }
 
-        protected async Task<IActionResult> GetDiagnosticReport(TResource resource, DiagnosticReportQuery queryBody, DateTime startTime, DateTime endTime, TimeSpan timeGrain, string correlationId = null)
+        protected async Task<IActionResult> GetDiagnosticReport(TResource resource, DiagnosticReportQuery queryBody, DateTime startTime, DateTime endTime, TimeSpan timeGrain, Form form = null, string correlationId = null)
         {
-            RuntimeContext<TResource> cxt = PrepareContext(resource, startTime, endTime);
+            RuntimeContext<TResource> cxt = PrepareContext(resource, startTime, endTime, Form: form);
             if (correlationId == null)
             {
                 if (cxt.OperationContext.RequestId != null)
@@ -530,7 +530,7 @@ namespace Diagnostics.RuntimeHost.Controllers
 
             if (filteredDetectorsToRun.Count > 0)
             {
-                var insightGroups = await Task.WhenAll(filteredDetectorsToRun.Select(detector => GetDiagnosticInsightsFromDetector(cxt, detector, filteredDetectorsToRun, true)));
+                var insightGroups = await Task.WhenAll(filteredDetectorsToRun.Select(detector => GetDiagnosticInsightsFromDetector(cxt, detector, filteredDetectorsToRun, true, form)));
                 foreach (var insightList in insightGroups)
                 {
                     if (insightList.Count() > 0 && detectorInsights.Where(x => x.DetectorId == insightList.First().DetectorId).Count() > 0)
@@ -594,7 +594,7 @@ namespace Diagnostics.RuntimeHost.Controllers
 
 
 
-        private async Task<IEnumerable<DiagnosticReportInsight>> GetDiagnosticInsightsFromDetector(RuntimeContext<TResource> context, DiagnosticApiResponse detector, List<DiagnosticApiResponse> detectorsRunning, bool runChildren = false)
+        private async Task<IEnumerable<DiagnosticReportInsight>> GetDiagnosticInsightsFromDetector(RuntimeContext<TResource> context, DiagnosticApiResponse detector, List<DiagnosticApiResponse> detectorsRunning, bool runChildren = false, Form form = null)
         {
             Response response = null;
             List<DiagnosticReportInsight> resultInsights = new List<DiagnosticReportInsight>();
@@ -636,7 +636,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                                     DetectorId = detector.Metadata.Id,
                                     Title = renderingProperties.Title,
                                     Description = renderingProperties.Description,
-                                    DetailsLink = InsightsAPIHelpers.GetDetectorLink(detector, context.OperationContext.Resource.ResourceUri, context.OperationContext.StartTime, context.OperationContext.EndTime),
+                                    DetailsLink = InsightsAPIHelpers.GetDetectorLink(detector, context.OperationContext.Resource.ResourceUri, context.OperationContext.StartTime, context.OperationContext.EndTime, context.OperationContext.Form, context.OperationContext.QueryParams),
                                     Table = set.Table
                                 };
                             }
@@ -676,7 +676,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                                             Title = insightMessage,
                                             Description = insightDescription,
                                             Solutions = allSolutions,
-                                            DetailsLink = InsightsAPIHelpers.GetDetectorLink(detector, context.OperationContext.Resource.ResourceUri, context.OperationContext.StartTime, context.OperationContext.EndTime)
+                                            DetailsLink = InsightsAPIHelpers.GetDetectorLink(detector, context.OperationContext.Resource.ResourceUri, context.OperationContext.StartTime, context.OperationContext.EndTime, context.OperationContext.Form, context.OperationContext.QueryParams)
                                         };
                                         break;
                                     }

--- a/src/Diagnostics.RuntimeHost/Controllers/LogicApp/LogicAppController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/LogicApp/LogicAppController.cs
@@ -40,7 +40,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.DiagnosticReport)]
-        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string logicAppName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string logicAppName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null, [FromQuery][ModelBinder(typeof(FormModelBinder))] Form form = null)
         {
             var validateBody = InsightsAPIHelpers.ValidateQueryBody(queryBody);
             if (!validateBody.Status)
@@ -51,7 +51,7 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 return BadRequest(errorMessage);
             }
-            return await base.GetDiagnosticReport(GetResource(subscriptionId, resourceGroupName, logicAppName), queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan);
+            return await base.GetDiagnosticReport(GetResource(subscriptionId, resourceGroupName, logicAppName), queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan, form: form);
         }
 
         [HttpPost(UriElements.Detectors + UriElements.DetectorResource + UriElements.StatisticsQuery)]

--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
@@ -93,7 +93,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         /// <param name="postBody">Request json body.</param>
         /// <returns>Task for showing diagnostic report.</returns>
         [HttpPost(UriElements.DiagnosticReport)]
-        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string siteName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string siteName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null, [FromQuery][ModelBinder(typeof(FormModelBinder))] Form form = null)
         {
             var validateBody = InsightsAPIHelpers.ValidateQueryBody(queryBody);
             if (!validateBody.Status)
@@ -106,7 +106,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                 return BadRequest(errorMessage);
             }
             App app = await GetAppResource(subscriptionId, resourceGroupName, siteName, postBody, startTimeUtc, endTimeUtc);
-            return await base.GetDiagnosticReport(app, queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan);
+            return await base.GetDiagnosticReport(app, queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan, form:form);
         }
 
         /// <summary>

--- a/src/Diagnostics.RuntimeHost/Controllers/WorkerApp/WorkerAppController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/WorkerApp/WorkerAppController.cs
@@ -40,7 +40,7 @@ namespace Diagnostics.RuntimeHost.Controllers
         }
 
         [HttpPost(UriElements.DiagnosticReport)]
-        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string siteName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null)
+        public async Task<IActionResult> DiagnosticReport(string subscriptionId, string resourceGroupName, string siteName, [FromBody] DiagnosticReportQuery queryBody, string startTime = null, string endTime = null, string timeGrain = null, [FromQuery][ModelBinder(typeof(FormModelBinder))] Form form = null)
         {
             var validateBody = InsightsAPIHelpers.ValidateQueryBody(queryBody);
             if (!validateBody.Status)
@@ -51,7 +51,7 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 return BadRequest(errorMessage);
             }
-            return await base.GetDiagnosticReport(GetResource(subscriptionId, resourceGroupName, siteName), queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan);
+            return await base.GetDiagnosticReport(GetResource(subscriptionId, resourceGroupName, siteName), queryBody, startTimeUtc, endTimeUtc, timeGrainTimeSpan, form: form);
         }
 
         [HttpPost(UriElements.Detectors + UriElements.DetectorResource + UriElements.StatisticsQuery)]

--- a/src/Diagnostics.RuntimeHost/Utilities/InsightsAPIHelpers.cs
+++ b/src/Diagnostics.RuntimeHost/Utilities/InsightsAPIHelpers.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Web;
 using Diagnostics.ModelsAndUtils.Attributes;
 using Diagnostics.ModelsAndUtils.Models;
+using Diagnostics.ModelsAndUtils.Models.ResponseExtensions;
 using Diagnostics.RuntimeHost.Models;
 using Newtonsoft.Json;
 
@@ -45,12 +48,33 @@ namespace Diagnostics.RuntimeHost.Utilities
             return allDetectors.Where(detector => detector.Metadata.AnalysisTypes != null && detector.Metadata.AnalysisTypes.Contains(analysisId));
         }
 
-        public static Link GetDetectorLink(DiagnosticApiResponse detector, string resourceUri, string startTime, string endTime)
+        public static Link GetDetectorLink(DiagnosticApiResponse detector, string resourceUri, string startTime, string endTime, Form form=null, Dictionary<string, string> queryParams = null)
         {
             var baseUrl = resourceUri;
+            string formParamsStr = "";
+            string queryParamsStr = "";
+            if (form != null)
+            {
+                try
+                {
+                    formParamsStr = "&form=" + JsonConvert.SerializeObject(form);
+                }
+                catch (Exception ex) { }
+            }
+            if (queryParams != null)
+            {
+                try
+                {
+                    queryParams.Remove("startTime");
+                    queryParams.Remove("endTime");
+                    queryParams.Remove("form");
+                    queryParamsStr = "&" + string.Join('&', queryParams.Keys.Select(k => k + "=" + HttpUtility.UrlEncode(queryParams.GetValueOrDefault(k))).ToArray());
+                }
+                catch (Exception ex) { }
+            }
             return new Link()
             {
-                Uri = $"{baseUrl}/{(detector.Metadata.Type == DetectorType.Analysis ? "analysis" : "detectors")}/{detector.Metadata.Id}?startTime={startTime}&endTime={endTime}",
+                Uri = $"{baseUrl}/{(detector.Metadata.Type == DetectorType.Analysis ? "analysis" : "detectors")}/{detector.Metadata.Id}?startTime={startTime}&endTime={endTime}{formParamsStr}{queryParamsStr}",
                 Text = $"{detector.Metadata.Name}"
             };
         }

--- a/src/Diagnostics.RuntimeHost/Utilities/InsightsAPIHelpers.cs
+++ b/src/Diagnostics.RuntimeHost/Utilities/InsightsAPIHelpers.cs
@@ -48,33 +48,23 @@ namespace Diagnostics.RuntimeHost.Utilities
             return allDetectors.Where(detector => detector.Metadata.AnalysisTypes != null && detector.Metadata.AnalysisTypes.Contains(analysisId));
         }
 
-        public static Link GetDetectorLink(DiagnosticApiResponse detector, string resourceUri, string startTime, string endTime, Form form=null, Dictionary<string, string> queryParams = null)
+        public static Link GetDetectorLink(DiagnosticApiResponse detector, string resourceUri, string startTime, string endTime, Dictionary<string, string> queryParams = null)
         {
             var baseUrl = resourceUri;
-            string formParamsStr = "";
             string queryParamsStr = "";
-            if (form != null)
-            {
-                try
-                {
-                    formParamsStr = "&form=" + JsonConvert.SerializeObject(form);
-                }
-                catch (Exception ex) { }
-            }
             if (queryParams != null)
             {
                 try
                 {
                     queryParams.Remove("startTime");
                     queryParams.Remove("endTime");
-                    queryParams.Remove("form");
                     queryParamsStr = "&" + string.Join('&', queryParams.Keys.Select(k => k + "=" + HttpUtility.UrlEncode(queryParams.GetValueOrDefault(k))).ToArray());
                 }
                 catch (Exception ex) { }
             }
             return new Link()
             {
-                Uri = $"{baseUrl}/{(detector.Metadata.Type == DetectorType.Analysis ? "analysis" : "detectors")}/{detector.Metadata.Id}?startTime={startTime}&endTime={endTime}{formParamsStr}{queryParamsStr}",
+                Uri = $"{baseUrl}/{(detector.Metadata.Type == DetectorType.Analysis ? "analysis" : "detectors")}/{detector.Metadata.Id}?startTime={startTime}&endTime={endTime}{queryParamsStr}",
                 Text = $"{detector.Metadata.Name}"
             };
         }


### PR DESCRIPTION
Insights API in its version 1 had two limitations:
1. It could not accept Detector Forms as input.
2. It was not adding detector query params in the detector deep links it returned

This PR aims to add these two capabilities to the Insights API, as it is used heavily by partners like Azure ML, AKS.
Output link contains all params:
![image](https://user-images.githubusercontent.com/8492235/132050597-eeafd87c-d86f-4721-81af-e06eaa8b9967.png)
