### PR TITLE
disable weak consistency for wawscusdiagleadertest1.centralus

### DIFF
--- a/src/Diagnostics.DataProviders/KustoSDKClient.cs
+++ b/src/Diagnostics.DataProviders/KustoSDKClient.cs
@@ -87,7 +87,7 @@ namespace Diagnostics.DataProviders
             var kustoClientId = $"Diagnostics.{operationName ?? "Query"};{_requestId};{startTime?.ToString() ?? "UnknownStartTime"};{endTime?.ToString() ?? "UnknownEndTime"}##{0}_{Guid.NewGuid().ToString()}";
             clientRequestProperties.ClientRequestId = kustoClientId;
             clientRequestProperties.SetOption("servertimeout", new TimeSpan(0,0,timeoutSeconds));
-            if(cluster.StartsWith("waws",StringComparison.OrdinalIgnoreCase))
+            if(cluster.StartsWith("waws",StringComparison.OrdinalIgnoreCase) && cluster != "wawscusdiagleadertest1.centralus")
             {
                 clientRequestProperties.SetOption(ClientRequestProperties.OptionQueryConsistency, ClientRequestProperties.OptionQueryConsistency_Weak);
             }


### PR DESCRIPTION
weak consistency lower down the perf of wawscusdiagleadertest1.centralus cluster, disable it for a better perf measurement