### PR TITLE
Check if Provider is enabled before loading certs for it.

### DIFF
--- a/src/Diagnostics.RuntimeHost/Startup.cs
+++ b/src/Diagnostics.RuntimeHost/Startup.cs
@@ -137,9 +137,19 @@ namespace Diagnostics.RuntimeHost
 
             if (!Environment.IsDevelopment())
             {
-                MdmCertLoader.Instance.Initialize(Configuration);
-                CompilerHostCertLoader.Instance.Initialize(Configuration);
-                SearchAPICertLoader.Instance.Initialize(Configuration);
+                if (Configuration.GetValue("Mdm:Enabled", true))
+                {
+                    MdmCertLoader.Instance.Initialize(Configuration);
+                }
+                if (Configuration.GetValue("CompilerHost:Enabled", true))
+                {
+                    CompilerHostCertLoader.Instance.Initialize(Configuration);
+                }
+                if (Configuration.GetValue("SearchAPI:Enabled", true))
+                {
+                    SearchAPICertLoader.Instance.Initialize(Configuration);
+                }
+
                 // Enable App Insights telemetry
                 services.AddApplicationInsightsTelemetry();
             }


### PR DESCRIPTION
Check if Provider is enabled before loading certs for it. This will help selectively disable providers across NClouds.