### PR TITLE
Fetch config from storage if not in cache

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/DeploymentController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DeploymentController.cs
@@ -49,6 +49,14 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 return BadRequest(validationError);
             }
+
+            // Additional validation to make sure Resource Provider is onboarded before the API is called.
+            var resourceProviderMapping = await this.devopsClient.GetRepoConfigsAsync(deploymentParameters.ResourceType);
+            if (resourceProviderMapping == null )
+            {
+                validationError = $"Resource Provider {deploymentParameters.ResourceType} is not onboarded";
+                return BadRequest(validationError);
+            }
                      
             DeploymentResponse response = new DeploymentResponse();
             response.DeploymentGuid = Guid.NewGuid().ToString();


### PR DESCRIPTION
- This improvement speeds up time to onboard resources and does not require process restart
- Fetches from storage on-demand instead of polling which reduces the no of API requests to storage 
- Previously to onboard resources would require config change followed by site restart. With this change, only config change is needed, and the web app will fetch from storage the next time API is queried for the newly onboarded resource. 
- Nothing changes from UI. It works same way for existing onboarded resources. 