### PR TITLE
KustSDKClient uses test leader cluster

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
@@ -53,6 +53,12 @@ namespace Diagnostics.DataProviders
         public string KustoClusterFailoverGroupings { get; set; }
 
         /// <summary>
+        /// DB Name mappings like clusterName|aggClusterName, where clusterName should be the values in KustoClusterNameGroupings
+        /// </summary>
+        [ConfigurationName("KustoAggClusterNameGroupMappings")]
+        public string KustoAggClusterNameGroupMappings { get; set; }
+
+        /// <summary>
         /// Tenant to authenticate with
         /// </summary>
         [ConfigurationName("AADAuthority")]
@@ -195,6 +201,8 @@ namespace Diagnostics.DataProviders
 
         public ConcurrentDictionary<string, string[]> QueryShadowingClusterMapping;
 
+        public ConcurrentDictionary<string, string> HiPerfAggClusterMapping;
+
         public List<ITuple> OverridableExceptionsToRetryAgainstLeaderCluster { get; set; }
 
         public IConfiguration config { private get; set; }
@@ -267,6 +275,25 @@ namespace Diagnostics.DataProviders
                                {
                                    var splitted = e.Split('|');
                                    return new KeyValuePair<string, string[]>(splitted[0], splitted[1].Split(':'));
+                               }));
+                }
+                catch (Exception)
+                {
+                    // swallow the exception
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(KustoAggClusterNameGroupMappings))
+            {
+                try
+                {
+                    HiPerfAggClusterMapping = new ConcurrentDictionary<string, string>(
+                           KustoAggClusterNameGroupMappings
+                               .Split(',')
+                               .Select(e =>
+                               {
+                                   var splitted = e.Split('|');
+                                   return new KeyValuePair<string, string>(splitted[0], splitted[1]);
                                }));
                 }
                 catch (Exception)

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -221,5 +221,26 @@ namespace Diagnostics.DataProviders
 
             return result;
         }
+
+        public async Task<string> GetAggHiPerfClusterNameByStampAsync(string stampName)
+        {
+            try
+            {
+                var dict = _configuration.HiPerfAggClusterMapping;
+                string cluster = await GetClusterNameFromStamp(stampName);
+                if (dict.TryGetValue(cluster, out string clusterName) && !string.IsNullOrEmpty(clusterName))
+                {
+                    return clusterName;                    
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
     }
 }

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -16,5 +16,7 @@ namespace Diagnostics.DataProviders
         Task<KustoQuery> GetKustoQuery(string query, string stampName);
 
         Task<KustoQuery> GetKustoClusterQuery(string query);
+
+        Task<string> GetAggHiPerfClusterNameByStampAsync(string stampName);
     }
 }

--- a/src/Diagnostics.DataProviders/KustoLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/KustoLogDecorator.cs
@@ -41,5 +41,10 @@ namespace Diagnostics.DataProviders
         {
             return MakeDependencyCall(DataProvider.GetKustoClusterQuery(query));
         }
+
+        public Task<string> GetAggHiPerfClusterNameByStampAsync(string stampName)
+        {
+            return MakeDependencyCall(DataProvider.GetAggHiPerfClusterNameByStampAsync(stampName));
+        }
     }
 }

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -75,7 +75,8 @@
         }
       ]
     },
-    "QueryShadowingClusterMapping": "wawscusfollower|wawscusdiagleader.centralus,wawscus|wawscusdiagleader.centralus"
+    "QueryShadowingClusterMapping": "wawscusfollower|wawscusdiagleader.centralus,wawscus|wawscusdiagleader.centralus",
+    "KustoAggClusterNameGroupMappings": "wawscusfollower|wawscusaggdiagleader.centralus"
   },
   "SupportObserver": {
     "ClientId": "",


### PR DESCRIPTION
If test cluster exists, KustSDKClient will use test leader cluster first and falls back to normal routine on any failure

Besides, add a `GetAggHiPerfClusterNameByStampAsync` function to KustoDataProvider