### PR TITLE
updates for kusto diag leaders

### DIFF
--- a/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
+++ b/src/Diagnostics.DataProviders/DataProviderConfigurations/KustoDataProviderConfiguration.cs
@@ -59,6 +59,12 @@ namespace Diagnostics.DataProviders
         public string KustoAggClusterNameGroupMappings { get; set; }
 
         /// <summary>
+        /// DB Name mappings like WawsPrimaryClusterName:DiagLeaderClusterName, where WawsPrimaryClusterName should be one of wawswus,wawseus,wawscus,wawsweu,wawsneu,wawseas
+        /// </summary>
+        [ConfigurationName("KustoWawsPrimaryToDiagLeaderMappings")]
+        public string KustoWawsPrimaryToDiagLeaderMappings { get; set; }
+
+        /// <summary>
         /// Tenant to authenticate with
         /// </summary>
         [ConfigurationName("AADAuthority")]
@@ -204,6 +210,8 @@ namespace Diagnostics.DataProviders
 
         public ConcurrentDictionary<string, string> HiPerfAggClusterMapping;
 
+        public ConcurrentDictionary<string, string> WawsPrimaryToDiagLeaderClusterMapping;
+
         public List<ITuple> OverridableExceptionsToRetryAgainstLeaderCluster { get; set; }
 
         public IConfiguration config { private get; set; }
@@ -290,6 +298,25 @@ namespace Diagnostics.DataProviders
                 {
                     HiPerfAggClusterMapping = new ConcurrentDictionary<string, string>(
                            KustoAggClusterNameGroupMappings
+                               .Split(',')
+                               .Select(e =>
+                               {
+                                   var splitted = e.Split('|');
+                                   return new KeyValuePair<string, string>(splitted[0], splitted[1]);
+                               }));
+                }
+                catch (Exception)
+                {
+                    // swallow the exception
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(KustoWawsPrimaryToDiagLeaderMappings))
+            {
+                try 
+                {
+                    WawsPrimaryToDiagLeaderClusterMapping = new ConcurrentDictionary<string, string>(
+                           KustoWawsPrimaryToDiagLeaderMappings
                                .Split(',')
                                .Select(e =>
                                {

--- a/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
+++ b/src/Diagnostics.DataProviders/KustoHeartBeatService/KustoHeartBeatService.cs
@@ -87,8 +87,17 @@ namespace Diagnostics.DataProviders
                             {
                                 var regionName = ((string)dr["Region"]).ToLower();
                                 var clusterName = (string)dr["ClusterName"];
-                                _configuration.RegionSpecificClusterNameCollection.TryAdd(regionName, clusterName + "follower");
-                                _configuration.FailoverClusterNameCollection.TryAdd(regionName, clusterName);
+                                if (_configuration.WawsPrimaryToDiagLeaderClusterMapping != null && _configuration.WawsPrimaryToDiagLeaderClusterMapping.ContainsKey(clusterName))
+                                {
+                                    string diagLeaderCluster = _configuration.WawsPrimaryToDiagLeaderClusterMapping[clusterName];
+                                    _configuration.RegionSpecificClusterNameCollection.TryAdd(regionName, diagLeaderCluster);
+                                    _configuration.FailoverClusterNameCollection.TryAdd(diagLeaderCluster, clusterName);
+                                }
+                                else 
+                                {
+                                    _configuration.RegionSpecificClusterNameCollection.TryAdd(regionName, clusterName + "follower");
+                                    _configuration.FailoverClusterNameCollection.TryAdd(clusterName + "follower", clusterName);
+                                }
                             }
                         }
                     }

--- a/src/Diagnostics.DataProviders/KustoSDKClient.cs
+++ b/src/Diagnostics.DataProviders/KustoSDKClient.cs
@@ -87,8 +87,7 @@ namespace Diagnostics.DataProviders
             var kustoClientId = $"Diagnostics.{operationName ?? "Query"};{_requestId};{startTime?.ToString() ?? "UnknownStartTime"};{endTime?.ToString() ?? "UnknownEndTime"}##{0}_{Guid.NewGuid().ToString()}";
             clientRequestProperties.ClientRequestId = kustoClientId;
             clientRequestProperties.SetOption("servertimeout", new TimeSpan(0,0,timeoutSeconds));
-            if(cluster.StartsWith("waws",StringComparison.OrdinalIgnoreCase) && cluster != "wawscusdiagleadertest1.centralus" 
-                && !cluster.Equals("wawscusaggdiagleader.centralus", StringComparison.OrdinalIgnoreCase))
+            if(cluster.StartsWith("waws",StringComparison.OrdinalIgnoreCase) && !cluster.Contains("diagleader", StringComparison.OrdinalIgnoreCase))
             {
                 clientRequestProperties.SetOption(ClientRequestProperties.OptionQueryConsistency, ClientRequestProperties.OptionQueryConsistency_Weak);
             }
@@ -371,6 +370,10 @@ namespace Diagnostics.DataProviders
             else if (FailoverClusterMapping.Keys.Contains(cluster))
             {
                 backupCluster = FailoverClusterMapping[cluster];
+            }
+            else if (_config.WawsPrimaryToDiagLeaderClusterMapping != null && _config.WawsPrimaryToDiagLeaderClusterMapping.ContainsKey(cluster))
+            {
+                backupCluster = _config.WawsPrimaryToDiagLeaderClusterMapping[cluster];
             }
 
             return backupCluster;

--- a/src/Diagnostics.RuntimeHost/appsettings.json
+++ b/src/Diagnostics.RuntimeHost/appsettings.json
@@ -75,8 +75,9 @@
         }
       ]
     },
-    "QueryShadowingClusterMapping": "",
-    "KustoAggClusterNameGroupMappings": "wawscusdiagleader.centralus|wawscusaggdiagleader.centralus"
+    "QueryShadowingClusterMapping": "wawswus|wawswusdiagleader.westus2,wawswusfollower|wawswusdiagleader.westus2,wawsneu|wawsneudiagleader.northeurope,wawsneufollower|wawsneudiagleader.northeurope",
+    "KustoAggClusterNameGroupMappings": "wawscusdiagleader.centralus|wawscusaggdiagleader.centralus,wawswusfollower|wawswusdiagleader.westus2,wawseusfollower|wawseusaggdiagleader.eastus,wawsweufollower|wawsweudiagleader.westeurope,wawsneufollower|wawsneuaggdiagleader.northeurope,wawseasfollower|wawseasaggdiagleader.southeastasia",
+    "KustoWawsPrimaryToDiagLeaderMappings": "wawscus|wawscusdiagleader.centralus"
   },
   "SupportObserver": {
     "ClientId": "",


### PR DESCRIPTION
- change GetClusterNameFromStamp function to use new diagleader when updating a missing region:cluster mapping
- add shadowing for wawswus and wawsneu
- turn on agg cluster for all regions
- not use weak consistency for all diagleader clusters