### PR TITLE
Fix DynamicInsightRendering rendering

### DIFF
--- a/src/Diagnostics.ModelsAndUtils/Models/CompilerResponse.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/CompilerResponse.cs
@@ -5,18 +5,18 @@ namespace Diagnostics.ModelsAndUtils.Models
 {
     public class CompilerResponse
     {
-        public bool CompilationSucceeded;
+        public bool CompilationSucceeded { get; set; }
 
-        public IEnumerable<string> CompilationTraces;
-        public IEnumerable<CompilationTraceOutputDetails> DetailedCompilationTraces;
+        public IEnumerable<string> CompilationTraces { get; set; }
+        public IEnumerable<CompilationTraceOutputDetails> DetailedCompilationTraces { get; set; }
 
-        public IEnumerable<string> References;
+        public IEnumerable<string> References { get; set; }
 
-        public string AssemblyBytes;
+        public string AssemblyBytes { get; set; }
 
-        public string PdbBytes;
+        public string PdbBytes { get; set; }
 
-        public string AssemblyName;
+        public string AssemblyName { get; set; }
     }
 
     public class CompilationTraceOutputDetails

--- a/src/Diagnostics.ModelsAndUtils/Models/QueryResponse.cs
+++ b/src/Diagnostics.ModelsAndUtils/Models/QueryResponse.cs
@@ -4,11 +4,11 @@ namespace Diagnostics.ModelsAndUtils.Models
 {
     public class QueryResponse<T>
     {
-        public CompilerResponse CompilationOutput;
-        public IEnumerable<RuntimeLogEntry> RuntimeLogOutput;
+        public CompilerResponse CompilationOutput { get; set; }
+        public IEnumerable<RuntimeLogEntry> RuntimeLogOutput { get; set; }
 
-        public bool RuntimeSucceeded;
+        public bool RuntimeSucceeded { get; set; }
 
-        public T InvocationOutput;
+        public T InvocationOutput { get; set; }
     }
 }

--- a/src/Diagnostics.RuntimeHost/SerializationConvertors/AsRuntimeTypeConverter.cs
+++ b/src/Diagnostics.RuntimeHost/SerializationConvertors/AsRuntimeTypeConverter.cs
@@ -16,11 +16,10 @@ namespace Diagnostics.RuntimeHost
             var options = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                IncludeFields = true,
                 WriteIndented = true
             };
 
-            options.Converters.Add(new AsNonGenericTypeConverter<Exception>());
+            options.Converters.Add(new AsPrintableTypeConverter<Exception>());
 
             return options;
         });
@@ -43,7 +42,7 @@ namespace Diagnostics.RuntimeHost
         }
     }
 
-    public class AsNonGenericTypeConverter<T> : JsonConverter<T>
+    public class AsPrintableTypeConverter<T> : JsonConverter<T>
     {
         private static JsonSerializerOptions _serializeWithoutFieldOptions = new JsonSerializerOptions
         {

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -149,11 +149,9 @@ namespace Diagnostics.RuntimeHost
                 }).AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.WriteIndented = true;
-                    options.JsonSerializerOptions.IncludeFields = true;
-                    options.JsonSerializerOptions.Converters.Add(new AsNonGenericTypeConverter<Exception>());
+                    options.JsonSerializerOptions.Converters.Add(new AsPrintableTypeConverter<Exception>());
                     options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<Rendering>());
                     options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<ModelsAndUtils.Models.ResponseExtensions.FormInputBase>());
-                    options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<QueryResponse<DiagnosticApiResponse>>());
                 });
             }
             else
@@ -161,11 +159,9 @@ namespace Diagnostics.RuntimeHost
                 services.AddControllers().AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.WriteIndented = true;
-                    options.JsonSerializerOptions.IncludeFields = true;
-                    options.JsonSerializerOptions.Converters.Add(new AsNonGenericTypeConverter<Exception>());
+                    options.JsonSerializerOptions.Converters.Add(new AsPrintableTypeConverter<Exception>());
                     options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<Rendering>());
                     options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<ModelsAndUtils.Models.ResponseExtensions.FormInputBase>());
-                    options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<QueryResponse<DiagnosticApiResponse>>());
                 });
             }
 


### PR DESCRIPTION
This PR should finally fix recent several rendering issues, including DynamicInsightRendering. It also fixes the infinite "track" events after compilation.

This PR reverts my recent change which uses the IncludeFields flag for JSON serialization. It also removes the converter for QueryResponse<> because it conflicts with rendering Rendering objects within.

This PR also renames AsNonGenericTypeConverter to AsPrintableTypeConverter because it makes more sense. It is used to serialize Exception and all of its derived classes.