### PR TITLE
Kusto execute cluster does not honor custom database name when showing queries in data source

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -200,7 +200,7 @@ namespace Diagnostics.DataProviders
         {
             if (string.IsNullOrWhiteSpace(databaseName))
             {
-                databaseName = !string.IsNullOrWhiteSpace(_kustoMap.MapDatabase(_configuration.DBName)) ? _configuration.DBName : string.Empty;
+                databaseName = !string.IsNullOrWhiteSpace(_kustoMap.MapDatabase(_configuration.DBName)) ? _configuration.DBName : "wawsprod";
             }
             var kustoQuery = await _kustoClient.GetKustoQueryAsync(Helpers.MakeQueryCloudAgnostic(_kustoMap, query), _kustoMap.MapCluster(clusterName) ?? clusterName, databaseName, operationName);
             return kustoQuery;

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -110,25 +110,19 @@ namespace Diagnostics.DataProviders
             {
                 //Allow partner KQL queries to proxy through us
                 var matches = Regex.Matches(query, @"cluster\((?<cluster>([^\)]+))\).database\((?<database>([^\)]+))\)\.");
-                string targetCluster = string.Empty;
-                string targetDatabase = string.Empty;
                 if (matches.Any())
                 {
                     foreach (Match element in matches)
                     {
-                        targetCluster = element.Groups["cluster"].Value.Trim(new char[] { '\'', '\"' });
-                        targetDatabase = element.Groups["database"].Value.Trim(new char[] { '\'', '\"' });
+                        string targetCluster = element.Groups["cluster"].Value.Trim(new char[] { '\'', '\"' });
+                        string targetDatabase = element.Groups["database"].Value.Trim(new char[] { '\'', '\"' });
 
                         if (!string.IsNullOrWhiteSpace(targetCluster) && !string.IsNullOrWhiteSpace(targetDatabase))
                         {
                             targetCluster = targetCluster.Replace(".kusto.windows.net", string.Empty, StringComparison.OrdinalIgnoreCase);
-                            break;
+                            return await ExecuteClusterQuery(query, targetCluster, targetDatabase, requestId, operationName);
                         }
                     }
-                }
-                if (!string.IsNullOrWhiteSpace(targetCluster) && !string.IsNullOrWhiteSpace(targetDatabase))
-                {
-                    return await ExecuteClusterQuery(query, targetCluster, targetDatabase, requestId, operationName).ConfigureAwait(true);
                 }
             }
 

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -15,6 +15,8 @@ namespace Diagnostics.DataProviders
 
         Task<KustoQuery> GetKustoQuery(string query, string stampName);
 
+        Task<KustoQuery> GetKustoQuery(string query, string clusterName, string databaseName = null, string operationName = null);
+
         Task<KustoQuery> GetKustoClusterQuery(string query);
 
         Task<string> GetAggHiPerfClusterNameByStampAsync(string stampName);

--- a/src/Diagnostics.DataProviders/KustoLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/KustoLogDecorator.cs
@@ -32,6 +32,11 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(DataProvider.ExecuteClusterQuery(query, cluster, databaseName, _requestId, operationName));
         }
 
+        public Task<KustoQuery> GetKustoQuery(string query, string clusterName, string databaseName = null, string operationName = null)
+        {
+            return MakeDependencyCall(DataProvider.GetKustoQuery(query, clusterName, databaseName, operationName));
+        }
+
         public Task<KustoQuery> GetKustoQuery(string query, string stampName)
         {
             return MakeDependencyCall(DataProvider.GetKustoQuery(query, stampName));


### PR DESCRIPTION
Kusto execute cluster does not honor custom database name when showing queries in data source.
Added additional method to get Kusto query based on a custom cluster and database name.