### PR TITLE
Fix broken compile response

### DIFF
--- a/src/Diagnostics.CompilerHost/Startup.cs
+++ b/src/Diagnostics.CompilerHost/Startup.cs
@@ -150,8 +150,12 @@ namespace Diagnostics.CompilerHost
                                         AddAuthenticationSchemes(CertificateAuthDefaults.AuthenticationScheme, "AzureAd")
                                         .Build();
             });
-            // Enable app insights telemetry
-            services.AddApplicationInsightsTelemetry();
+
+            if (!Environment.IsDevelopment())
+            {
+                // Enable app insights telemetry
+                services.AddApplicationInsightsTelemetry();
+            }
             services.AddControllers().AddNewtonsoftJson();
             CustomStartup();
 

--- a/src/Diagnostics.DataProviders/TokenService/LogAnalyticsTokenServiceBase.cs
+++ b/src/Diagnostics.DataProviders/TokenService/LogAnalyticsTokenServiceBase.cs
@@ -84,7 +84,7 @@ namespace Diagnostics.DataProviders.TokenService
                 ValidateAuthority = true
             };
 
-            creds = await ApplicationTokenProvider.LoginSilentAsync(domain, clientId, clientSecret, adSettings);
+            creds = await ApplicationTokenProvider.LoginSilentAsync(domain, clientId, clientSecret, adSettings).ConfigureAwait(false);
         }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Storage/DeploymentParameters.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Storage/DeploymentParameters.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Diagnostics.ModelsAndUtils.Models.Storage
 {
@@ -11,37 +10,31 @@ namespace Diagnostics.ModelsAndUtils.Models.Storage
         /// <summary>
         /// Single commit id to deploy. Not applicable if <see cref="FromCommitId"/> and <see cref="ToCommitId"/> is given.
         /// </summary>
-        [JsonPropertyName("CommitId")]
         public string CommitId { get; set; }
 
         /// <summary>
         /// Start commit to deploy. Not applicable if <see cref="CommitId"/> is given.
         /// </summary>
-        [JsonPropertyName("FromCommitId")]
         public string FromCommitId { get; set; }
 
         /// <summary>
         /// End commit to deploy. Not applicable if <see cref="CommitId"/> is given.
         /// </summary>
-        [JsonPropertyName("ToCommitId")]
         public string ToCommitId { get; set; }
 
         /// <summary>
         /// If provided, includes detectors modified after this date. Cannot be combined with <see cref="FromCommitId"/> and <see cref="ToCommitId"/>.
         /// </summary>
-        [JsonPropertyName("StartDate")]
         public string StartDate { get; set; }
 
         /// <summary>
         /// If provided, includes detectors modified before this date. Cannot be combined with <see cref="FromCommitId"/> and <see cref="ToCommitId"/>.
         /// </summary>
-        [JsonPropertyName("EndDate")]
         public string EndDate { get; set; }
 
         /// <summary>
         /// Resource type of the caller. eg. Microsoft.Web/sites.
         /// </summary>
-        [JsonPropertyName("ResourceType")]
         public string ResourceType { get; set; }
     }
 
@@ -53,29 +46,21 @@ namespace Diagnostics.ModelsAndUtils.Models.Storage
         /// <summary>
         /// List of detectors that got updated/added/edited;
         /// </summary>
-
-        [JsonPropertyName("DeployedDetectors")]
         public List<string> DeployedDetectors { get; set; }
 
         /// <summary>
         /// List of detectors that failed deployment along with the reason of failure;
         /// </summary>
-
-        [JsonPropertyName("FailedDetectors")]
         public Dictionary<string, string> FailedDetectors { get; set; }
 
         /// <summary>
         /// List of detectors that were marked for deletion;
         /// </summary>
-
-        [JsonPropertyName("DeletedDetectors")]
         public List<string> DeletedDetectors { get; set; }
 
         /// <summary>
         /// Unique Guid to track the deployment;
         /// </summary>
-
-        [JsonPropertyName("DeploymentGuid")]
         public string DeploymentGuid { get; set; }
     }
 }

--- a/src/Diagnostics.ModelsAndUtils/Models/Storage/DeploymentParameters.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/Storage/DeploymentParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Diagnostics.ModelsAndUtils.Models.Storage
 {
@@ -10,32 +11,38 @@ namespace Diagnostics.ModelsAndUtils.Models.Storage
         /// <summary>
         /// Single commit id to deploy. Not applicable if <see cref="FromCommitId"/> and <see cref="ToCommitId"/> is given.
         /// </summary>
-        public string CommitId;
+        [JsonPropertyName("CommitId")]
+        public string CommitId { get; set; }
 
         /// <summary>
         /// Start commit to deploy. Not applicable if <see cref="CommitId"/> is given.
         /// </summary>
-        public string FromCommitId;
+        [JsonPropertyName("FromCommitId")]
+        public string FromCommitId { get; set; }
 
         /// <summary>
         /// End commit to deploy. Not applicable if <see cref="CommitId"/> is given.
         /// </summary>
-        public string ToCommitId;
+        [JsonPropertyName("ToCommitId")]
+        public string ToCommitId { get; set; }
 
         /// <summary>
         /// If provided, includes detectors modified after this date. Cannot be combined with <see cref="FromCommitId"/> and <see cref="ToCommitId"/>.
         /// </summary>
-        public string StartDate;
+        [JsonPropertyName("StartDate")]
+        public string StartDate { get; set; }
 
         /// <summary>
         /// If provided, includes detectors modified before this date. Cannot be combined with <see cref="FromCommitId"/> and <see cref="ToCommitId"/>.
         /// </summary>
-        public string EndDate;
+        [JsonPropertyName("EndDate")]
+        public string EndDate { get; set; }
 
         /// <summary>
         /// Resource type of the caller. eg. Microsoft.Web/sites.
         /// </summary>
-        public string ResourceType;
+        [JsonPropertyName("ResourceType")]
+        public string ResourceType { get; set; }
     }
 
     /// <summary>
@@ -46,21 +53,29 @@ namespace Diagnostics.ModelsAndUtils.Models.Storage
         /// <summary>
         /// List of detectors that got updated/added/edited;
         /// </summary>
-        public List<string> DeployedDetectors;
+
+        [JsonPropertyName("DeployedDetectors")]
+        public List<string> DeployedDetectors { get; set; }
 
         /// <summary>
         /// List of detectors that failed deployment along with the reason of failure;
         /// </summary>
-        public Dictionary<string, string> FailedDetectors;
+
+        [JsonPropertyName("FailedDetectors")]
+        public Dictionary<string, string> FailedDetectors { get; set; }
 
         /// <summary>
         /// List of detectors that were marked for deletion;
         /// </summary>
-        public List<string> DeletedDetectors;
+
+        [JsonPropertyName("DeletedDetectors")]
+        public List<string> DeletedDetectors { get; set; }
 
         /// <summary>
         /// Unique Guid to track the deployment;
         /// </summary>
-        public string DeploymentGuid;
+
+        [JsonPropertyName("DeploymentGuid")]
+        public string DeploymentGuid { get; set; }
     }
 }

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -348,7 +348,7 @@ namespace Diagnostics.RuntimeHost.Controllers
             bool isCompilationNeeded = !ScriptCompilation.IsSameScript(jsonBody.Script, scriptETag) || !_assemblyCacheService.IsAssemblyLoaded(assemblyFullName);
             if (isCompilationNeeded)
             {
-                queryRes.CompilationOutput = await _compilerHostClient.GetCompilationResponse(jsonBody.Script, jsonBody.EntityType, jsonBody.References, runtimeContext.OperationContext.RequestId);
+                queryRes.CompilationOutput = await _compilerHostClient.GetCompilationResponse(jsonBody.Script, jsonBody.EntityType, jsonBody.References, runtimeContext.OperationContext.RequestId).ConfigureAwait(false);
             }
             else
             {

--- a/src/Diagnostics.RuntimeHost/Extensions/StorageServiceExtensions.cs
+++ b/src/Diagnostics.RuntimeHost/Extensions/StorageServiceExtensions.cs
@@ -27,10 +27,12 @@ namespace Microsoft.Extensions.DependencyInjection
             }
             if (configuration.IsAzureChinaCloud() || configuration.IsAzureUSGovernment())
             {
+                // Sovereign clouds cannot access our StorageService
                 services.AddSingleton<IStorageService, NullableStorageService>();
             }
             else
             {
+                // IStorageService dependency needs to be initialized for any other cloud including UnitTest
                 services.AddSingleton<IStorageService, NullableStorageService>();
             }
 

--- a/src/Diagnostics.RuntimeHost/Extensions/StorageServiceExtensions.cs
+++ b/src/Diagnostics.RuntimeHost/Extensions/StorageServiceExtensions.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 services.AddSingleton<IStorageService, NullableStorageService>();
             }
+            else
+            {
+                services.AddSingleton<IStorageService, NullableStorageService>();
+            }
 
             return services;
         }

--- a/src/Diagnostics.RuntimeHost/SerializationConvertors/AsRuntimeTypeConverter.cs
+++ b/src/Diagnostics.RuntimeHost/SerializationConvertors/AsRuntimeTypeConverter.cs
@@ -27,6 +27,7 @@ namespace Diagnostics.RuntimeHost
                 var serializeOptions = new JsonSerializerOptions
                 {
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    IncludeFields = true,
                     WriteIndented = true
                 };
 

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -135,11 +135,11 @@ namespace Diagnostics.RuntimeHost
                 MdmCertLoader.Instance.Initialize(Configuration);
                 CompilerHostCertLoader.Instance.Initialize(Configuration);
                 SearchAPICertLoader.Instance.Initialize(Configuration);
+                // Enable App Insights telemetry
+                services.AddApplicationInsightsTelemetry();
             }
 
             services.AddMemoryCache();
-            // Enable App Insights telemetry
-            services.AddApplicationInsightsTelemetry();
             services.AddAppServiceApplicationLogging();
 
             if (Environment.IsDevelopment())
@@ -150,7 +150,9 @@ namespace Diagnostics.RuntimeHost
                 }).AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.WriteIndented = true;
+                    options.JsonSerializerOptions.IncludeFields = true;
                     options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<Rendering>());
+                    options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<QueryResponse<DiagnosticApiResponse>>());
                 });
             }
             else
@@ -158,10 +160,9 @@ namespace Diagnostics.RuntimeHost
                 services.AddControllers().AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.WriteIndented = true;
-                }).AddJsonOptions(options =>
-                {
-                    options.JsonSerializerOptions.WriteIndented = true;
+                    options.JsonSerializerOptions.IncludeFields = true;
                     options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<Rendering>());
+                    options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<QueryResponse<DiagnosticApiResponse>>());
                 });
             }
 


### PR DESCRIPTION
This PR fixes the empty response from runtimehost when compiling a detector.

This PR also changes the following things:
- Add ConfigureAwait(false) for some async calls
- Disable Application Insights for local development mode
- Fix unhandled exception when launching runtime host if CloudDomain is set to UnitTest