### PR TITLE
stop testing wawscusdiagleader.centralus

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
@@ -193,7 +193,8 @@ namespace Diagnostics.DataProviders
         public string ExceptionsToRetryFor { get; set; }
 
         /// <summary>
-        /// List of , separated sourceCluster|testCluster1:testCluster2:... and requests will be shadowed from sourceCluster to all the following testClusters
+        /// List of , separated sourceCluster|testCluster1:testCluster2:... and requests will be intercepted from sourceCluster to all the following testClusters.
+        /// Will fallback to sourceCluster on any exception
         /// e.g. "wawswusfollower|testwuscluster1:testwuscluster2,wawseusfollower|testeuscluster1"
         /// </summary>
         [ConfigurationName("QueryShadowingClusterMapping")]

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -75,8 +75,8 @@
         }
       ]
     },
-    "QueryShadowingClusterMapping": "wawscusfollower|wawscusdiagleader.centralus,wawscus|wawscusdiagleader.centralus",
-    "KustoAggClusterNameGroupMappings": "wawscusfollower|wawscusaggdiagleader.centralus"
+    "QueryShadowingClusterMapping": "",
+    "KustoAggClusterNameGroupMappings": "wawscusdiagleader.centralus|wawscusaggdiagleader.centralus"
   },
   "SupportObserver": {
     "ClientId": "",


### PR DESCRIPTION
will update the `KustoClusterNameGroupings` configuration in Diagnostics KV to replace `wawscusfollower` by `wawscusdiagleader.centralus`