### PR TITLE
Increase Thread Pool MinThreads to 90

### DIFF
--- a/src/Diagnostics.RuntimeHost/runtimeconfig.template.json
+++ b/src/Diagnostics.RuntimeHost/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+  "configProperties": {
+    "System.Threading.ThreadPool.MinThreads": 90
+  }
+}


### PR DESCRIPTION
Increasing threadpool settings to check if we get rid of detectors taking high latency for runtime host when data providers are not taking high time.

On a side note, this can also be achieved by setting `COMPlus_ThreadPool_ForceMinWorkerThreads=0x50` environment variable. Not sure which one is easier to maintain for us. I felt its the project code hence I found a configuration way to do this.