### PR TITLE
Allow a query to be executed on a few app service clusters

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -153,7 +153,7 @@ namespace Diagnostics.DataProviders
             {"wawseas", new Tuple<string, string>("waws-prod-hk1-029", "EastAsia") }
         };
 
-        public async Task<DataTable> ExecuteQueryOnFewAppAppServiceClusters(List<string> appServiceClusterNames, string query, string operationName)
+        public async Task<DataTable> ExecuteQueryOnFewAppServiceClusters(List<string> appServiceClusterNames, string query, string operationName)
         {
             if (string.IsNullOrWhiteSpace(operationName))
             {

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -167,7 +167,7 @@ namespace Diagnostics.DataProviders
 
             if (appServiceClusterNames?.Count < 1)
             {
-                throw new ArgumentNullException(nameof(appServiceClusterNames), "App service kust cluster names list cannot be empty. Please supply at least one kusto cluster name where the query should be executed.");
+                throw new ArgumentNullException(nameof(appServiceClusterNames), "App service kusto cluster names list cannot be empty. Please supply at least one kusto cluster name where the query should be executed.");
             }
 
             List<Task<DataTable>> queryTask = new List<Task<DataTable>>();

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -144,6 +144,7 @@ namespace Diagnostics.DataProviders
 
         private Dictionary<string, Tuple<string, string>> clusterStampNameMapping = new Dictionary<string, Tuple<string, string>>() 
         {
+            //One random stamp name per region.
             {"wawswus", new Tuple<string, string>("waws-prod-bay-153", "WestUS") },
             {"wawseus", new Tuple<string, string>("waws-prod-blu-189", "EastUS") },
             {"wawscus", new Tuple<string, string>("waws-prod-dm1-187", "CentralUS") },

--- a/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/DataProviders/KustoDataProvider.cs
@@ -142,6 +142,67 @@ namespace Diagnostics.DataProviders
             return await _kustoClient.ExecuteQueryAsync(Helpers.MakeQueryCloudAgnostic(_kustoMap, query), _kustoMap.MapCluster(cluster) ?? cluster, _kustoMap.MapDatabase(_configuration.DBName) ?? _configuration.DBName, requestId, operationName, _queryStartTime, _queryEndTime);
         }
 
+        private Dictionary<string, Tuple<string, string>> clusterStampNameMapping = new Dictionary<string, Tuple<string, string>>() 
+        {
+            {"wawswus", new Tuple<string, string>("waws-prod-bay-153", "WestUS") },
+            {"wawseus", new Tuple<string, string>("waws-prod-blu-189", "EastUS") },
+            {"wawscus", new Tuple<string, string>("waws-prod-dm1-187", "CentralUS") },
+            {"wawsweu", new Tuple<string, string>("waws-prod-am2-329", "WestEurope") },
+            {"wawsneu", new Tuple<string, string>("waws-prod-db3-169", "NorthEurope") },
+            {"wawseas", new Tuple<string, string>("waws-prod-hk1-029", "EastAsia") }
+        };
+
+        public async Task<DataTable> ExecuteQueryOnFewAppAppServiceClusters(List<string> appServiceClusterNames, string query, string operationName)
+        {
+            if (string.IsNullOrWhiteSpace(operationName))
+            {
+                throw new ArgumentNullException(nameof(operationName), "OperationName cannot be empty. Please supply a name to identify the query.");
+            }
+
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                throw new ArgumentNullException(nameof(query), "Query cannot be empty. Please supply a query to execute.");
+            }
+
+            if (appServiceClusterNames?.Count < 1)
+            {
+                throw new ArgumentNullException(nameof(appServiceClusterNames), "App service kust cluster names list cannot be empty. Please supply at least one kusto cluster name where the query should be executed.");
+            }
+
+            List<Task<DataTable>> queryTask = new List<Task<DataTable>>();
+
+            if (IsPublicCloud)
+            {
+                foreach (string targetClusterName in appServiceClusterNames)
+                {
+                    if (clusterStampNameMapping.TryGetValue(targetClusterName, out Tuple<string, string> stampDetails))
+                    {
+                        queryTask.Add(ExecuteQuery(query, stampDetails.Item1, null, $"{operationName}-{stampDetails.Item2}"));
+                    }
+                }
+            }
+            else
+            {
+                queryTask.Add(ExecuteQuery(query, Diagnostics.DataProviders.DataProviderConstants.FakeStampForAnalyticsCluster, null, operationName));
+            }
+
+            var queryResult = await Task.WhenAll(queryTask.ToArray());
+            DataTable mergedTable = new DataTable();
+            foreach (DataTable dt in queryResult)
+            {
+                if (dt.Rows.Count > 0)
+                {
+                    if (dt.Rows.Count > 3000)
+                    {
+                        throw new Exception($"Query {operationName} returned more than 3000 rows. Please modify the query to fetch fewer rows while running across all app service clusters.");
+                    }
+                    mergedTable.Merge(dt, false, MissingSchemaAction.Add);
+                }
+            }
+            return mergedTable;
+
+        }
+
         public async Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string operationName)
         {
             if (string.IsNullOrWhiteSpace(operationName))
@@ -157,12 +218,10 @@ namespace Diagnostics.DataProviders
 
             if(IsPublicCloud)
             {
-                queryTask.Add(ExecuteQuery(query, "waws-prod-bay-153", null, operationName));
-                queryTask.Add(ExecuteQuery(query, "waws-prod-blu-189", null, operationName));
-                queryTask.Add(ExecuteQuery(query, "waws-prod-dm1-187", null, operationName));
-                queryTask.Add(ExecuteQuery(query, "waws-prod-am2-329", null, operationName));
-                queryTask.Add(ExecuteQuery(query, "waws-prod-db3-169", null, operationName));
-                queryTask.Add(ExecuteQuery(query, "waws-prod-hk1-029", null, operationName));
+                foreach (var stampDetails in clusterStampNameMapping)
+                {
+                    queryTask.Add(ExecuteQuery(query, stampDetails.Value.Item1, null, $"{operationName}-{stampDetails.Value.Item2}"));
+                }
             }
             else
             {

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System.Collections.Generic;
+using System.Data;
 using System.Threading.Tasks;
 
 namespace Diagnostics.DataProviders
@@ -12,6 +13,8 @@ namespace Diagnostics.DataProviders
         Task<DataTable> ExecuteQuery(string query, string stampName, string requestId = null, string operationName = null);
 
         Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string operationName);
+
+        Task<DataTable> ExecuteQueryOnFewAppAppServiceClusters(List<string> appServiceClusterNames, string query, string operationName);
 
         Task<KustoQuery> GetKustoQuery(string query, string stampName);
 

--- a/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
+++ b/src/Diagnostics.DataProviders/Interfaces/IKustoDataProvider.cs
@@ -14,7 +14,7 @@ namespace Diagnostics.DataProviders
 
         Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string operationName);
 
-        Task<DataTable> ExecuteQueryOnFewAppAppServiceClusters(List<string> appServiceClusterNames, string query, string operationName);
+        Task<DataTable> ExecuteQueryOnFewAppServiceClusters(List<string> appServiceClusterNames, string query, string operationName);
 
         Task<KustoQuery> GetKustoQuery(string query, string stampName);
 

--- a/src/Diagnostics.DataProviders/KustoLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/KustoLogDecorator.cs
@@ -23,9 +23,9 @@ namespace Diagnostics.DataProviders
             return MakeDependencyCall(DataProvider.ExecuteQueryOnAllAppAppServiceClusters(query, operationName));
         }
 
-        public Task<DataTable> ExecuteQueryOnFewAppAppServiceClusters(List<string> appServiceClusterNames, string query, string operationName)
+        public Task<DataTable> ExecuteQueryOnFewAppServiceClusters(List<string> appServiceClusterNames, string query, string operationName)
         {
-            return MakeDependencyCall(DataProvider.ExecuteQueryOnFewAppAppServiceClusters(appServiceClusterNames, query, operationName));
+            return MakeDependencyCall(DataProvider.ExecuteQueryOnFewAppServiceClusters(appServiceClusterNames, query, operationName));
         }
 
         public Task<DataTable> ExecuteClusterQuery(string query, string requestId = null, string operationName = null)

--- a/src/Diagnostics.DataProviders/KustoLogDecorator.cs
+++ b/src/Diagnostics.DataProviders/KustoLogDecorator.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System.Collections.Generic;
+using System.Data;
 using System.Threading.Tasks;
 
 namespace Diagnostics.DataProviders
@@ -20,6 +21,11 @@ namespace Diagnostics.DataProviders
         public Task<DataTable> ExecuteQueryOnAllAppAppServiceClusters(string query, string operationName)
         {
             return MakeDependencyCall(DataProvider.ExecuteQueryOnAllAppAppServiceClusters(query, operationName));
+        }
+
+        public Task<DataTable> ExecuteQueryOnFewAppAppServiceClusters(List<string> appServiceClusterNames, string query, string operationName)
+        {
+            return MakeDependencyCall(DataProvider.ExecuteQueryOnFewAppAppServiceClusters(appServiceClusterNames, query, operationName));
         }
 
         public Task<DataTable> ExecuteClusterQuery(string query, string requestId = null, string operationName = null)


### PR DESCRIPTION
Allow a query to be executed on a few app service clusters instead of all. This eliminated the need to perform a cross cluster union and enables scenarios where a query should be executed in few regions. This is being created to enable certain scenarios for static webapps.