### PR TITLE
System.Text.Json issue - Fix for GetKustoQuery method used by existing detectors

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -21,7 +21,8 @@ namespace Diagnostics.DataProviders
         public string OperationName;
 
         [JsonPropertyName("text")]
-        public string TextProperty { 
+        public string TextSTJCompat
+        { 
             get
             {
                 return Text;
@@ -29,7 +30,7 @@ namespace Diagnostics.DataProviders
         }
 
         [JsonPropertyName("url")]
-        public string UrlProperty
+        public string UrlSTJCompat
         {
             get
             {
@@ -38,7 +39,7 @@ namespace Diagnostics.DataProviders
         }
 
         [JsonPropertyName("kustoDesktopUrl")]
-        public string KustoDesktopUrlProperty
+        public string KustoDesktopUrlSTJCompat
         {
             get
             {
@@ -47,7 +48,7 @@ namespace Diagnostics.DataProviders
         }
 
         [JsonPropertyName("operationName")]
-        public string OperationNameProperty
+        public string OperationNameSTJCompat
         {
             get
             {

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,10 +15,45 @@ namespace Diagnostics.DataProviders
 {
     public class KustoQuery
     {
-        public string Text { get; set; }
-        public string Url { get; set; }
-        public string KustoDesktopUrl { get; set; }
-        public string OperationName { get; set; }
+        public string Text;
+        public string Url;
+        public string KustoDesktopUrl;
+        public string OperationName;
+
+        [JsonPropertyName("text")]
+        public string TextProperty { 
+            get
+            {
+                return Text;
+            }
+        }
+
+        [JsonPropertyName("url")]
+        public string UrlProperty
+        {
+            get
+            {
+                return Url;
+            }
+        }
+
+        [JsonPropertyName("kustoDesktopUrl")]
+        public string KustoDesktopUrlProperty
+        {
+            get
+            {
+                return KustoDesktopUrl;
+            }
+        }
+
+        [JsonPropertyName("operationName")]
+        public string OperationNameProperty
+        {
+            get
+            {
+                return OperationName;
+            }
+        }
     }
 
     public class KustoDataProvider : DiagnosticDataProvider, IKustoDataProvider


### PR DESCRIPTION
Detectors using dp.Kusto.GetKustoQuery (e.g. DWASQuery and many more) are broken in staging because we changed the fields of the KustoQuery class and those calls are failing with FieldNotFound exceptions. 

This PR will fix that issue.