### PR TITLE
Revert IMdmDataProviderConfiguration change which removed CertificateName

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/AntaresMdmDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/AntaresMdmDataProviderConfiguration.cs
@@ -18,6 +18,12 @@ namespace Diagnostics.DataProviders.DataProviderConfigurations
         public string Endpoint { get; set; }
 
         /// <summary>
+        /// Gets or sets the name of certificate in keyvault.
+        /// </summary>
+        [ConfigurationName("CertificateName")]
+        public string CertificateName { get; set; }
+
+        /// <summary>
         /// Gets or sets monitoring account.
         /// </summary>
         [ConfigurationName("MdmShoeboxAccount")]

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/ContainerAppsMdmDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/ContainerAppsMdmDataProviderConfiguration.cs
@@ -24,6 +24,11 @@ namespace Diagnostics.DataProviders.DataProviderConfigurations
         public string MonitoringAccount { get; set; }
 
         /// <summary>
+        /// Gets or sets certificate name (Not used).
+        /// </summary>
+        public string CertificateName { get; set; }
+
+        /// <summary>
         /// Post initialize.
         /// </summary>
         public override void PostInitialize()

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/GenericMdmDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/GenericMdmDataProviderConfiguration.cs
@@ -25,7 +25,7 @@ namespace Diagnostics.DataProviders.DataProviderConfigurations
         /// <summary>
         /// Gets or sets certificate name.
         /// </summary>
-        public string CertificateSubjectName { get; set; }
+        public string CertificateName { get; set; }
 
         /// <summary>
         /// Post initialize.

--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/IMdmDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/IMdmDataProviderConfiguration.cs
@@ -16,6 +16,11 @@ namespace Diagnostics.DataProviders.DataProviderConfigurations
         string Endpoint { get; set; }
 
         /// <summary>
+        /// Gets or sets the name of certificate in keyvault.
+        /// </summary>
+        string CertificateName { get; set; }
+
+        /// <summary>
         /// Gets or sets monitoring account.
         /// </summary>
         string MonitoringAccount { get; set; }


### PR DESCRIPTION
This is to fix a regression caused by change abfda9b4545a4261a98a2ed5b4dc9b5dc792b10b which removed the CertificateName property from IMdmDataProviderConfiguration.