### PR TITLE
Block All Kusto function for static web apps

### DIFF
--- a/src/Diagnostics.Scripts/EntityInvoker.cs
+++ b/src/Diagnostics.Scripts/EntityInvoker.cs
@@ -418,7 +418,12 @@ namespace Diagnostics.Scripts
                     (this._resourceFilter.ResourceType == ResourceType.App 
                     || this._resourceFilter.ResourceType == ResourceType.HostingEnvironment 
                     || this._resourceFilter.ResourceType == ResourceType.AppServiceCertificate
-                    || this._resourceFilter.ResourceType == ResourceType.AppServiceDomain))
+                    || this._resourceFilter.ResourceType == ResourceType.AppServiceDomain
+                    || (
+                        this._resourceFilter.ResourceType == ResourceType.ArmResource 
+                        && (this._resourceFilter as ArmResourceFilter)?.Provider.Equals("Microsoft.Web", StringComparison.OrdinalIgnoreCase) == true
+                        )
+                    ))
                 {
                     
                     throw new ScriptCompilationException("Use of All('TableName') in kusto query is not allowed. Use dp.Kusto.ExecuteQueryOnAllAppAppServiceClusters(string query, string operationName) instead.");


### PR DESCRIPTION
Block All Kusto function for static web apps detector development experience.
Detector authors are using the All function and those queries are timing out. Cross cluster queries are slow and end up increasing the concurrency of cluster and may lead to throttling.