### PR TITLE
Fix runtime exception incorrectly shown in the runtime logs

### DIFF
--- a/src/Diagnostics.RuntimeHost/SerializationConvertors/AsRuntimeTypeConverter.cs
+++ b/src/Diagnostics.RuntimeHost/SerializationConvertors/AsRuntimeTypeConverter.cs
@@ -58,6 +58,17 @@ namespace Diagnostics.RuntimeHost
             writer.WriteString("Source", value?.Source);
             writer.WriteString("StackTraceString", value?.StackTrace);
 
+            if (value?.InnerException != null)
+            {
+                writer.WriteStartObject("InnerException");
+                JsonSerializer.Serialize<Exception>(writer, value?.InnerException, options);
+                writer.WriteEndObject();
+            }
+            else
+            {
+                writer.WriteNull("InnerException");
+            }
+
             writer.WriteEndObject();
         }
     }

--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -149,7 +149,7 @@ namespace Diagnostics.RuntimeHost
                 }).AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.WriteIndented = true;
-                    options.JsonSerializerOptions.Converters.Add(new AsPrintableTypeConverter<Exception>());
+                    options.JsonSerializerOptions.Converters.Add(new ExceptionConverter());
                     options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<Rendering>());
                     options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<ModelsAndUtils.Models.ResponseExtensions.FormInputBase>());
                 });
@@ -159,7 +159,7 @@ namespace Diagnostics.RuntimeHost
                 services.AddControllers().AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.WriteIndented = true;
-                    options.JsonSerializerOptions.Converters.Add(new AsPrintableTypeConverter<Exception>());
+                    options.JsonSerializerOptions.Converters.Add(new ExceptionConverter());
                     options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<Rendering>());
                     options.JsonSerializerOptions.Converters.Add(new AsRuntimeTypeConverter<ModelsAndUtils.Models.ResponseExtensions.FormInputBase>());
                 });


### PR DESCRIPTION
This PR fixes an issue where runtime exception isn't correctly shown in the runtime output text when compiling a detector.