### PR TITLE
Use TryAdd to avoid Key exists exception

### DIFF
--- a/src/Diagnostics.RuntimeHost/Controllers/DeploymentController.cs
+++ b/src/Diagnostics.RuntimeHost/Controllers/DeploymentController.cs
@@ -132,7 +132,7 @@ namespace Diagnostics.RuntimeHost.Controllers
                 foreach(string gist in gistReferences)
                 {                   
                     var gistContent = await devopsClient.GetFileContentAsync($"{gist}/{gist}.csx", deploymentParameters.ResourceType, HttpContext.Request.Headers[HeaderConstants.RequestIdHeaderName], null, deploymentParameters.ResourceType);
-                    references.Add(gist, gistContent.ToString());                                                  
+                    references.TryAdd(gist, gistContent.ToString());                                                  
                 }
 
                 // Otherwise, compile the detector to generate dll.


### PR DESCRIPTION
Fixed a bug where if multiple detectors using same gist reference were deployed in the same API, the key exists exception is thrown.
