### PR TITLE
Nmallick1/handle incorrect st for resource type 

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/ApiManagement/ApiManagementController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ApiManagement/ApiManagementController.cs
@@ -9,6 +9,9 @@ using Microsoft.AspNetCore.Authorization;
 using Newtonsoft.Json;
 using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.Extensions.Configuration;
+using Diagnostics.Logger;
+using Microsoft.Extensions.Primitives;
+using System.Linq;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -75,9 +78,23 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
             }
-            catch (RuntimeBinderException)
+            catch (RuntimeBinderException rex)
             {
                 postBodyString = "";
+
+                string requestId = string.Empty;
+                if (Request.Headers.TryGetValue(HeaderConstants.RequestIdHeaderName, out StringValues values) && values != default(StringValues) && values.Count > 0)
+                {
+                    requestId = values.FirstOrDefault().Split(new char[] { ',' })[0] ?? string.Empty;
+                }
+                Logger.DiagnosticsETWProvider.Instance.LogRuntimeHostHandledException(
+                            requestId,
+                            $"{nameof(SitesController)}.{nameof(GetInsights)}",
+                            subscriptionId,
+                            resourceGroupName,
+                            serviceName,
+                            "PostBodyEmptyForGetInsightsRequestFromASC",
+                            $"Error trying to serialize post body sent from ASC. Detailed exception message : {rex.Message}");
             }
             return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, serviceName), pesId, supportTopicId, sapPesId, sapSupportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }

--- a/src/Diagnostics.RuntimeHost/Controllers/AppServiceCertificate/AppServiceCertificateController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/AppServiceCertificate/AppServiceCertificateController.cs
@@ -9,6 +9,9 @@ using Microsoft.AspNetCore.Authorization;
 using Newtonsoft.Json;
 using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.Extensions.Configuration;
+using Diagnostics.Logger;
+using Microsoft.Extensions.Primitives;
+using System.Linq;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -60,9 +63,23 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
             }
-            catch (RuntimeBinderException)
+            catch (RuntimeBinderException rex)
             {
                 postBodyString = "";
+
+                string requestId = string.Empty;
+                if (Request.Headers.TryGetValue(HeaderConstants.RequestIdHeaderName, out StringValues values) && values != default(StringValues) && values.Count > 0)
+                {
+                    requestId = values.FirstOrDefault().Split(new char[] { ',' })[0] ?? string.Empty;
+                }
+                Logger.DiagnosticsETWProvider.Instance.LogRuntimeHostHandledException(
+                            requestId,
+                            $"{nameof(SitesController)}.{nameof(GetInsights)}",
+                            subscriptionId,
+                            resourceGroupName,
+                            certificateName,
+                            "PostBodyEmptyForGetInsightsRequestFromASC",
+                            $"Error trying to serialize post body sent from ASC. Detailed exception message : {rex.Message}");
             }
             return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, certificateName), pesId, supportTopicId, sapPesId, sapSupportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }

--- a/src/Diagnostics.RuntimeHost/Controllers/AppServiceDomain/AppServiceDomainController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/AppServiceDomain/AppServiceDomainController.cs
@@ -9,6 +9,9 @@ using Microsoft.AspNetCore.Authorization;
 using Newtonsoft.Json;
 using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.Extensions.Configuration;
+using Diagnostics.Logger;
+using Microsoft.Extensions.Primitives;
+using System.Linq;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -60,9 +63,23 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
             }
-            catch (RuntimeBinderException)
+            catch (RuntimeBinderException rex)
             {
                 postBodyString = "";
+
+                string requestId = string.Empty;
+                if (Request.Headers.TryGetValue(HeaderConstants.RequestIdHeaderName, out StringValues values) && values != default(StringValues) && values.Count > 0)
+                {
+                    requestId = values.FirstOrDefault().Split(new char[] { ',' })[0] ?? string.Empty;
+                }
+                Logger.DiagnosticsETWProvider.Instance.LogRuntimeHostHandledException(
+                            requestId,
+                            $"{nameof(SitesController)}.{nameof(GetInsights)}",
+                            subscriptionId,
+                            resourceGroupName,
+                            domainName,
+                            "PostBodyEmptyForGetInsightsRequestFromASC",
+                            $"Error trying to serialize post body sent from ASC. Detailed exception message : {rex.Message}");
             }
             return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, domainName), pesId, supportTopicId, sapSupportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }

--- a/src/Diagnostics.RuntimeHost/Controllers/ArmResource/ArmResourceController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ArmResource/ArmResourceController.cs
@@ -10,6 +10,8 @@ using Microsoft.AspNetCore.Authorization;
 using Newtonsoft.Json;
 using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+using System.Linq;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -85,9 +87,23 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
             }
-            catch (RuntimeBinderException)
+            catch (RuntimeBinderException rex)
             {
                 postBodyString = "";
+
+                string requestId = string.Empty;
+                if (Request.Headers.TryGetValue(HeaderConstants.RequestIdHeaderName, out StringValues values) && values != default(StringValues) && values.Count > 0)
+                {
+                    requestId = values.FirstOrDefault().Split(new char[] { ',' })[0] ?? string.Empty;
+                }
+                Logger.DiagnosticsETWProvider.Instance.LogRuntimeHostHandledException(
+                            requestId,
+                            $"{nameof(SitesController)}.{nameof(GetInsights)}",
+                            subscriptionId,
+                            resourceGroupName,
+                            resourceName,
+                            "PostBodyEmptyForGetInsightsRequestFromASC",
+                            $"Error trying to serialize post body sent from ASC. Detailed exception message : {rex.Message}");
             }
             return base.GetInsights(new ArmResource(subscriptionId, resourceGroupName, provider, resourceTypeName, resourceName, GetLocation()), pesId, supportTopicId, sapPesId, sapSupportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }

--- a/src/Diagnostics.RuntimeHost/Controllers/ContainerApp/ContainerAppController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/ContainerApp/ContainerAppController.cs
@@ -13,6 +13,9 @@ using Diagnostics.DataProviders;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
+using Diagnostics.Logger;
+using Microsoft.Extensions.Primitives;
+using System.Linq;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -105,9 +108,23 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
             }
-            catch (RuntimeBinderException)
+            catch (RuntimeBinderException rex)
             {
                 postBodyString = "";
+
+                string requestId = string.Empty;
+                if (Request.Headers.TryGetValue(HeaderConstants.RequestIdHeaderName, out StringValues values) && values != default(StringValues) && values.Count > 0)
+                {
+                    requestId = values.FirstOrDefault().Split(new char[] { ',' })[0] ?? string.Empty;
+                }
+                Logger.DiagnosticsETWProvider.Instance.LogRuntimeHostHandledException(
+                            requestId,
+                            $"{nameof(SitesController)}.{nameof(GetInsights)}",
+                            subscriptionId,
+                            resourceGroupName,
+                            siteName,
+                            "PostBodyEmptyForGetInsightsRequestFromASC",
+                            $"Error trying to serialize post body sent from ASC. Detailed exception message : {rex.Message}");
             }
             var providerName = GetResourceProviderName(subscriptionId, resourceGroupName);
             return await base.GetInsights(new ContainerApp(subscriptionId, resourceGroupName, providerName, siteName), pesId, supportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);

--- a/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DiagnosticControllerBase.cs
@@ -791,10 +791,12 @@ namespace Diagnostics.RuntimeHost.Controllers
                     applicableDetectors = allDetectors
                     .Where(detector => detector.SupportTopicList.FirstOrDefault(st => st.Id == supportTopicId) != null);
                 }
-
-                var insightGroups = await Task.WhenAll(applicableDetectors.Select(detector => GetInsightsFromDetector(cxt, detector, detectorsRun)));
-
-                insights = insightGroups.Where(group => group != null).SelectMany(group => group).ToList();
+                if(applicableDetectors != null)
+                {
+                    var insightGroups = await Task.WhenAll(applicableDetectors.Select(detector => GetInsightsFromDetector(cxt, detector, detectorsRun)));
+                    insights = insightGroups.Where(group => group != null).SelectMany(group => group).ToList();
+                }
+                
             }
             catch (Exception ex)
             {

--- a/src/Diagnostics.RuntimeHost/Controllers/HostingEnvironment/HostingEnvironmentController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/HostingEnvironment/HostingEnvironmentController.cs
@@ -12,6 +12,9 @@ using Newtonsoft.Json;
 using Microsoft.CSharp.RuntimeBinder;
 using Diagnostics.ModelsAndUtils.Utilities;
 using Microsoft.Extensions.Configuration;
+using Diagnostics.Logger;
+using Microsoft.Extensions.Primitives;
+using System.Linq;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -125,9 +128,23 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
             }
-            catch (RuntimeBinderException)
+            catch (RuntimeBinderException rex)
             {
                 postBodyString = "";
+
+                string requestId = string.Empty;
+                if (Request.Headers.TryGetValue(HeaderConstants.RequestIdHeaderName, out StringValues values) && values != default(StringValues) && values.Count > 0)
+                {
+                    requestId = values.FirstOrDefault().Split(new char[] { ',' })[0] ?? string.Empty;
+                }
+                Logger.DiagnosticsETWProvider.Instance.LogRuntimeHostHandledException(
+                            requestId,
+                            $"{nameof(SitesController)}.{nameof(GetInsights)}",
+                            subscriptionId,
+                            resourceGroupName,
+                            hostingEnvironmentName,
+                            "PostBodyEmptyForGetInsightsRequestFromASC",
+                            $"Error trying to serialize post body sent from ASC. Detailed exception message : {rex.Message}");
             }
             return await base.GetInsights(ase, pesId, supportTopicId, sapPesId, sapSupportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }

--- a/src/Diagnostics.RuntimeHost/Controllers/LogicApp/LogicAppController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/LogicApp/LogicAppController.cs
@@ -9,6 +9,9 @@ using Microsoft.AspNetCore.Authorization;
 using Newtonsoft.Json;
 using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.Extensions.Configuration;
+using Diagnostics.Logger;
+using Microsoft.Extensions.Primitives;
+using System.Linq;
 
 namespace Diagnostics.RuntimeHost.Controllers
 {
@@ -75,9 +78,23 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
             }
-            catch (RuntimeBinderException)
+            catch (RuntimeBinderException rex)
             {
                 postBodyString = "";
+
+                string requestId = string.Empty;
+                if (Request.Headers.TryGetValue(HeaderConstants.RequestIdHeaderName, out StringValues values) && values != default(StringValues) && values.Count > 0)
+                {
+                    requestId = values.FirstOrDefault().Split(new char[] { ',' })[0] ?? string.Empty;
+                }
+                Logger.DiagnosticsETWProvider.Instance.LogRuntimeHostHandledException(
+                            requestId,
+                            $"{nameof(SitesController)}.{nameof(GetInsights)}",
+                            subscriptionId,
+                            resourceGroupName,
+                            logicAppName,
+                            "PostBodyEmptyForGetInsightsRequestFromASC",
+                            $"Error trying to serialize post body sent from ASC. Detailed exception message : {rex.Message}");
             }
             return await base.GetInsights(GetResource(subscriptionId, resourceGroupName, logicAppName), pesId, supportTopicId, sapPesId, sapSupportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }

--- a/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/Site/SitesController.cs
@@ -256,9 +256,23 @@ namespace Diagnostics.RuntimeHost.Controllers
             {
                 postBodyString = JsonConvert.SerializeObject(postBody.Parameters);
             }
-            catch (RuntimeBinderException)
+            catch (RuntimeBinderException rex)
             {
                 postBodyString = "";
+
+                string requestId = string.Empty;
+                if (Request.Headers.TryGetValue(HeaderConstants.RequestIdHeaderName, out StringValues values) && values != default(StringValues) && values.Count > 0)
+                {
+                    requestId = values.FirstOrDefault().Split(new char[] { ',' })[0] ?? string.Empty;
+                }
+                Logger.DiagnosticsETWProvider.Instance.LogRuntimeHostHandledException(
+                            requestId,
+                            $"{nameof(SitesController)}.{nameof(GetInsights)}",
+                            subscriptionId,
+                            resourceGroupName,
+                            siteName,
+                            "PostBodyEmptyForGetInsightsRequestFromASC",
+                            $"Error trying to serialize post body sent from ASC. Detailed exception message : {rex.Message}");
             }
             return await base.GetInsights(app, pesId, supportTopicId, sapPesId, sapSupportTopicId, startTime, endTime, timeGrain, supportTopic, postBodyString);
         }


### PR DESCRIPTION
There are times when an engineer would modify the product in ASC but the ST for that case still points to the old product, for example, the resource selected is an Azure Web App however the case was originally created against AppServiceCertificate. In such cases, we will fail to find an applicable detector since none would match the ST and we were throwing NRE.